### PR TITLE
fix(errors): handle nil *katapult.Response.Response values

### DIFF
--- a/internal/provider/resource_ip.go
+++ b/internal/provider/resource_ip.go
@@ -118,7 +118,7 @@ func resourceIPRead(
 
 	ip, resp, err := meta.Client.IPAddresses.GetByID(ctx, d.Id())
 	if err != nil {
-		if resp != nil && resp.StatusCode == 404 {
+		if resp != nil && resp.Response != nil && resp.StatusCode == 404 {
 			d.SetId("")
 
 			return diags

--- a/internal/provider/resource_load_balancer.go
+++ b/internal/provider/resource_load_balancer.go
@@ -135,7 +135,7 @@ func resourceLoadBalancerRead(
 
 	lb, resp, err := c.LoadBalancers.GetByID(ctx, id)
 	if err != nil {
-		if resp != nil && resp.StatusCode == 404 {
+		if resp != nil && resp.Response != nil && resp.StatusCode == 404 {
 			d.SetId("")
 
 			return diags


### PR DESCRIPTION
This is a dirty workaround until errors are refactored in the katapult package
to be compatible with errors.Is().