### PR TITLE
ci(nightly): temporarily disable parallel execution

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,8 @@ jobs:
         env:
           VERBOSE: "true"
           VCR: "rec"
+          # TODO Remove parallel option when all parallel issues are resolved.
+          TESTARGS: "-parallel=1"
           KATAPULT_API_KEY: ${{ secrets.KATAPULT_API_KEY }}
           KATAPULT_ORGANIZATION_ID: ${{ secrets.KATAPULT_ORGANIZATION_ID }}
           KATAPULT_DATA_CENTER_ID: ${{ secrets.KATAPULT_DATA_CENTER_ID }}


### PR DESCRIPTION
We're seeing some oddities which we believe are due to the parallel execution of
the acceptance tests. So we're going to disable parallel execution temporarily
to see how things go.