### PR TITLE
ci(cov): remove coverage report job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,27 +32,6 @@ jobs:
       - name: Check if mods are tidy
         run: make check-tidy
 
-  cov:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Produce coverage report
-        run: make cov-func
-        env:
-          KATAPULT_API_KEY: ${{ secrets.KATAPULT_API_KEY }}
-          KATAPULT_ORGANIZATION_ID: ${{ secrets.KATAPULT_ORGANIZATION_ID }}
-          KATAPULT_DATA_CENTER_ID: ${{ secrets.KATAPULT_DATA_CENTER_ID }}
-
   test:
     name: Acceptance Test (VCR Replay)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Coverage reports are not very useful at the moment. Testing focus has been on
Terraform acceptance tests against real cloud infrastructure, rather than unit
testing every function.