### PR TITLE
ci(release): add release job which runs against git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,35 @@ jobs:
         run: make check-docs
       - name: Ensure generated documentation is up to date
         run: mv docs docs-current && make docs && diff -rN docs-current docs
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [lint, lint-provider, tidy, test, docs]
+    if: contains(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Import GPG key
+        id: import_gpg
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
+          PASSPHRASE: "${{ secrets.PASSPHRASE }}"
+      - name: goreleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: "${{ steps.import_gpg.outputs.fingerprint }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: test signing
+        run: >-
+          gpg --verify
+          dist/terraform-provider-katapult_v0.0.0-next_SHA256SUMS.sig
+          dist/terraform-provider-katapult_v0.0.0-next_SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .terraform
 /terraform-provider-katapult*
 bin/*
+dist/*
 coverage.out

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,48 @@
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }}"
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: "386"
+archives:
+  - format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+release:
+  draft: true
+changelog:
+  skip: true

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ LDFLAGS := -w -s
 
 VERSION ?= $(shell git describe --tags 2>/dev/null)
 GIT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null)
-DATE ?= $(shell date +%s)
 
 ifeq ($(trim $(VERSION)),)
 	VERSION = 0.0.1
@@ -74,9 +73,8 @@ build: $(BINARY)
 
 $(BINARY): $(SOURCES)
 	go build $(V) -a -o "$@" -ldflags "$(LDFLAGS) \
-		-X main.Version=$(VERSION) \
-		-X main.Commit=$(GIT_SHA) \
-		-X main.Date=$(DATE)"
+		-X main.version=$(VERSION) \
+		-X main.commit=$(GIT_SHA)"
 
 TF_PLUGINS ?= $(HOME)/.terraform.d/plugins
 INSTALL_DIR = $(TF_PLUGINS)/$(HOSTNAME)/$(NAMESPACE)/$(NAME)/$(VERSION)

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,8 +1,7 @@
 terraform {
   required_providers {
     katapult = {
-      version = "0.0.1"
-      source  = "katapult.io/katapult/katapult"
+      source = "katapult.io/katapult/katapult"
     }
   }
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,7 +22,6 @@ const defaultGeneratedNamePrefix = "tf"
 type Config struct {
 	Version    string
 	Commit     string
-	Date       string
 	HTTPClient *http.Client
 
 	GeneratedNamePrefix string

--- a/main.go
+++ b/main.go
@@ -6,17 +6,15 @@ import (
 )
 
 var (
-	Version string = "dev"
-	Commit  string = ""
-	Date    string = ""
+	version string = "dev"
+	commit  string = ""
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: provider.New(&provider.Config{
-			Version: Version,
-			Commit:  Commit,
-			Date:    Date,
+			Version: version,
+			Commit:  commit,
 		}),
 	})
 }


### PR DESCRIPTION
It uses goreleaser to build binaries for a number of platforms, GPG signs the
release as required by Terraform, and creates a draft release on GitHub which we
can manually verify before publishing.