### PR TITLE
fix(virtual_machine): avoid timing related deletion failure

### DIFF
--- a/internal/provider/data_source_virtual_machine_test.go
+++ b/internal/provider/data_source_virtual_machine_test.go
@@ -16,6 +16,10 @@ func TestAccKatapultDataSourceVirtualMachine_by_id(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckKatapultVirtualMachineDestroy(tt),
+			testAccCheckKatapultIPDestroy(tt),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: undent.Stringf(`
@@ -99,6 +103,10 @@ func TestAccKatapultDataSourceVirtualMachine_by_fqdn(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckKatapultVirtualMachineDestroy(tt),
+			testAccCheckKatapultIPDestroy(tt),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: undent.Stringf(`

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -50,6 +50,17 @@ func purgeTrashObject(
 		return err
 	}
 
+	_, err = waitForTaskCompletion(ctx, m, timeout, task)
+
+	return err
+}
+
+func waitForTaskCompletion(
+	ctx context.Context,
+	m *Meta,
+	timeout time.Duration,
+	task *katapult.Task,
+) (*katapult.Task, error) {
 	taskWaiter := &resource.StateChangeConf{
 		Pending: []string{
 			string(katapult.TaskPending),
@@ -74,9 +85,13 @@ func purgeTrashObject(
 		MinTimeout:                5 * time.Second,
 		ContinuousTargetOccurence: 1,
 	}
-	_, err = taskWaiter.WaitForStateContext(ctx)
 
-	return err
+	t, err := taskWaiter.WaitForStateContext(ctx)
+	if tsk, ok := t.(*katapult.Task); ok {
+		return tsk, err
+	}
+
+	return nil, err
 }
 
 func stringsDiff(a, b []string) []string {

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.rand_id
@@ -1,1 +1,1 @@
-vq1k12mgrfpy
+imi686727awe

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.yaml
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.yaml
@@ -8,11 +8,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/available_networks?organization%5Bsub_domain%5D=terraform-acc-test
     method: GET
   response:
-    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
+    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public
+      Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New
+      York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -27,7 +29,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:16 GMT
+      - Thu, 25 Feb 2021 17:17:48 GMT
       Etag:
       - W/"556a80fd56c052ba0c772f9d204cefad"
       Server:
@@ -37,9 +39,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "175"
+      - "174"
       X-Request-Id:
-      - 59f23b12-2152-4119-a3fa-d28d592557d6
+      - c6bbc538-4a47-4edd-bc00-c3c298842c81
     status: 200 OK
     code: 200
     duration: ""
@@ -50,11 +52,12 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom"}}}'
+    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -69,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:16 GMT
+      - Thu, 25 Feb 2021 17:17:48 GMT
       Etag:
       - W/"472ac8fb76e85c650214cebfe1011d9e"
       Server:
@@ -79,9 +82,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "174"
+      - "172"
       X-Request-Id:
-      - 451e13b6-179d-4aaf-a7a2-1e51aa3dcc02
+      - c3bfb0e5-c1ae-4c33-8ef4-0595acae3495
     status: 200 OK
     code: 200
     duration: ""
@@ -95,11 +98,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"185-53-57-92.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    body: '{"ip_address":{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"185-53-57-221.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -110,97 +115,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "543"
+      - "546"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:16 GMT
+      - Thu, 25 Feb 2021 17:17:49 GMT
       Etag:
-      - W/"2c54f3610c04084524322d70459d6b1e"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "173"
-      X-Request-Id:
-      - 7c741bed-c05a-4166-b67a-14e69598fcce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wcX6d0TSobKLun8N
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"185-53-57-92.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "561"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:16 GMT
-      Etag:
-      - W/"c6d01fe1d28cc3d2096f080b04d37f2b"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "172"
-      X-Request-Id:
-      - eb202e4b-0708-4746-9936-ff1a26e306e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wcX6d0TSobKLun8N
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"185-53-57-92.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "561"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:16 GMT
-      Etag:
-      - W/"c6d01fe1d28cc3d2096f080b04d37f2b"
+      - W/"2afde1148089f4aa6f151907f43dfc64"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -210,13 +131,101 @@ interactions:
       X-Ratelimit-Remaining:
       - "171"
       X-Request-Id:
-      - 87c225f2-297b-4fed-a085-8f93b59ce8d6
+      - d6da7a3f-ed73-4b63-bb20-472bad7e15be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_NyoIojWuWwnuR5Dh
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"185-53-57-221.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:17:50 GMT
+      Etag:
+      - W/"aa73a0bc6a149dc680196602fef2ede2"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "168"
+      X-Request-Id:
+      - dc991cd2-f0ea-4b63-bdad-9098707786e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_NyoIojWuWwnuR5Dh
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"185-53-57-221.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:17:50 GMT
+      Etag:
+      - W/"aa73a0bc6a149dc680196602fef2ede2"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "167"
+      X-Request-Id:
+      - bb3582bc-9ed5-426c-a4d5-932220b370b9
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_wcX6d0TSobKLun8N</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_NyoIojWuWwnuR5Dh</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-fqdn-imi686727awe-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-fqdn-imi686727awe</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -224,11 +233,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_1Dn0cRR1HYi6EMR7","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_BcoiiIwLf27980ht","state":"pending"},"virtual_machine_build":{"id":"vmbuild_BcoiiIwLf27980ht","state":"pending"},"hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host"}'
+    body: '{"task":{"id":"task_IFmdBLBPOzK3eJdo","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_ggSfizoeTzNRMsHm","state":"pending"},"virtual_machine_build":{"id":"vmbuild_ggSfizoeTzNRMsHm","state":"pending"},"hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -243,9 +252,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:17 GMT
+      - Thu, 25 Feb 2021 17:17:50 GMT
       Etag:
-      - W/"2e4cd7d4be2a027a5cd660914b9286cf"
+      - W/"d74504d85cefffd6dd0cb552ebdbaefc"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -253,9 +262,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "170"
+      - "166"
       X-Request-Id:
-      - f5fe8c2a-d1ba-4948-bb75-3a4db5d29883
+      - d58d1903-c120-4304-82d2-eff6090d62a6
     status: 201 Created
     code: 201
     duration: ""
@@ -266,95 +275,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_BcoiiIwLf27980ht
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_ggSfizoeTzNRMsHm
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_BcoiiIwLf27980ht","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.92\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-vq1k12mgrfpy\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1613684477}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1889"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:19 GMT
-      Etag:
-      - W/"48bc969ff329b433f7dd2e48fa6113e6"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "169"
-      X-Request-Id:
-      - 2e624c4f-c6a4-4c24-bd86-d7a39093b479
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_BcoiiIwLf27980ht
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_BcoiiIwLf27980ht","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.92\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-vq1k12mgrfpy\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1613684477}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1889"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:24 GMT
-      Etag:
-      - W/"48bc969ff329b433f7dd2e48fa6113e6"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "168"
-      X-Request-Id:
-      - 8b93bbf7-b22d-4a2b-996e-bb1048636ff1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_BcoiiIwLf27980ht
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_BcoiiIwLf27980ht","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.92\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-vq1k12mgrfpy\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1613684477}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_ggSfizoeTzNRMsHm","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-imi686727awe-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-imi686727awe\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273470}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -369,222 +301,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:34 GMT
+      - Thu, 25 Feb 2021 17:17:52 GMT
       Etag:
-      - W/"a3a2338f62e7d3542b17ef7268230fdd"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "167"
-      X-Request-Id:
-      - eafd6b1e-369a-463c-9908-53ebcb15da3c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn"},"properties":{"tag_names":["web","public"]}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
-  response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2393"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:34 GMT
-      Etag:
-      - W/"2d262822748bd456ac6870bba7cd9c44"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "166"
-      X-Request-Id:
-      - 5b7432e1-9608-4c5d-8b66-dea35bd4e4df
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2392"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:36 GMT
-      Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "165"
-      X-Request-Id:
-      - dbc2d057-808e-47dd-b4b3-18d7f4fee6e8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2392"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:36 GMT
-      Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "164"
-      X-Request-Id:
-      - bb7ec079-6cc7-4b54-8492-ad2d2e5e8561
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2392"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:36 GMT
-      Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "163"
-      X-Request-Id:
-      - 90d5a8ef-085f-4f2d-8f9c-d0ce2c7604cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2392"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:36 GMT
-      Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
+      - W/"40a7d680bcbdf4ef6b4d31bbba8f6303"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -594,7 +313,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "162"
       X-Request-Id:
-      - 8f608351-8791-49a4-aa2e-6bc69cac2799
+      - 2994cef8-d473-4914-8154-1d7b28f20661
     status: 200 OK
     code: 200
     duration: ""
@@ -605,11 +324,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_ggSfizoeTzNRMsHm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_ggSfizoeTzNRMsHm","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-imi686727awe-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-imi686727awe\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273470}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -620,55 +346,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2392"
+      - "1890"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:36 GMT
+      - Thu, 25 Feb 2021 17:17:57 GMT
       Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "161"
-      X-Request-Id:
-      - 211f900c-24c1-4326-a0f1-aac433ccbe49
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wcX6d0TSobKLun8N
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "753"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:37 GMT
-      Etag:
-      - W/"6de920a184e36ed4e41556b7f2640370"
+      - W/"40a7d680bcbdf4ef6b4d31bbba8f6303"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -678,7 +362,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "160"
       X-Request-Id:
-      - e9661528-9bdd-4f7d-ae9e-e98e60303856
+      - 5187bd8f-6ac4-4488-8e1d-d6274694bc12
     status: 200 OK
     code: 200
     duration: ""
@@ -689,51 +373,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_ggSfizoeTzNRMsHm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2392"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:37 GMT
-      Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "159"
-      X-Request-Id:
-      - b649807c-793d-4a96-8122-ee4796375aef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_ggSfizoeTzNRMsHm","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-imi686727awe-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-imi686727awe\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273470}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -744,13 +395,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2392"
+      - "1890"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:37 GMT
+      - Thu, 25 Feb 2021 17:18:07 GMT
       Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
+      - W/"40a7d680bcbdf4ef6b4d31bbba8f6303"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -758,9 +409,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "158"
+      - "199"
       X-Request-Id:
-      - 0849bb94-6e8e-4462-884d-ab1b67ef14c3
+      - bb700716-a5f3-4275-a037-c12f151c4c40
     status: 200 OK
     code: 200
     duration: ""
@@ -771,11 +422,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_ggSfizoeTzNRMsHm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_ggSfizoeTzNRMsHm","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.221\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-imi686727awe-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-imi686727awe\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614273470}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -786,13 +444,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2392"
+      - "1890"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:37 GMT
+      - Thu, 25 Feb 2021 17:18:17 GMT
       Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
+      - W/"d71640ff5951df3effdba7ef5bab72c8"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -800,24 +458,35 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "157"
+      - "197"
       X-Request-Id:
-      - 116d21af-a1e9-41f1-bb78-342d0d21cdb7
+      - a34739a0-932f-4fb5-a840-abf64eb86c2b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: |
+      {"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
       - application/json
+      Content-Type:
+      - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
-    method: GET
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -828,13 +497,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2392"
+      - "2394"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:37 GMT
+      - Thu, 25 Feb 2021 17:18:17 GMT
       Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -842,9 +511,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "156"
+      - "196"
       X-Request-Id:
-      - 9bfb77d3-5f03-4e68-8cc0-e9786da4b6d0
+      - 351a84f6-56d0-4fa3-86b7-6315256cbb0c
     status: 200 OK
     code: 200
     duration: ""
@@ -855,11 +524,505 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:19 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "193"
+      X-Request-Id:
+      - 8adf275a-9fbb-4da1-975d-fa7643711da3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:19 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "192"
+      X-Request-Id:
+      - 5071179c-05e0-4c1f-b940-930e8243d908
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:19 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "191"
+      X-Request-Id:
+      - eb82884b-3323-4211-9708-e3f111ff2630
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "190"
+      X-Request-Id:
+      - ab1e2d1d-8f98-42f1-9ff9-e6916c64cfea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "189"
+      X-Request-Id:
+      - e9079459-b5fd-48eb-8a38-3c06b266cad9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_NyoIojWuWwnuR5Dh
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "755"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"85f2a76ab1bd54c43a97ef2fa2638139"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "186"
+      X-Request-Id:
+      - 4237583b-4197-44e9-873b-15a3445696de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "184"
+      X-Request-Id:
+      - 1f198b8b-7d54-47e0-8eba-b4f8577e0671
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "183"
+      X-Request-Id:
+      - 9d102474-5181-477c-aa68-598da42815d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "181"
+      X-Request-Id:
+      - b3cb54c8-b90f-4aa4-be14-ecdd9bdbd368
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2394"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:21 GMT
+      Etag:
+      - W/"2ddb065737dcea8eaf7923f0fd897704"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "176"
+      X-Request-Id:
+      - df5dba7b-f6bf-4903-98f9-e4a50756bdd7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
     method: POST
   response:
-    body: '{"task":{"id":"task_2icO7SAtLUVhkVVz","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_ZwhCgRZV5cEbKECK","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -874,9 +1037,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:38 GMT
+      - Thu, 25 Feb 2021 17:18:21 GMT
       Etag:
-      - W/"9be68b65cdf4213c7998659c9a4772c0"
+      - W/"64c00cdccf7d4b2012b2311997219462"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -884,9 +1047,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "155"
+      - "175"
       X-Request-Id:
-      - 0ab4b8d0-eaa1-4e9c-b3a8-8f9456455056
+      - 9bb15219-1b2a-493f-9652-5af996a82d80
     status: 200 OK
     code: 200
     duration: ""
@@ -897,11 +1060,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ZwhCgRZV5cEbKECK
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
+    body: '{"task":{"id":"task_ZwhCgRZV5cEbKECK","name":"Stop virtual machine","status":"running","created_at":1614273501,"started_at":1614273502,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -912,13 +1075,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2392"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:40 GMT
+      - Thu, 25 Feb 2021 17:18:22 GMT
       Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
+      - W/"91fa165d712b5fcfda1fb17301f2561e"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -926,9 +1089,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "154"
+      - "171"
       X-Request-Id:
-      - 77621047-18e3-43fc-b51a-1860f1ccacb9
+      - 861696ae-02ae-40b5-a508-9eff5e587413
     status: 200 OK
     code: 200
     duration: ""
@@ -939,11 +1102,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ZwhCgRZV5cEbKECK
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
+    body: '{"task":{"id":"task_ZwhCgRZV5cEbKECK","name":"Stop virtual machine","status":"completed","created_at":1614273501,"started_at":1614273502,"finished_at":1614273502,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -954,13 +1117,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2392"
+      - "178"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:45 GMT
+      - Thu, 25 Feb 2021 17:18:27 GMT
       Etag:
-      - W/"fc0f07130a251a474d1c3ce905666b1e"
+      - W/"847da98aad1ebe7467373780aab11932"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -968,9 +1131,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "153"
+      - "169"
       X-Request-Id:
-      - ef662e03-df20-462f-a39f-ba95c45ca80f
+      - 587d6c76-a23c-427b-962d-f7ad76506045
     status: 200 OK
     code: 200
     duration: ""
@@ -981,53 +1144,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2392"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:41:55 GMT
-      Etag:
-      - W/"1ff93444b07bfa8b4255c53249fbca7b"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "152"
-      X-Request-Id:
-      - 7e0ba553-ba08-47d5-af9d-0fd29896aa71
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_2FvWna2Iu8HwoqGn
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_OHbRicdEviherqHG","keep_until":1613857315,"object_id":"vm_2FvWna2Iu8HwoqGn","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_2FvWna2Iu8HwoqGn","name":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy","hostname":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host","fqdn":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684477,"initial_root_password":"Gpqt6UmvBnSmir0e","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_wcX6d0TSobKLun8N","address":"185.53.57.92","reverse_dns":"tf-acc-test-data-source-by-fqdn-vq1k12mgrfpy-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.92/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_2FvWna2Iu8HwoqGn","allocation_type":"VirtualMachine"}]}}'
+    body: '{"trash_object":{"id":"trsh_pLlGi7jvQUkIx2GV","keep_until":1614446307,"object_id":"vm_V0tH1a8koEihLsrz","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_V0tH1a8koEihLsrz","name":"tf-acc-test-data-source-by-fqdn-imi686727awe","hostname":"tf-acc-test-data-source-by-fqdn-imi686727awe-host","fqdn":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"aKy3Kxt7ITEEcLxs","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_NyoIojWuWwnuR5Dh","address":"185.53.57.221","reverse_dns":"tf-acc-test-data-source-by-fqdn-imi686727awe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.221/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_V0tH1a8koEihLsrz","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1038,13 +1167,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2527"
+      - "2529"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:56 GMT
+      - Thu, 25 Feb 2021 17:18:28 GMT
       Etag:
-      - W/"d3911ad2af00f4f21b46de1d5f7a86bf"
+      - W/"4426c24e46f892c5776178f22ae02a1e"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1052,9 +1181,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "151"
+      - "168"
       X-Request-Id:
-      - d6b0178c-b8ab-43b1-9670-619e9e3a764e
+      - 3d8a7073-3033-46d1-8498-0bd7faa384ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1065,8 +1194,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_wcX6d0TSobKLun8N
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_NyoIojWuWwnuR5Dh
     method: POST
   response:
     body: '{}'
@@ -1084,7 +1213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:56 GMT
+      - Thu, 25 Feb 2021 17:18:28 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1094,9 +1223,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "150"
+      - "166"
       X-Request-Id:
-      - d7987b75-c18d-4c23-9cd3-458f2a855c80
+      - 96c16ed2-4c70-4691-854d-479ce4d42c58
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,11 +1236,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_OHbRicdEviherqHG
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_pLlGi7jvQUkIx2GV
     method: DELETE
   response:
-    body: '{"task":{"id":"task_FOQmqd8pCWWqR6f4","name":"Purge items from trash","status":"pending","created_at":1613684516,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_3GFrvNXfCcfHmb18","name":"Purge items from trash","status":"pending","created_at":1614273508,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1126,9 +1255,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:56 GMT
+      - Thu, 25 Feb 2021 17:18:28 GMT
       Etag:
-      - W/"d342e8492fd2838c11d082e154cdb9a4"
+      - W/"6868d1c6cc08fc2dd1e608e8daece9f4"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1136,9 +1265,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "149"
+      - "165"
       X-Request-Id:
-      - 69ee1faa-af63-4b84-8623-a8a1f53120ea
+      - 5fc0b1aa-2725-44b3-976f-8d8bb53cbfdb
     status: 200 OK
     code: 200
     duration: ""
@@ -1149,11 +1278,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FOQmqd8pCWWqR6f4
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_3GFrvNXfCcfHmb18
     method: GET
   response:
-    body: '{"task":{"id":"task_FOQmqd8pCWWqR6f4","name":"Purge items from trash","status":"running","created_at":1613684516,"started_at":1613684517,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_3GFrvNXfCcfHmb18","name":"Purge items from trash","status":"running","created_at":1614273508,"started_at":1614273509,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1168,9 +1297,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:41:57 GMT
+      - Thu, 25 Feb 2021 17:18:29 GMT
       Etag:
-      - W/"c2526d038d5c0ea4f73733177a477b76"
+      - W/"a73bf10621c7b76f6c04f2a8661f3e65"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1178,9 +1307,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "148"
+      - "164"
       X-Request-Id:
-      - 66da6ce2-713f-4489-aaf4-18c7a856edab
+      - 964d4e87-0f3a-4c7c-89e3-f3f3e74ee589
     status: 200 OK
     code: 200
     duration: ""
@@ -1191,11 +1320,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FOQmqd8pCWWqR6f4
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_3GFrvNXfCcfHmb18
     method: GET
   response:
-    body: '{"task":{"id":"task_FOQmqd8pCWWqR6f4","name":"Purge items from trash","status":"completed","created_at":1613684516,"started_at":1613684517,"finished_at":1613684519,"progress":100}}'
+    body: '{"task":{"id":"task_3GFrvNXfCcfHmb18","name":"Purge items from trash","status":"completed","created_at":1614273508,"started_at":1614273509,"finished_at":1614273510,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1210,9 +1339,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:42:02 GMT
+      - Thu, 25 Feb 2021 17:18:34 GMT
       Etag:
-      - W/"e25f49364bc579cf41b0af52ab7a10ea"
+      - W/"925d85cba133b48cdc6d0a0a238d8daf"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1220,9 +1349,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "199"
+      - "163"
       X-Request-Id:
-      - 117de1e3-4bf0-483e-9327-791f9508c0f4
+      - 47d2c210-e490-420e-9703-531e99024d54
     status: 200 OK
     code: 200
     duration: ""
@@ -1233,8 +1362,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wcX6d0TSobKLun8N
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_NyoIojWuWwnuR5Dh
     method: DELETE
   response:
     body: '{}'
@@ -1252,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:42:02 GMT
+      - Thu, 25 Feb 2021 17:18:34 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1262,9 +1391,138 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "198"
+      - "162"
       X-Request-Id:
-      - 2b1b3f1f-2126-42ea-9576-99b2da205ba8
+      - 09fbe04d-9c02-4d1f-97ce-c241c2bf024d
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:34 GMT
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "161"
+      X-Request-Id:
+      - cdde438f-99f1-4f99-a7e7-9ed03dfcff64
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_V0tH1a8koEihLsrz
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:34 GMT
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "160"
+      X-Request-Id:
+      - e39371c6-78d4-4713-b544-80a055eecee7
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_NyoIojWuWwnuR5Dh
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:34 GMT
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "159"
+      X-Request-Id:
+      - d69e5d36-aad7-4fa0-beaa-4e4878e2d589
+    status: 404 Not Found
+    code: 404
     duration: ""

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.rand_id
@@ -1,1 +1,1 @@
-f4nscwku13hm
+bapppfhq6yck

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.yaml
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.yaml
@@ -8,11 +8,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/available_networks?organization%5Bsub_domain%5D=terraform-acc-test
     method: GET
   response:
-    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
+    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public
+      Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New
+      York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -27,7 +29,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:30 GMT
+      - Thu, 25 Feb 2021 17:17:48 GMT
       Etag:
       - W/"556a80fd56c052ba0c772f9d204cefad"
       Server:
@@ -37,9 +39,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "199"
+      - "173"
       X-Request-Id:
-      - 064b33a2-8477-4137-a578-099cab31e660
+      - 330c97a8-dc47-48b2-bf20-08fd95739663
     status: 200 OK
     code: 200
     duration: ""
@@ -50,11 +52,12 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom"}}}'
+    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -69,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:30 GMT
+      - Thu, 25 Feb 2021 17:17:48 GMT
       Etag:
       - W/"472ac8fb76e85c650214cebfe1011d9e"
       Server:
@@ -79,9 +82,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "198"
+      - "170"
       X-Request-Id:
-      - b872ea06-b71a-4df3-99eb-5d7e9c36792d
+      - 4a563d25-2032-477d-a5ae-08e05b87cb65
     status: 200 OK
     code: 200
     duration: ""
@@ -95,11 +98,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"185-53-57-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    body: '{"ip_address":{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"185-53-57-21.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -110,13 +115,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "546"
+      - "543"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:30 GMT
+      - Thu, 25 Feb 2021 17:17:50 GMT
       Etag:
-      - W/"751fe0b0aaf3107e72a6369476abf07e"
+      - W/"191b4dd420d2c4d4a6b8358724e117d2"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -124,9 +129,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "197"
+      - "169"
       X-Request-Id:
-      - 7aae6ba2-4ff5-4fa0-995d-a00ecd599de3
+      - 46ad9596-6aaa-4e0b-a9fc-25e4d17bad4d
     status: 200 OK
     code: 200
     duration: ""
@@ -137,11 +142,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_TP8APIfJXewCt1Uc
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WcqZxrHfmSQ6cNT2
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"185-53-57-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"185-53-57-21.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -152,13 +159,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "564"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:30 GMT
+      - Thu, 25 Feb 2021 17:17:50 GMT
       Etag:
-      - W/"747a06a7daf819bff211854825696a81"
+      - W/"be0f61341eccf041ff3e4a081b179234"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -166,9 +173,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "196"
+      - "165"
       X-Request-Id:
-      - e4ac999d-d4f3-4a09-b57f-be02696affc9
+      - d54ccbca-04ea-4a37-81b1-37720dd92b81
     status: 200 OK
     code: 200
     duration: ""
@@ -179,11 +186,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_TP8APIfJXewCt1Uc
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WcqZxrHfmSQ6cNT2
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"185-53-57-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"185-53-57-21.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -194,13 +203,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "564"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:30 GMT
+      - Thu, 25 Feb 2021 17:17:50 GMT
       Etag:
-      - W/"747a06a7daf819bff211854825696a81"
+      - W/"be0f61341eccf041ff3e4a081b179234"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -208,15 +217,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "195"
+      - "164"
       X-Request-Id:
-      - a317e862-5128-4abd-b01f-0ddddb31cd42
+      - de34555f-0a20-41e1-8836-947683bf26f8
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_TP8APIfJXewCt1Uc</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-id-f4nscwku13hm-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-id-f4nscwku13hm</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_WcqZxrHfmSQ6cNT2</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-id-bapppfhq6yck-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-id-bapppfhq6yck</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -224,11 +233,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_ZtqcIcBN9wy8v3j3","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_ILLged7ezgnwG6Jc","state":"pending"},"virtual_machine_build":{"id":"vmbuild_ILLged7ezgnwG6Jc","state":"pending"},"hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host"}'
+    body: '{"task":{"id":"task_TordItgubDzG4OeL","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_raoMbj5LsxK9f7q1","state":"pending"},"virtual_machine_build":{"id":"vmbuild_raoMbj5LsxK9f7q1","state":"pending"},"hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -243,9 +252,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:30 GMT
+      - Thu, 25 Feb 2021 17:17:51 GMT
       Etag:
-      - W/"78fa5c44383f1f28cdefce17a582e24c"
+      - W/"017503787062f3bf5911cc2237f00954"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -253,9 +262,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "194"
+      - "163"
       X-Request-Id:
-      - 1a66302a-ccd1-4b91-8d69-8e799700b70d
+      - 0e9ff6a7-8862-420e-89db-d6125be87ba1
     status: 201 Created
     code: 201
     duration: ""
@@ -266,11 +275,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_ILLged7ezgnwG6Jc
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_raoMbj5LsxK9f7q1
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ILLged7ezgnwG6Jc","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-f4nscwku13hm-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-f4nscwku13hm\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1613684910}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_raoMbj5LsxK9f7q1","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.21\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-bapppfhq6yck-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-bapppfhq6yck\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273471}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -281,13 +297,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1880"
+      - "1879"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:32 GMT
+      - Thu, 25 Feb 2021 17:17:53 GMT
       Etag:
-      - W/"15a86aea01024a4055a1fe1b83ca9026"
+      - W/"6f51cc25fdac53d2ef5e4dc6b9e01ce7"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -295,9 +311,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "193"
+      - "161"
       X-Request-Id:
-      - 275d1e47-d744-44d1-b5db-6c38333298b6
+      - 91c04643-cd83-4aa2-bfc9-c703923856ef
     status: 200 OK
     code: 200
     duration: ""
@@ -308,11 +324,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_ILLged7ezgnwG6Jc
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_raoMbj5LsxK9f7q1
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ILLged7ezgnwG6Jc","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-f4nscwku13hm-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-f4nscwku13hm\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1613684910}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_raoMbj5LsxK9f7q1","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.21\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-bapppfhq6yck-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-bapppfhq6yck\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273471}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -323,13 +346,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1880"
+      - "1879"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:37 GMT
+      - Thu, 25 Feb 2021 17:17:58 GMT
       Etag:
-      - W/"15a86aea01024a4055a1fe1b83ca9026"
+      - W/"6f51cc25fdac53d2ef5e4dc6b9e01ce7"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -337,9 +360,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "192"
+      - "159"
       X-Request-Id:
-      - b45d3742-0630-4829-a9f0-d8b8c04a6b97
+      - 93660e53-e282-42c6-af0d-05810ecd78e8
     status: 200 OK
     code: 200
     duration: ""
@@ -350,11 +373,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_ILLged7ezgnwG6Jc
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_raoMbj5LsxK9f7q1
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ILLged7ezgnwG6Jc","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-f4nscwku13hm-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-f4nscwku13hm\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1613684910}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_raoMbj5LsxK9f7q1","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.21\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-bapppfhq6yck-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-bapppfhq6yck\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273471}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -365,310 +395,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1880"
+      - "1879"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:48:47 GMT
+      - Thu, 25 Feb 2021 17:18:08 GMT
       Etag:
-      - W/"15a86aea01024a4055a1fe1b83ca9026"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "191"
-      X-Request-Id:
-      - 2738a582-28c9-4140-9392-8af0a5d68a64
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_ILLged7ezgnwG6Jc
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ILLged7ezgnwG6Jc","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-f4nscwku13hm-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-f4nscwku13hm\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1613684910}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1880"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:48:57 GMT
-      Etag:
-      - W/"3a41858b91ce1fa4bbfacb35a72631b6"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "190"
-      X-Request-Id:
-      - 369897ab-4343-49f0-962c-5206e1727fc4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c"},"properties":{"tag_names":["web","public"]}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
-  response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2386"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:48:57 GMT
-      Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "189"
-      X-Request-Id:
-      - 114d2235-81c0-4251-b752-cd0ae4c6e007
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2386"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:48:59 GMT
-      Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "188"
-      X-Request-Id:
-      - 72911989-b29f-431d-a0e2-6854664dfbe1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2386"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:48:59 GMT
-      Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "187"
-      X-Request-Id:
-      - 7f98cc88-ca02-4b6a-9022-48b3dda5b909
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2386"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:48:59 GMT
-      Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "186"
-      X-Request-Id:
-      - d3b61826-d04c-4f44-b09e-7f0cda5b4834
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2386"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:49:00 GMT
-      Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "199"
-      X-Request-Id:
-      - b5b5f9a4-04eb-403c-815e-c6f5ff80f013
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2386"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:49:00 GMT
-      Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
+      - W/"6f51cc25fdac53d2ef5e4dc6b9e01ce7"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -678,7 +411,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "198"
       X-Request-Id:
-      - 3578deb0-6ad4-4531-88eb-916d2d48bdc8
+      - 2f20bd31-8fd2-404e-9641-0403922b3ed9
     status: 200 OK
     code: 200
     duration: ""
@@ -689,11 +422,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_TP8APIfJXewCt1Uc
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_raoMbj5LsxK9f7q1
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm"}}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_raoMbj5LsxK9f7q1","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.21\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-bapppfhq6yck-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-bapppfhq6yck\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614273471}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -704,97 +444,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "751"
+      - "1879"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:00 GMT
+      - Thu, 25 Feb 2021 17:18:18 GMT
       Etag:
-      - W/"93d2130ca30b5bef8dd4e53c7bdb1132"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "197"
-      X-Request-Id:
-      - b0600167-9082-45cb-99d9-2f248c01f9e8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2386"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:49:00 GMT
-      Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "196"
-      X-Request-Id:
-      - 29b863c1-6a10-44e8-82ec-86543924f875
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2386"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 18 Feb 2021 21:49:00 GMT
-      Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
+      - W/"010e4ba8130387fd3fef37110f67ed7b"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -804,22 +460,33 @@ interactions:
       X-Ratelimit-Remaining:
       - "195"
       X-Request-Id:
-      - 29bf8edc-9f86-4504-95d7-6819c275ae92
+      - ee907196-533e-4dbd-9072-a16a5ad6a966
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: |
+      {"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
       - application/json
+      Content-Type:
+      - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
-    method: GET
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -830,13 +497,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2386"
+      - "2384"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:00 GMT
+      - Thu, 25 Feb 2021 17:18:18 GMT
       Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -846,7 +513,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "194"
       X-Request-Id:
-      - bf7bb221-d64b-499f-a4a7-5975c173b157
+      - bf14d4a4-8653-400d-8035-d9876a359608
     status: 200 OK
     code: 200
     duration: ""
@@ -857,11 +524,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -872,13 +547,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2386"
+      - "2384"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:01 GMT
+      - Thu, 25 Feb 2021 17:18:20 GMT
       Etag:
-      - W/"87c22c541a636dfb4e900c4d9b390238"
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -886,9 +561,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "193"
+      - "188"
       X-Request-Id:
-      - 49c415d7-5290-4f65-b2c1-4725dab8919a
+      - 3c7160f9-0e29-498c-985f-9012ed0ad0c1
     status: 200 OK
     code: 200
     duration: ""
@@ -899,11 +574,455 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2384"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "187"
+      X-Request-Id:
+      - 91a0a93f-fced-4f75-a5dd-586f44216838
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2384"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "185"
+      X-Request-Id:
+      - 3c849b3b-d185-415c-b506-cddddacdbe93
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2384"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:20 GMT
+      Etag:
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "182"
+      X-Request-Id:
+      - 2e0bea57-9caf-4d81-b7d2-8a85aeab74b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2384"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:21 GMT
+      Etag:
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "180"
+      X-Request-Id:
+      - 4a607453-5ffc-4587-b403-d901a907ba7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WcqZxrHfmSQ6cNT2
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "749"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:21 GMT
+      Etag:
+      - W/"44ab4bab6ad58318bf6987c818d1a39c"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "179"
+      X-Request-Id:
+      - e258c635-35e2-43a1-86fc-9efe9df27c3c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2384"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:21 GMT
+      Etag:
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "178"
+      X-Request-Id:
+      - 3a4f977e-0ca2-4d9f-8e72-ae4a3dbdb0d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2384"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:21 GMT
+      Etag:
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "177"
+      X-Request-Id:
+      - dae30962-af3c-471b-ac0a-212c3e131110
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2384"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:21 GMT
+      Etag:
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "174"
+      X-Request-Id:
+      - a5f7b68d-58bf-4fd6-b593-1a594047429e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2384"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:22 GMT
+      Etag:
+      - W/"216e67c30171506db3e2c2a44b9fe66d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "173"
+      X-Request-Id:
+      - cc87b261-32ea-46cc-bf53-09eeb060b6ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
     method: POST
   response:
-    body: '{"task":{"id":"task_5MY1ntyYKwhkWB3g","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_ZuDk85o02lsjlI0R","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -918,9 +1037,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:01 GMT
+      - Thu, 25 Feb 2021 17:18:22 GMT
       Etag:
-      - W/"315959e48361c4611f55fb9ed362a8d8"
+      - W/"14cfdfb6f49e7d1a1e827816e563c7e5"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -928,9 +1047,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "192"
+      - "172"
       X-Request-Id:
-      - f13494b1-9718-4e26-97de-42282be4e968
+      - 5b4c2741-9e78-4688-bdc6-53593824e6b1
     status: 200 OK
     code: 200
     duration: ""
@@ -941,11 +1060,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ZuDk85o02lsjlI0R
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
+    body: '{"task":{"id":"task_ZuDk85o02lsjlI0R","name":"Stop virtual machine","status":"pending","created_at":1614273502,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -956,13 +1075,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2386"
+      - "162"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:03 GMT
+      - Thu, 25 Feb 2021 17:18:23 GMT
       Etag:
-      - W/"5badf178120af004da0ebacdeb374e47"
+      - W/"30e69cfd54830d27aa9409c37cb47111"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -970,9 +1089,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "191"
+      - "170"
       X-Request-Id:
-      - ce5ed130-1e4e-4f46-94a7-c9343d04b544
+      - b05e5297-8ea6-48a6-8f93-00d274997f18
     status: 200 OK
     code: 200
     duration: ""
@@ -983,11 +1102,145 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wPDbeXgtaj6nkF6c
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ZuDk85o02lsjlI0R
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ZuDk85o02lsjlI0R","name":"Stop virtual machine","status":"pending","created_at":1614273502,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:28 GMT
+      Etag:
+      - W/"30e69cfd54830d27aa9409c37cb47111"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "167"
+      X-Request-Id:
+      - 13f04c10-63bc-4001-b19a-3840be2528be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ZuDk85o02lsjlI0R
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ZuDk85o02lsjlI0R","name":"Stop virtual machine","status":"running","created_at":1614273502,"started_at":1614273517,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:38 GMT
+      Etag:
+      - W/"843026fbab801367411fc45c7ed11f2d"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "158"
+      X-Request-Id:
+      - 03c07fcc-a15b-498c-aae5-0f542e9c5979
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ZuDk85o02lsjlI0R
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ZuDk85o02lsjlI0R","name":"Stop virtual machine","status":"completed","created_at":1614273502,"started_at":1614273517,"finished_at":1614273518,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:48 GMT
+      Etag:
+      - W/"ee07f7fcd7a928b265c591782427e935"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "157"
+      X-Request-Id:
+      - b6ea17ef-a8f9-4bf6-a788-0025e0354b50
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_h87vRw3vzZAnQIMe","keep_until":1613857743,"object_id":"vm_wPDbeXgtaj6nkF6c","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_wPDbeXgtaj6nkF6c","name":"tf-acc-test-data-source-by-id-f4nscwku13hm","hostname":"tf-acc-test-data-source-by-id-f4nscwku13hm-host","fqdn":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1613684911,"initial_root_password":"Ux8ARxQzxErQcc3y","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_TP8APIfJXewCt1Uc","address":"185.53.57.126","reverse_dns":"tf-acc-test-data-source-by-id-f4nscwku13hm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wPDbeXgtaj6nkF6c","allocation_type":"VirtualMachine"}]}}'
+    body: '{"trash_object":{"id":"trsh_CYJ1LPAd1W9SqgoR","keep_until":1614446328,"object_id":"vm_GPuIrBhcpnJtlWCO","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_GPuIrBhcpnJtlWCO","name":"tf-acc-test-data-source-by-id-bapppfhq6yck","hostname":"tf-acc-test-data-source-by-id-bapppfhq6yck-host","fqdn":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273471,"initial_root_password":"acmGTsjHxnx96gbY","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_WcqZxrHfmSQ6cNT2","address":"185.53.57.21","reverse_dns":"tf-acc-test-data-source-by-id-bapppfhq6yck-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GPuIrBhcpnJtlWCO","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -998,13 +1251,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2521"
+      - "2519"
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:04 GMT
+      - Thu, 25 Feb 2021 17:18:49 GMT
       Etag:
-      - W/"e632c844c90017599907e699e5158aa2"
+      - W/"166aaed408af6b1bfcc47c2f086cc602"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1012,9 +1265,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "190"
+      - "156"
       X-Request-Id:
-      - c34588fa-2ac9-425c-8a66-10cb288afe50
+      - 87ac01c9-ed2b-4c17-9dc7-840de9ee5c09
     status: 200 OK
     code: 200
     duration: ""
@@ -1025,8 +1278,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_TP8APIfJXewCt1Uc
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_WcqZxrHfmSQ6cNT2
     method: POST
   response:
     body: '{}'
@@ -1044,7 +1297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:04 GMT
+      - Thu, 25 Feb 2021 17:18:49 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1054,9 +1307,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "189"
+      - "155"
       X-Request-Id:
-      - 4c5afa54-c996-46fc-ab63-11968ea2755c
+      - 42dc1b70-8c31-4ee7-ba77-e036e27fc208
     status: 200 OK
     code: 200
     duration: ""
@@ -1067,11 +1320,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_h87vRw3vzZAnQIMe
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_CYJ1LPAd1W9SqgoR
     method: DELETE
   response:
-    body: '{"task":{"id":"task_GeB1C86gkJ4RW1hO","name":"Purge items from trash","status":"pending","created_at":1613684944,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_Z9fRzMI74EHsgMQw","name":"Purge items from trash","status":"pending","created_at":1614273529,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1086,9 +1339,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:04 GMT
+      - Thu, 25 Feb 2021 17:18:49 GMT
       Etag:
-      - W/"d2cca4fb244c38732668ac6f4e4a7cb6"
+      - W/"c89377a4776167f249340949055f6f29"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1096,9 +1349,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "188"
+      - "154"
       X-Request-Id:
-      - 1fe72998-951d-4690-82a0-ec99710eeeb6
+      - 1436b5db-1945-4f3f-a305-80860cab470a
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,11 +1362,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_GeB1C86gkJ4RW1hO
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_Z9fRzMI74EHsgMQw
     method: GET
   response:
-    body: '{"task":{"id":"task_GeB1C86gkJ4RW1hO","name":"Purge items from trash","status":"running","created_at":1613684944,"started_at":1613684944,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_Z9fRzMI74EHsgMQw","name":"Purge items from trash","status":"running","created_at":1614273529,"started_at":1614273529,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1128,9 +1381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:05 GMT
+      - Thu, 25 Feb 2021 17:18:50 GMT
       Etag:
-      - W/"ce1f5d35f1ed886609b57516d7d0b889"
+      - W/"0d8ef24ff7007a1685b90f1e5d2f79d0"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1138,9 +1391,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "187"
+      - "153"
       X-Request-Id:
-      - c44ad0b0-dffb-4c22-a143-1487fe5dc23f
+      - ee6da0d2-b377-4fb4-8b5c-97e7cf0c87bc
     status: 200 OK
     code: 200
     duration: ""
@@ -1151,11 +1404,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_GeB1C86gkJ4RW1hO
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_Z9fRzMI74EHsgMQw
     method: GET
   response:
-    body: '{"task":{"id":"task_GeB1C86gkJ4RW1hO","name":"Purge items from trash","status":"completed","created_at":1613684944,"started_at":1613684944,"finished_at":1613684945,"progress":100}}'
+    body: '{"task":{"id":"task_Z9fRzMI74EHsgMQw","name":"Purge items from trash","status":"completed","created_at":1614273529,"started_at":1614273529,"finished_at":1614273531,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1170,9 +1423,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:10 GMT
+      - Thu, 25 Feb 2021 17:18:55 GMT
       Etag:
-      - W/"e2988104f8b515ffb0184b367c9ccc37"
+      - W/"b14a9f0027fa1d2ed3d382a71ffa2837"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1180,9 +1433,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "186"
+      - "152"
       X-Request-Id:
-      - c22943eb-3e35-48d1-a18c-e3f4680c4001
+      - 3c7da6b3-bcfa-40ac-b16a-f3ca5012e057
     status: 200 OK
     code: 200
     duration: ""
@@ -1193,8 +1446,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.14.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.2 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_TP8APIfJXewCt1Uc
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WcqZxrHfmSQ6cNT2
     method: DELETE
   response:
     body: '{}'
@@ -1212,7 +1465,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 18 Feb 2021 21:49:10 GMT
+      - Thu, 25 Feb 2021 17:18:55 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1222,9 +1475,138 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "185"
+      - "151"
       X-Request-Id:
-      - a04ecd1c-6fb3-469f-90b9-d64f5e3c0b9c
+      - 7734d2cc-347f-42ed-98b8-07dc2921643a
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:56 GMT
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "150"
+      X-Request-Id:
+      - b62f8527-e2d1-4109-a3c1-b487b7e82a49
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GPuIrBhcpnJtlWCO
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:56 GMT
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "149"
+      X-Request-Id:
+      - 2bc53ebe-362b-434c-a94b-059857bb7890
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WcqZxrHfmSQ6cNT2
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:18:56 GMT
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "148"
+      X-Request-Id:
+      - 8a13c3f4-3a02-4238-b42d-aa6e5eae38db
+    status: 404 Not Found
+    code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_basic.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_basic.cassette.rand_id
@@ -1,1 +1,1 @@
-llmj8f8sqgm8
+dh7wkynuvlrw

--- a/internal/provider/testdata/VirtualMachine_basic.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_basic.cassette.yaml
@@ -12,7 +12,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/available_networks?organization%5Bsub_domain%5D=terraform-acc-test
     method: GET
   response:
-    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
+    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public
+      Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New
+      York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -27,7 +29,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
       - W/"556a80fd56c052ba0c772f9d204cefad"
       Server:
@@ -37,9 +39,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "196"
+      - "197"
       X-Request-Id:
-      - dfde6b0a-d09f-4afa-a332-87bdf8549e4b
+      - 8ed60142-53c2-4182-81ee-ea9eab4accdb
     status: 200 OK
     code: 200
     duration: ""
@@ -54,7 +56,8 @@ interactions:
     url: https://api.katapult.io/core/v1/data_centers/_?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom"}}}'
+    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -69,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
       - W/"472ac8fb76e85c650214cebfe1011d9e"
       Server:
@@ -79,9 +82,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "189"
+      - "191"
       X-Request-Id:
-      - 948784d6-2b21-4341-9f04-5b58a6a1193e
+      - e86b9352-311e-4106-997d-3a4ad9be4221
     status: 200 OK
     code: 200
     duration: ""
@@ -99,7 +102,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"185-53-57-170.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    body: '{"ip_address":{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"185-53-57-37.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -110,13 +115,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "546"
+      - "543"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"1e80c8e1aacdad984bcd98d03169d82d"
+      - W/"a46142874fa1eb021f60b80b3e085f85"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -124,9 +129,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "188"
+      - "189"
       X-Request-Id:
-      - 587421af-f61c-4ac2-8bcd-2dc43ff97b82
+      - 2182a080-2e57-449b-b3f0-6a93dc80dc9b
     status: 200 OK
     code: 200
     duration: ""
@@ -138,10 +143,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h7FLNa3jFAOAYWBB
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8rby1Nlwx4IsqVQ2
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"185-53-57-170.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"185-53-57-37.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -152,13 +159,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "564"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"d61683b835ffe97ca4b9704e4657551e"
+      - W/"24d4f0ed87425cd9533d66284deae37c"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -166,9 +173,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "180"
+      - "185"
       X-Request-Id:
-      - af874ee8-f46e-4869-b21d-17a31714cf7a
+      - a6ba0580-bf5d-4686-ae5d-36896cec6225
     status: 200 OK
     code: 200
     duration: ""
@@ -180,10 +187,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h7FLNa3jFAOAYWBB
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8rby1Nlwx4IsqVQ2
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"185-53-57-170.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"185-53-57-37.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -194,13 +203,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "564"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"d61683b835ffe97ca4b9704e4657551e"
+      - W/"24d4f0ed87425cd9533d66284deae37c"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -208,15 +217,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "177"
+      - "182"
       X-Request-Id:
-      - 2d3f58ea-d9d7-4ba2-9f12-532236babd9a
+      - 1a6cbf49-364c-4b19-81e7-fcb1677ae4fe
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_h7FLNa3jFAOAYWBB</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-basic-llmj8f8sqgm8-host</Hostname></Hostname><Name>tf-acc-test-basic-llmj8f8sqgm8</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_8rby1Nlwx4IsqVQ2</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-basic-dh7wkynuvlrw-host</Hostname></Hostname><Name>tf-acc-test-basic-dh7wkynuvlrw</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -228,7 +237,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_4CURIa5KwLsQWMxa","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_DCRuEJmZr361MvSD","state":"pending"},"virtual_machine_build":{"id":"vmbuild_DCRuEJmZr361MvSD","state":"pending"},"hostname":"tf-acc-test-basic-llmj8f8sqgm8-host"}'
+    body: '{"task":{"id":"task_nuYN5EnQHjCpOfnZ","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_Rpc7ASOj2XwbCNvl","state":"pending"},"virtual_machine_build":{"id":"vmbuild_Rpc7ASOj2XwbCNvl","state":"pending"},"hostname":"tf-acc-test-basic-dh7wkynuvlrw-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -243,9 +252,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"9f5a23d094498e007483ccaa7d490ac6"
+      - W/"6d25118a5581b6ffaec324c4e424ccee"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -253,9 +262,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "176"
+      - "178"
       X-Request-Id:
-      - b7b3cf02-0f23-46f1-9e73-5d71b7225062
+      - d5614851-2deb-46a2-8a2b-70d4b2e8b342
     status: 201 Created
     code: 201
     duration: ""
@@ -267,10 +276,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_DCRuEJmZr361MvSD
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_Rpc7ASOj2XwbCNvl
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DCRuEJmZr361MvSD","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.170\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-llmj8f8sqgm8-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-llmj8f8sqgm8\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_Rpc7ASOj2XwbCNvl","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.37\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dh7wkynuvlrw-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dh7wkynuvlrw\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -281,13 +297,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1610"
+      - "1609"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:12 GMT
+      - Thu, 25 Feb 2021 17:24:13 GMT
       Etag:
-      - W/"ea07d1c1fa571ac065da5945c72e8959"
+      - W/"c829148964d47eb7ffad94afefa32d01"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -295,9 +311,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "173"
+      - "174"
       X-Request-Id:
-      - eb8b2ac3-4e6c-4ac1-9bc4-b36026ccc9d4
+      - 7f813c4a-cfaf-4de6-91ce-53c7458d1704
     status: 200 OK
     code: 200
     duration: ""
@@ -309,10 +325,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_DCRuEJmZr361MvSD
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_Rpc7ASOj2XwbCNvl
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DCRuEJmZr361MvSD","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.170\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-llmj8f8sqgm8-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-llmj8f8sqgm8\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_Rpc7ASOj2XwbCNvl","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.37\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dh7wkynuvlrw-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dh7wkynuvlrw\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -323,13 +346,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1820"
+      - "1819"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:17 GMT
+      - Thu, 25 Feb 2021 17:24:18 GMT
       Etag:
-      - W/"32fee93c01902f2f0e50cf40f9dec58a"
+      - W/"dfc5f8800aaeaba9123ec6fc6d785547"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -339,7 +362,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "169"
       X-Request-Id:
-      - e07aef01-4c4b-467e-a4ad-90723e6da7f0
+      - 3383732d-94c7-4452-88e2-84e44e3a5d79
     status: 200 OK
     code: 200
     duration: ""
@@ -351,10 +374,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_DCRuEJmZr361MvSD
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_Rpc7ASOj2XwbCNvl
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DCRuEJmZr361MvSD","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.170\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-llmj8f8sqgm8-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-llmj8f8sqgm8\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_Rpc7ASOj2XwbCNvl","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.37\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dh7wkynuvlrw-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dh7wkynuvlrw\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -365,13 +395,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1820"
+      - "1819"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:27 GMT
+      - Thu, 25 Feb 2021 17:24:28 GMT
       Etag:
-      - W/"32fee93c01902f2f0e50cf40f9dec58a"
+      - W/"dfc5f8800aaeaba9123ec6fc6d785547"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -379,9 +409,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "165"
+      - "166"
       X-Request-Id:
-      - 42c4d7a1-08e0-44f6-82ab-56926c71544e
+      - feeb599a-8afb-4047-8a55-34263ea5a490
     status: 200 OK
     code: 200
     duration: ""
@@ -393,10 +423,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_DCRuEJmZr361MvSD
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_Rpc7ASOj2XwbCNvl
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DCRuEJmZr361MvSD","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.170\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-llmj8f8sqgm8-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-llmj8f8sqgm8\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_Rpc7ASOj2XwbCNvl","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.37\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dh7wkynuvlrw-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dh7wkynuvlrw\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -407,13 +444,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1820"
+      - "1819"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:37 GMT
+      - Thu, 25 Feb 2021 17:24:38 GMT
       Etag:
-      - W/"3af2f0b4cf5d9563a07af008e822d45f"
+      - W/"1877efa0ecbc9f79f0be56ee392f98cd"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -421,15 +458,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "161"
+      - "136"
       X-Request-Id:
-      - 14738f6e-f459-4f76-aa47-afda4a8d7cf6
+      - 382d11a5-9849-4919-9691-988ded1e8561
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_9hYciEae64bdDmqV"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -441,7 +478,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"fHppd2CyqDivddz3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"KcFHQmHm5w3Wuauf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ju2A8YAw3NDheZRs","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -452,13 +497,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2338"
+      - "2336"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:37 GMT
+      - Thu, 25 Feb 2021 17:24:38 GMT
       Etag:
-      - W/"c53e62e1e65e83446346aac6e00b1d89"
+      - W/"6ec34d7ee3d72cb00bdb4851494614f9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -466,9 +511,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "159"
+      - "133"
       X-Request-Id:
-      - 71566b07-59ad-4633-9725-0d098ceef724
+      - 5010bb56-7cbc-4338-80a6-fdcc9f6c03c5
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +525,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ju2A8YAw3NDheZRs
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"fHppd2CyqDivddz3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"KcFHQmHm5w3Wuauf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ju2A8YAw3NDheZRs","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -494,13 +547,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2338"
+      - "2336"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
+      - Thu, 25 Feb 2021 17:24:40 GMT
       Etag:
-      - W/"c53e62e1e65e83446346aac6e00b1d89"
+      - W/"6ec34d7ee3d72cb00bdb4851494614f9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -508,9 +561,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "153"
+      - "123"
       X-Request-Id:
-      - 52b003fb-facb-4b5d-88c2-e0f369e42dd0
+      - adb31e8e-85bb-4095-b9bb-fdc26a25d50a
     status: 200 OK
     code: 200
     duration: ""
@@ -522,10 +575,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ju2A8YAw3NDheZRs
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"fHppd2CyqDivddz3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"KcFHQmHm5w3Wuauf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ju2A8YAw3NDheZRs","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -536,13 +597,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2338"
+      - "2336"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
+      - Thu, 25 Feb 2021 17:24:40 GMT
       Etag:
-      - W/"c53e62e1e65e83446346aac6e00b1d89"
+      - W/"6ec34d7ee3d72cb00bdb4851494614f9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -550,9 +611,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "150"
+      - "119"
       X-Request-Id:
-      - 1f6c288e-9b1e-4db3-9237-88239b13d13a
+      - 8db57575-1cd0-4adc-b669-ac483f8fe1f5
     status: 200 OK
     code: 200
     duration: ""
@@ -564,10 +625,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ju2A8YAw3NDheZRs
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"fHppd2CyqDivddz3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"KcFHQmHm5w3Wuauf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ju2A8YAw3NDheZRs","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -578,13 +647,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2338"
+      - "2336"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
+      - Thu, 25 Feb 2021 17:24:40 GMT
       Etag:
-      - W/"c53e62e1e65e83446346aac6e00b1d89"
+      - W/"6ec34d7ee3d72cb00bdb4851494614f9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -592,9 +661,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "146"
+      - "116"
       X-Request-Id:
-      - c5d9b66d-ac9d-4c2c-83e3-33a9dcb3b3eb
+      - 16376d88-5fc0-4ced-9ce3-e8d3de7142cc
     status: 200 OK
     code: 200
     duration: ""
@@ -606,10 +675,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h7FLNa3jFAOAYWBB
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8rby1Nlwx4IsqVQ2
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8"}}}'
+    body: '{"ip_address":{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ju2A8YAw3NDheZRs","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -620,13 +691,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "727"
+      - "725"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:41 GMT
+      - Thu, 25 Feb 2021 17:24:41 GMT
       Etag:
-      - W/"7803305108fc74ac3a2a3b2c711af854"
+      - W/"e849f23926ae8ba5412acfd63855f0a3"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -634,9 +705,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "141"
+      - "114"
       X-Request-Id:
-      - 333ed5f2-07fb-4ba1-8826-64fa1ab13490
+      - 778fe204-a077-4572-bc8f-d1575ee8859e
     status: 200 OK
     code: 200
     duration: ""
@@ -648,10 +719,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ju2A8YAw3NDheZRs
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"fHppd2CyqDivddz3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"KcFHQmHm5w3Wuauf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ju2A8YAw3NDheZRs","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -662,13 +741,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2338"
+      - "2336"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:41 GMT
+      - Thu, 25 Feb 2021 17:24:41 GMT
       Etag:
-      - W/"c53e62e1e65e83446346aac6e00b1d89"
+      - W/"6ec34d7ee3d72cb00bdb4851494614f9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -676,9 +755,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "140"
+      - "110"
       X-Request-Id:
-      - 37c03754-cf1a-4eca-802c-fca8404fb1c7
+      - 5e1fc454-76d3-43fb-be34-4c0b1e3bea83
     status: 200 OK
     code: 200
     duration: ""
@@ -690,10 +769,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ju2A8YAw3NDheZRs
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"fHppd2CyqDivddz3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"KcFHQmHm5w3Wuauf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ju2A8YAw3NDheZRs","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -704,13 +791,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2338"
+      - "2336"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:43 GMT
+      - Thu, 25 Feb 2021 17:24:42 GMT
       Etag:
-      - W/"c53e62e1e65e83446346aac6e00b1d89"
+      - W/"6ec34d7ee3d72cb00bdb4851494614f9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -718,9 +805,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "133"
+      - "105"
       X-Request-Id:
-      - 1d23311b-c1af-427f-a9ad-cc352c2bec0d
+      - 4e40c6b4-e4aa-4fe5-83ec-b060de4b5cfa
     status: 200 OK
     code: 200
     duration: ""
@@ -732,10 +819,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_ju2A8YAw3NDheZRs
     method: POST
   response:
-    body: '{"task":{"id":"task_TxW8CLVAm6NGmTax","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_ihEwWNGF1LVNZEiu","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -750,9 +837,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:43 GMT
+      - Thu, 25 Feb 2021 17:24:42 GMT
       Etag:
-      - W/"3085dd27f85679122297b9528f0f2e5f"
+      - W/"57ef1967dfa8b7a52976d0bb196a955f"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -760,9 +847,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "132"
+      - "103"
       X-Request-Id:
-      - 6b148161-9671-42bd-b729-7987e84e6b4f
+      - faeb4adf-bb11-41db-87e6-790f3b3757a4
     status: 200 OK
     code: 200
     duration: ""
@@ -774,10 +861,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/tasks/task_ihEwWNGF1LVNZEiu
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"fHppd2CyqDivddz3","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"}]}}'
+    body: '{"task":{"id":"task_ihEwWNGF1LVNZEiu","name":"Stop virtual machine","status":"running","created_at":1614273882,"started_at":1614273883,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -788,13 +875,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2338"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
+      - Thu, 25 Feb 2021 17:24:43 GMT
       Etag:
-      - W/"e01a80ea32e91ad9a431a1af09effa38"
+      - W/"bb3000ffa2a11978d6b4c96940c08708"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -802,9 +889,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "113"
+      - "98"
       X-Request-Id:
-      - 4c2c1dd1-8f07-4f11-8386-00a443adccc4
+      - b9b9352e-2723-4331-a5c2-0f99ba715c52
     status: 200 OK
     code: 200
     duration: ""
@@ -816,10 +903,60 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/tasks/task_ihEwWNGF1LVNZEiu
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ihEwWNGF1LVNZEiu","name":"Stop virtual machine","status":"completed","created_at":1614273882,"started_at":1614273883,"finished_at":1614273884,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:48 GMT
+      Etag:
+      - W/"f614bd4ccf1153f0ece8d9d8fc523f32"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "86"
+      X-Request-Id:
+      - 17e62fbd-6bb6-4021-bbf6-c24be92c6d0f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ju2A8YAw3NDheZRs
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_bGiPrhIxrDxub9sY","keep_until":1614256605,"object_id":"vm_9hYciEae64bdDmqV","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_9hYciEae64bdDmqV","name":"tf-acc-test-basic-llmj8f8sqgm8","hostname":"tf-acc-test-basic-llmj8f8sqgm8-host","fqdn":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"fHppd2CyqDivddz3","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h7FLNa3jFAOAYWBB","address":"185.53.57.170","reverse_dns":"tf-acc-test-basic-llmj8f8sqgm8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.170/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_9hYciEae64bdDmqV","allocation_type":"VirtualMachine"}]}}'
+    body: '{"trash_object":{"id":"trsh_WA9kdZrTDbt6UHnz","keep_until":1614446688,"object_id":"vm_ju2A8YAw3NDheZRs","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_ju2A8YAw3NDheZRs","name":"tf-acc-test-basic-dh7wkynuvlrw","hostname":"tf-acc-test-basic-dh7wkynuvlrw-host","fqdn":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"KcFHQmHm5w3Wuauf","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_8rby1Nlwx4IsqVQ2","address":"185.53.57.37","reverse_dns":"tf-acc-test-basic-dh7wkynuvlrw-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.37/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ju2A8YAw3NDheZRs","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -830,13 +967,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2473"
+      - "2471"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:46 GMT
+      - Thu, 25 Feb 2021 17:24:49 GMT
       Etag:
-      - W/"388ab84017e62eb03768d77c72bc9297"
+      - W/"7612d3063ab8287a58ac4fdbf30972a8"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -844,9 +981,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "112"
+      - "85"
       X-Request-Id:
-      - 3b7276ba-cd07-4151-adb1-c0e600e05a5d
+      - 2f1127e9-1ea1-435c-906f-6942174ba335
     status: 200 OK
     code: 200
     duration: ""
@@ -858,7 +995,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_h7FLNa3jFAOAYWBB
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_8rby1Nlwx4IsqVQ2
     method: POST
   response:
     body: '{}'
@@ -876,7 +1013,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:47 GMT
+      - Thu, 25 Feb 2021 17:24:49 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -886,9 +1023,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "105"
+      - "82"
       X-Request-Id:
-      - 1793a6fd-64af-45b7-9269-c133142ef4f0
+      - 045e2b0b-a24c-4131-8db2-0ad1c6aa5716
     status: 200 OK
     code: 200
     duration: ""
@@ -900,10 +1037,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_bGiPrhIxrDxub9sY
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_WA9kdZrTDbt6UHnz
     method: DELETE
   response:
-    body: '{"task":{"id":"task_SqNwgo9Tq4fnJ7T3","name":"Purge items from trash","status":"pending","created_at":1614083807,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_A95eXaMhoEsLF6Kz","name":"Purge items from trash","status":"pending","created_at":1614273889,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -918,9 +1055,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:47 GMT
+      - Thu, 25 Feb 2021 17:24:49 GMT
       Etag:
-      - W/"7bbc7d0aa767484aa275a4c8748384e9"
+      - W/"5593e1137f55d6497a5c7c39ef124321"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -928,9 +1065,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "103"
+      - "81"
       X-Request-Id:
-      - 9b6ecbca-7fa9-44a7-b5e4-65d86547b1ff
+      - 12fa4d92-55ae-4642-a502-496a5d30330e
     status: 200 OK
     code: 200
     duration: ""
@@ -942,10 +1079,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_SqNwgo9Tq4fnJ7T3
+    url: https://api.katapult.io/core/v1/tasks/task_A95eXaMhoEsLF6Kz
     method: GET
   response:
-    body: '{"task":{"id":"task_SqNwgo9Tq4fnJ7T3","name":"Purge items from trash","status":"pending","created_at":1614083807,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_A95eXaMhoEsLF6Kz","name":"Purge items from trash","status":"pending","created_at":1614273889,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -960,9 +1097,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:48 GMT
+      - Thu, 25 Feb 2021 17:24:50 GMT
       Etag:
-      - W/"7bbc7d0aa767484aa275a4c8748384e9"
+      - W/"5593e1137f55d6497a5c7c39ef124321"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -970,9 +1107,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "96"
+      - "78"
       X-Request-Id:
-      - 4805b049-4833-44ed-9f97-fe077d45cc58
+      - 1c882db2-1bc4-4ddb-9077-790c373d19d9
     status: 200 OK
     code: 200
     duration: ""
@@ -984,10 +1121,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_SqNwgo9Tq4fnJ7T3
+    url: https://api.katapult.io/core/v1/tasks/task_A95eXaMhoEsLF6Kz
     method: GET
   response:
-    body: '{"task":{"id":"task_SqNwgo9Tq4fnJ7T3","name":"Purge items from trash","status":"pending","created_at":1614083807,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_A95eXaMhoEsLF6Kz","name":"Purge items from trash","status":"pending","created_at":1614273889,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1002,9 +1139,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:53 GMT
+      - Thu, 25 Feb 2021 17:24:55 GMT
       Etag:
-      - W/"7bbc7d0aa767484aa275a4c8748384e9"
+      - W/"5593e1137f55d6497a5c7c39ef124321"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1012,9 +1149,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "77"
+      - "66"
       X-Request-Id:
-      - f443666a-77ba-499b-88c9-1a400fa8fc47
+      - 510bac66-bfa5-4e91-b162-8b6f7f1e401e
     status: 200 OK
     code: 200
     duration: ""
@@ -1026,10 +1163,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_SqNwgo9Tq4fnJ7T3
+    url: https://api.katapult.io/core/v1/tasks/task_A95eXaMhoEsLF6Kz
     method: GET
   response:
-    body: '{"task":{"id":"task_SqNwgo9Tq4fnJ7T3","name":"Purge items from trash","status":"running","created_at":1614083807,"started_at":1614083822,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_A95eXaMhoEsLF6Kz","name":"Purge items from trash","status":"running","created_at":1614273889,"started_at":1614273904,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1044,9 +1181,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:03 GMT
+      - Thu, 25 Feb 2021 17:25:05 GMT
       Etag:
-      - W/"261bb356149e1b5f7360bddb050b9d23"
+      - W/"3ad18ca4fc7b89d725c946cc7457636c"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1054,9 +1191,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "198"
+      - "199"
       X-Request-Id:
-      - 203864fc-f0fa-48c2-8c33-ca141e0a77bb
+      - c233b9e7-9530-4a41-bfe8-e7ab6058d1c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1068,10 +1205,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_SqNwgo9Tq4fnJ7T3
+    url: https://api.katapult.io/core/v1/tasks/task_A95eXaMhoEsLF6Kz
     method: GET
   response:
-    body: '{"task":{"id":"task_SqNwgo9Tq4fnJ7T3","name":"Purge items from trash","status":"completed","created_at":1614083807,"started_at":1614083822,"finished_at":1614083824,"progress":100}}'
+    body: '{"task":{"id":"task_A95eXaMhoEsLF6Kz","name":"Purge items from trash","status":"completed","created_at":1614273889,"started_at":1614273904,"finished_at":1614273906,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1086,9 +1223,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:13 GMT
+      - Thu, 25 Feb 2021 17:25:15 GMT
       Etag:
-      - W/"8db405c8039630068e1fba8709a617ff"
+      - W/"a2be382f1887e2f0cf7c10377732848a"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1096,9 +1233,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "195"
+      - "196"
       X-Request-Id:
-      - 3963b263-baa1-417f-a657-c4373492c1f6
+      - fb70eaa0-3685-4a2a-b0dd-8ef63f6bb0f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1110,7 +1247,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h7FLNa3jFAOAYWBB
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8rby1Nlwx4IsqVQ2
     method: DELETE
   response:
     body: '{}'
@@ -1128,7 +1265,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:13 GMT
+      - Thu, 25 Feb 2021 17:25:15 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1138,9 +1275,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "194"
+      - "195"
       X-Request-Id:
-      - e488aba9-bf57-40b8-b734-c3c489ace24f
+      - 89454d9c-ec43-482b-9350-a83a23bb52ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1152,10 +1289,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_9hYciEae64bdDmqV
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ju2A8YAw3NDheZRs
     method: GET
   response:
-    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1170,7 +1308,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:13 GMT
+      - Thu, 25 Feb 2021 17:25:15 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1180,9 +1318,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "193"
+      - "194"
       X-Request-Id:
-      - 69b1c94f-56d1-497c-bcb7-d6fad82dd324
+      - 3c72e857-15fa-45ed-935a-f326c4fbf1c8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1194,10 +1332,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h7FLNa3jFAOAYWBB
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8rby1Nlwx4IsqVQ2
     method: GET
   response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses were found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1212,7 +1351,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:13 GMT
+      - Thu, 25 Feb 2021 17:25:15 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1222,9 +1361,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "192"
+      - "193"
       X-Request-Id:
-      - c1682247-7ea9-4337-ba5f-66a62525d41b
+      - d2501b3f-7d5b-4320-83c9-f84afb373bdb
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_minimal.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_minimal.cassette.yaml
@@ -12,7 +12,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/available_networks?organization%5Bsub_domain%5D=terraform-acc-test
     method: GET
   response:
-    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
+    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public
+      Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New
+      York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -27,7 +29,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
       - W/"556a80fd56c052ba0c772f9d204cefad"
       Server:
@@ -37,9 +39,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "197"
+      - "198"
       X-Request-Id:
-      - 031383ee-8bc5-4176-8656-b8483eaf1cc4
+      - 96636990-43fe-4116-8709-8983bd6ff872
     status: 200 OK
     code: 200
     duration: ""
@@ -54,7 +56,8 @@ interactions:
     url: https://api.katapult.io/core/v1/data_centers/_?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom"}}}'
+    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -69,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
       - W/"472ac8fb76e85c650214cebfe1011d9e"
       Server:
@@ -81,7 +84,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "193"
       X-Request-Id:
-      - 53aa1342-8b8d-42f6-85d9-03b9bd81949d
+      - 2d59f009-6164-46ef-81c0-b296635f69c0
     status: 200 OK
     code: 200
     duration: ""
@@ -99,7 +102,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"185-53-57-181.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    body: '{"ip_address":{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"185-53-57-113.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -114,9 +119,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"341a9e86a82744df48abedbcdb3dc80d"
+      - W/"0152e81bb7862df093fb5621ca23f96e"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -124,9 +129,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "191"
+      - "188"
       X-Request-Id:
-      - b8a5ede5-19a4-4e96-9fcf-33f4b18ded82
+      - 60730cf4-5578-4db4-883a-10d88c305bde
     status: 200 OK
     code: 200
     duration: ""
@@ -138,10 +143,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fMD5HaEqFFRyQf0I
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_99o00j9dUMJL4mXk
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"185-53-57-181.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"185-53-57-113.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -156,9 +163,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"5f9a772ad802c0d44fd8f7cd06ffd81e"
+      - W/"770ed9f9299aabb439e84872c965138e"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -166,9 +173,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "186"
+      - "184"
       X-Request-Id:
-      - 7280abdb-f98a-454a-a859-40856dacf514
+      - bb534b0e-7c4c-4952-9c73-0058b1c53b86
     status: 200 OK
     code: 200
     duration: ""
@@ -180,10 +187,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fMD5HaEqFFRyQf0I
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_99o00j9dUMJL4mXk
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"185-53-57-181.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"185-53-57-113.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -198,9 +207,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"5f9a772ad802c0d44fd8f7cd06ffd81e"
+      - W/"770ed9f9299aabb439e84872c965138e"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -208,15 +217,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "183"
+      - "180"
       X-Request-Id:
-      - ceec2a89-7a65-4d9b-a456-c71d5824dda7
+      - d70d2a43-37f5-4d49-ba9d-dab9adf10a39
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_fMD5HaEqFFRyQf0I</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-jealous-handsome-skateboard</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_99o00j9dUMJL4mXk</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-purple-silent-albatross</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -228,7 +237,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_U2rQA5EUfcGwlLxo","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_6epAXlhKY8pxPQgv","state":"pending"},"virtual_machine_build":{"id":"vmbuild_6epAXlhKY8pxPQgv","state":"pending"},"hostname":"tf-acc-test-jealous-handsome-skateboard"}'
+    body: '{"task":{"id":"task_KGWFEvTS5ARrq8xW","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_LmFaOq2K5fhIzH9Z","state":"pending"},"virtual_machine_build":{"id":"vmbuild_LmFaOq2K5fhIzH9Z","state":"pending"},"hostname":"tf-acc-test-purple-silent-albatross"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -239,13 +248,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "278"
+      - "274"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:11 GMT
       Etag:
-      - W/"89d4050b8a45fce6fac51f872a894c3b"
+      - W/"6b392efaf7660e55f2199eabc69d9472"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -253,9 +262,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "181"
+      - "176"
       X-Request-Id:
-      - c5274455-2a26-4a05-85d0-3388458d6f4b
+      - ebaae71b-181e-4ef7-99f0-26931f76fdfc
     status: 201 Created
     code: 201
     duration: ""
@@ -267,10 +276,16 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_6epAXlhKY8pxPQgv
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_LmFaOq2K5fhIzH9Z
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_6epAXlhKY8pxPQgv","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.181\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-jealous-handsome-skateboard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_LmFaOq2K5fhIzH9Z","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.113\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-purple-silent-albatross\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -281,13 +296,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1586"
+      - "1355"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:12 GMT
+      - Thu, 25 Feb 2021 17:24:13 GMT
       Etag:
-      - W/"194c69bd1cd80269e50143b3f9b689bd"
+      - W/"6a5f30ccdb8e1e867a95aaf7e246e40b"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -295,9 +310,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "174"
+      - "172"
       X-Request-Id:
-      - 1b6ae54e-b74e-473f-91ae-4f91e537576a
+      - f2c7dadd-319f-4b03-ba66-3749c8938d7d
     status: 200 OK
     code: 200
     duration: ""
@@ -309,10 +324,16 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_6epAXlhKY8pxPQgv
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_LmFaOq2K5fhIzH9Z
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_6epAXlhKY8pxPQgv","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.181\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-jealous-handsome-skateboard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_LmFaOq2K5fhIzH9Z","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.113\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-purple-silent-albatross\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -323,13 +344,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1586"
+      - "1570"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:17 GMT
+      - Thu, 25 Feb 2021 17:24:18 GMT
       Etag:
-      - W/"194c69bd1cd80269e50143b3f9b689bd"
+      - W/"644432074fd4356ea03365b8dded5707"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -337,9 +358,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "170"
+      - "168"
       X-Request-Id:
-      - 243f1c86-cdeb-4acb-9313-f0ca0d9a6de7
+      - 02557979-e8a6-4f97-837b-796fff52781d
     status: 200 OK
     code: 200
     duration: ""
@@ -351,10 +372,16 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_6epAXlhKY8pxPQgv
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_LmFaOq2K5fhIzH9Z
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_6epAXlhKY8pxPQgv","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.181\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-jealous-handsome-skateboard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_LmFaOq2K5fhIzH9Z","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.113\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-purple-silent-albatross\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -365,13 +392,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1586"
+      - "1570"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:27 GMT
+      - Thu, 25 Feb 2021 17:24:28 GMT
       Etag:
-      - W/"194c69bd1cd80269e50143b3f9b689bd"
+      - W/"644432074fd4356ea03365b8dded5707"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -379,9 +406,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "166"
+      - "164"
       X-Request-Id:
-      - 9444e10a-b5b7-407d-af0c-343b34efcd37
+      - 4e85b6ee-4b88-4c8b-aa43-5002cb1aa884
     status: 200 OK
     code: 200
     duration: ""
@@ -393,10 +420,16 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_6epAXlhKY8pxPQgv
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_LmFaOq2K5fhIzH9Z
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_6epAXlhKY8pxPQgv","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.181\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-jealous-handsome-skateboard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_LmFaOq2K5fhIzH9Z","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.113\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-purple-silent-albatross\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -407,13 +440,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "1586"
+      - "1570"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:37 GMT
+      - Thu, 25 Feb 2021 17:24:38 GMT
       Etag:
-      - W/"4ea3351bcfee1941697cd0b841281671"
+      - W/"d3007e13449418a35f8711aaba766bf0"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -421,9 +454,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "162"
+      - "134"
       X-Request-Id:
-      - 572182b2-aa43-4e2e-a21a-017884df8cd6
+      - 25252d36-8adf-406d-923a-c2d2d7128639
     status: 200 OK
     code: 200
     duration: ""
@@ -435,10 +468,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iXB354Imtl2XtP0L
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"DHTKqqFWErF6G6es","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jNgegMYwoFAq0oi3","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273852,"initial_root_password":"idSamkouvRy3zXW3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iXB354Imtl2XtP0L","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -449,13 +489,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2159"
+      - "2143"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:39 GMT
+      - Thu, 25 Feb 2021 17:24:40 GMT
       Etag:
-      - W/"44aa5ad112460c8150abd3927506d412"
+      - W/"4372913fd1534010f8e2bf7b5c863c20"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -463,9 +503,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "156"
+      - "123"
       X-Request-Id:
-      - 84c70fd1-30a5-41d0-941d-3b101f45c893
+      - 2daaf77c-caf6-4432-af8a-50ec72c9fe28
     status: 200 OK
     code: 200
     duration: ""
@@ -477,10 +517,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iXB354Imtl2XtP0L
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"DHTKqqFWErF6G6es","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jNgegMYwoFAq0oi3","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273852,"initial_root_password":"idSamkouvRy3zXW3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iXB354Imtl2XtP0L","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -491,13 +538,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2159"
+      - "2143"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
+      - Thu, 25 Feb 2021 17:24:40 GMT
       Etag:
-      - W/"44aa5ad112460c8150abd3927506d412"
+      - W/"4372913fd1534010f8e2bf7b5c863c20"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -505,9 +552,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "154"
+      - "118"
       X-Request-Id:
-      - d610a36d-bb14-447f-b99a-9df7a3e161fe
+      - 16a5b3fd-722a-47c1-8a1d-7320175f32ed
     status: 200 OK
     code: 200
     duration: ""
@@ -519,10 +566,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iXB354Imtl2XtP0L
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"DHTKqqFWErF6G6es","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jNgegMYwoFAq0oi3","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273852,"initial_root_password":"idSamkouvRy3zXW3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iXB354Imtl2XtP0L","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -533,13 +587,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2159"
+      - "2143"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
+      - Thu, 25 Feb 2021 17:24:40 GMT
       Etag:
-      - W/"44aa5ad112460c8150abd3927506d412"
+      - W/"4372913fd1534010f8e2bf7b5c863c20"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -547,9 +601,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "149"
+      - "115"
       X-Request-Id:
-      - 434eaf71-f69c-41f9-ae2a-14e834e703f9
+      - 4abd91ad-5b07-4f10-9239-dceda8109da3
     status: 200 OK
     code: 200
     duration: ""
@@ -561,10 +615,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fMD5HaEqFFRyQf0I
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_99o00j9dUMJL4mXk
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jNgegMYwoFAq0oi3","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard"}}}'
+    body: '{"ip_address":{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iXB354Imtl2XtP0L","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -575,13 +631,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "740"
+      - "732"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:41 GMT
+      - Thu, 25 Feb 2021 17:24:41 GMT
       Etag:
-      - W/"913889b1ae5ef3d31660c6952b845880"
+      - W/"3e09a7dafe74fc89ec6e69a7b44efca5"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -589,9 +645,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "145"
+      - "111"
       X-Request-Id:
-      - 26ce20ed-7242-4623-9b0d-73d2c30f699f
+      - cfb57e2e-834f-4d8e-98e5-4d9396e1648f
     status: 200 OK
     code: 200
     duration: ""
@@ -603,10 +659,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iXB354Imtl2XtP0L
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"DHTKqqFWErF6G6es","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jNgegMYwoFAq0oi3","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273852,"initial_root_password":"idSamkouvRy3zXW3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iXB354Imtl2XtP0L","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -617,13 +680,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2159"
+      - "2143"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:41 GMT
+      - Thu, 25 Feb 2021 17:24:41 GMT
       Etag:
-      - W/"44aa5ad112460c8150abd3927506d412"
+      - W/"4372913fd1534010f8e2bf7b5c863c20"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -631,9 +694,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "144"
+      - "108"
       X-Request-Id:
-      - a13b4870-c66d-4202-a4fa-d9382b5af12c
+      - 09145949-95e8-4b0d-a920-523e43797404
     status: 200 OK
     code: 200
     duration: ""
@@ -645,10 +708,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iXB354Imtl2XtP0L
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"DHTKqqFWErF6G6es","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jNgegMYwoFAq0oi3","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273852,"initial_root_password":"idSamkouvRy3zXW3","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iXB354Imtl2XtP0L","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -659,13 +729,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2159"
+      - "2143"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:43 GMT
+      - Thu, 25 Feb 2021 17:24:42 GMT
       Etag:
-      - W/"44aa5ad112460c8150abd3927506d412"
+      - W/"4372913fd1534010f8e2bf7b5c863c20"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -673,9 +743,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "137"
+      - "104"
       X-Request-Id:
-      - 6cecce4f-525d-427c-bcf0-31e40fd155b1
+      - 5e663f58-03b4-4c0e-9a84-c6d40837790d
     status: 200 OK
     code: 200
     duration: ""
@@ -687,10 +757,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_iXB354Imtl2XtP0L
     method: POST
   response:
-    body: '{"task":{"id":"task_RObHhtfMI9YeYB5K","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_v5tpR85uGrPWRjMz","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -705,9 +775,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:43 GMT
+      - Thu, 25 Feb 2021 17:24:42 GMT
       Etag:
-      - W/"24099c8cb83bad9b037c2d0e31612e17"
+      - W/"f77f31bda255478f918aceabbd4a286d"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -715,9 +785,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "136"
+      - "102"
       X-Request-Id:
-      - 91d502be-9cfc-485f-a1a5-a4e6b1ac5c57
+      - 840876ee-2342-4db6-8a70-0529ad6623ae
     status: 200 OK
     code: 200
     duration: ""
@@ -729,10 +799,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/tasks/task_v5tpR85uGrPWRjMz
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"DHTKqqFWErF6G6es","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jNgegMYwoFAq0oi3","allocation_type":"VirtualMachine"}]}}'
+    body: '{"task":{"id":"task_v5tpR85uGrPWRjMz","name":"Stop virtual machine","status":"running","created_at":1614273882,"started_at":1614273883,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -743,13 +813,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2159"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
+      - Thu, 25 Feb 2021 17:24:43 GMT
       Etag:
-      - W/"c56e36478c0cf7da986e4e1645746ea0"
+      - W/"ebf61d09fb659c4e3340c550e90aa360"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -757,9 +827,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "115"
+      - "97"
       X-Request-Id:
-      - f7662d71-8f47-46af-9412-994691bd34ba
+      - f4ec2039-97a6-4c54-956a-ef228c7a0230
     status: 200 OK
     code: 200
     duration: ""
@@ -771,10 +841,59 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/tasks/task_v5tpR85uGrPWRjMz
+    method: GET
+  response:
+    body: '{"task":{"id":"task_v5tpR85uGrPWRjMz","name":"Stop virtual machine","status":"completed","created_at":1614273882,"started_at":1614273883,"finished_at":1614273884,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:48 GMT
+      Etag:
+      - W/"f416fcef1d30c19bd03aa984abbdb620"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "84"
+      X-Request-Id:
+      - 5440a59e-53dd-432b-8f44-6120d67d05ec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iXB354Imtl2XtP0L
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_0OV1v4MmALrrpSGR","keep_until":1614256605,"object_id":"vm_jNgegMYwoFAq0oi3","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_jNgegMYwoFAq0oi3","name":"tf-acc-test-jealous-handsome-skateboard","hostname":"tf-acc-test-jealous-handsome-skateboard","fqdn":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"DHTKqqFWErF6G6es","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fMD5HaEqFFRyQf0I","address":"185.53.57.181","reverse_dns":"tf-acc-test-jealous-handsome-skateboard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.181/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jNgegMYwoFAq0oi3","allocation_type":"VirtualMachine"}]}}'
+    body: '{"trash_object":{"id":"trsh_k8bBofYBQt9bf5XX","keep_until":1614446688,"object_id":"vm_iXB354Imtl2XtP0L","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_iXB354Imtl2XtP0L","name":"tf-acc-test-purple-silent-albatross","hostname":"tf-acc-test-purple-silent-albatross","fqdn":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273852,"initial_root_password":"idSamkouvRy3zXW3","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_99o00j9dUMJL4mXk","address":"185.53.57.113","reverse_dns":"tf-acc-test-purple-silent-albatross.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.113/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iXB354Imtl2XtP0L","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -785,13 +904,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2294"
+      - "2278"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:46 GMT
+      - Thu, 25 Feb 2021 17:24:50 GMT
       Etag:
-      - W/"615b7a67b06fc967f2e06bb1556ae6c3"
+      - W/"59a62664155db4b4b1aa3e6885949e55"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -799,9 +918,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "114"
+      - "83"
       X-Request-Id:
-      - b47d1293-7df8-4da0-9732-675057fde18f
+      - 3afaae64-35cf-4b79-a203-ce33a7d9acd2
     status: 200 OK
     code: 200
     duration: ""
@@ -813,7 +932,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_fMD5HaEqFFRyQf0I
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_99o00j9dUMJL4mXk
     method: POST
   response:
     body: '{}'
@@ -831,7 +950,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:47 GMT
+      - Thu, 25 Feb 2021 17:24:50 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -841,9 +960,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "111"
+      - "80"
       X-Request-Id:
-      - 2fa5f50f-a3ad-47f5-b4e0-4ff98131223a
+      - 81a7b600-762b-4237-85cb-0409d51095bb
     status: 200 OK
     code: 200
     duration: ""
@@ -855,10 +974,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0OV1v4MmALrrpSGR
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_k8bBofYBQt9bf5XX
     method: DELETE
   response:
-    body: '{"task":{"id":"task_cwW7PaksZRiotiQ0","name":"Purge items from trash","status":"pending","created_at":1614083807,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_dQEY0g1c0xKsh6vh","name":"Purge items from trash","status":"pending","created_at":1614273890,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -873,9 +992,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:47 GMT
+      - Thu, 25 Feb 2021 17:24:50 GMT
       Etag:
-      - W/"3254016e3bee8def177d0ea41e80f878"
+      - W/"04186b3af1b434dd3060d0f1afe8785c"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -883,9 +1002,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "104"
+      - "79"
       X-Request-Id:
-      - 6a87099d-a5c0-4810-95d7-49982d7b5dfa
+      - ef0805ec-51d5-4b4a-bc76-7ecce733c133
     status: 200 OK
     code: 200
     duration: ""
@@ -897,10 +1016,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_cwW7PaksZRiotiQ0
+    url: https://api.katapult.io/core/v1/tasks/task_dQEY0g1c0xKsh6vh
     method: GET
   response:
-    body: '{"task":{"id":"task_cwW7PaksZRiotiQ0","name":"Purge items from trash","status":"running","created_at":1614083807,"started_at":1614083807,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_dQEY0g1c0xKsh6vh","name":"Purge items from trash","status":"pending","created_at":1614273890,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -911,13 +1030,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "170"
+      - "164"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:48 GMT
+      - Thu, 25 Feb 2021 17:24:51 GMT
       Etag:
-      - W/"1ba3b81fa6ffa59687b0338b97be6efb"
+      - W/"04186b3af1b434dd3060d0f1afe8785c"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -925,9 +1044,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "97"
+      - "73"
       X-Request-Id:
-      - 55696fe3-f198-4250-aafa-1c41a25494bd
+      - eeda8b5c-dda5-4b23-96d5-2345e95f3317
     status: 200 OK
     code: 200
     duration: ""
@@ -939,10 +1058,136 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_cwW7PaksZRiotiQ0
+    url: https://api.katapult.io/core/v1/tasks/task_dQEY0g1c0xKsh6vh
     method: GET
   response:
-    body: '{"task":{"id":"task_cwW7PaksZRiotiQ0","name":"Purge items from trash","status":"completed","created_at":1614083807,"started_at":1614083807,"finished_at":1614083809,"progress":100}}'
+    body: '{"task":{"id":"task_dQEY0g1c0xKsh6vh","name":"Purge items from trash","status":"pending","created_at":1614273890,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:56 GMT
+      Etag:
+      - W/"04186b3af1b434dd3060d0f1afe8785c"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "65"
+      X-Request-Id:
+      - e24bd7bd-3258-44b0-b5b9-d680cd5921d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_dQEY0g1c0xKsh6vh
+    method: GET
+  response:
+    body: '{"task":{"id":"task_dQEY0g1c0xKsh6vh","name":"Purge items from trash","status":"pending","created_at":1614273890,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:25:06 GMT
+      Etag:
+      - W/"04186b3af1b434dd3060d0f1afe8785c"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "198"
+      X-Request-Id:
+      - 3aee8b07-4066-4196-88ff-4a5b6ed6bfc2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_dQEY0g1c0xKsh6vh
+    method: GET
+  response:
+    body: '{"task":{"id":"task_dQEY0g1c0xKsh6vh","name":"Purge items from trash","status":"pending","created_at":1614273890,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:25:16 GMT
+      Etag:
+      - W/"04186b3af1b434dd3060d0f1afe8785c"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "192"
+      X-Request-Id:
+      - 0f4cd104-7131-4ac8-9dee-e417cd14bde1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_dQEY0g1c0xKsh6vh
+    method: GET
+  response:
+    body: '{"task":{"id":"task_dQEY0g1c0xKsh6vh","name":"Purge items from trash","status":"completed","created_at":1614273890,"started_at":1614273920,"finished_at":1614273921,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -957,9 +1202,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:53 GMT
+      - Thu, 25 Feb 2021 17:25:26 GMT
       Etag:
-      - W/"a8a484263ba63b90ed4428cdfaa76726"
+      - W/"42643a0bbb71347ddd7c1dbb356b1dac"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -967,9 +1212,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "79"
+      - "190"
       X-Request-Id:
-      - b623dc0a-01c7-4bd2-8afa-de390f151f2a
+      - d8832c71-c23b-47fa-9111-a4751800971f
     status: 200 OK
     code: 200
     duration: ""
@@ -981,7 +1226,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fMD5HaEqFFRyQf0I
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_99o00j9dUMJL4mXk
     method: DELETE
   response:
     body: '{}'
@@ -999,7 +1244,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:53 GMT
+      - Thu, 25 Feb 2021 17:25:26 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1009,9 +1254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "78"
+      - "189"
       X-Request-Id:
-      - 3da58af1-9e60-4197-a796-c6ec3c8dae43
+      - 4570b891-b881-498e-b465-2c32c75b3b21
     status: 200 OK
     code: 200
     duration: ""
@@ -1023,10 +1268,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jNgegMYwoFAq0oi3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iXB354Imtl2XtP0L
     method: GET
   response:
-    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1041,7 +1287,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:53 GMT
+      - Thu, 25 Feb 2021 17:25:26 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1051,9 +1297,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "76"
+      - "188"
       X-Request-Id:
-      - e878fae4-72f4-41c7-9223-fc225d588b79
+      - 8396906c-0448-4d45-b042-850d728a5ae6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1065,10 +1311,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fMD5HaEqFFRyQf0I
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_99o00j9dUMJL4mXk
     method: GET
   response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses were found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1083,7 +1330,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:53 GMT
+      - Thu, 25 Feb 2021 17:25:26 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1093,9 +1340,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "75"
+      - "187"
       X-Request-Id:
-      - 0c5f0975-4511-4789-b4bd-a7289cfd59fb
+      - 678a4fbc-badf-4669-88df-17677b7719d4
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update.cassette.rand_id
@@ -1,1 +1,1 @@
-i6nwty3ppd0y
+zpuj8higs37z

--- a/internal/provider/testdata/VirtualMachine_update.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update.cassette.yaml
@@ -12,7 +12,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/available_networks?organization%5Bsub_domain%5D=terraform-acc-test
     method: GET
   response:
-    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
+    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public
+      Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New
+      York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -27,7 +29,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
       - W/"556a80fd56c052ba0c772f9d204cefad"
       Server:
@@ -37,9 +39,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "198"
+      - "199"
       X-Request-Id:
-      - a336fea3-a43b-4682-b53c-fcd20cc6cfb9
+      - a2f0f158-58aa-4559-ae70-cc99dd2cda50
     status: 200 OK
     code: 200
     duration: ""
@@ -54,7 +56,8 @@ interactions:
     url: https://api.katapult.io/core/v1/data_centers/_?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom"}}}'
+    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -69,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
       - W/"472ac8fb76e85c650214cebfe1011d9e"
       Server:
@@ -79,9 +82,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "194"
+      - "196"
       X-Request-Id:
-      - cb3f561d-8524-46c8-ac80-072001567386
+      - 44fd7a23-cb5a-4c67-86ca-849faeabddb4
     status: 200 OK
     code: 200
     duration: ""
@@ -99,7 +102,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"185-53-57-123.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    body: '{"ip_address":{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"185-53-57-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -114,9 +119,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"eb2d0a0a7402fd47a38a9fb070a34205"
+      - W/"1e6a5e0bd329d67cc5ea41d3fd0e1838"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -124,9 +129,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "190"
+      - "194"
       X-Request-Id:
-      - 6fe3b248-57a2-443f-b83a-e7c64f40174f
+      - c2365d3c-546e-416d-923b-1ed4511695e1
     status: 200 OK
     code: 200
     duration: ""
@@ -138,10 +143,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JwebzioDv9ssOBwh
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z1WyabOhrawBfZBi
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"185-53-57-123.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"185-53-57-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -156,9 +163,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"52d13c4355a617705b2d9279e79e4604"
+      - W/"ac3fdf98744eaa46f6ce38ee406ae705"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -166,9 +173,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "183"
+      - "186"
       X-Request-Id:
-      - 2c055343-71a9-4d57-964e-238edeeb1118
+      - 8574ddb1-c7e5-45a7-af3f-db8c8d918576
     status: 200 OK
     code: 200
     duration: ""
@@ -180,10 +187,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JwebzioDv9ssOBwh
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z1WyabOhrawBfZBi
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"185-53-57-123.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"185-53-57-195.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -198,9 +207,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"52d13c4355a617705b2d9279e79e4604"
+      - W/"ac3fdf98744eaa46f6ce38ee406ae705"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -208,15 +217,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "180"
+      - "181"
       X-Request-Id:
-      - 223efb25-8443-4e44-a0a7-f2d9f22f59af
+      - c8ba0111-4eaa-43e7-8bc6-b016ff363aa9
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_JwebzioDv9ssOBwh</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-i6nwty3ppd0y-host</Hostname></Hostname><Name>tf-acc-test-update-i6nwty3ppd0y</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_Z1WyabOhrawBfZBi</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-zpuj8higs37z-host</Hostname></Hostname><Name>tf-acc-test-update-zpuj8higs37z</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -228,7 +237,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Gvqsgod0XOwIgQWa","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_miuLb9xQVUcKpPMP","state":"pending"},"virtual_machine_build":{"id":"vmbuild_miuLb9xQVUcKpPMP","state":"pending"},"hostname":"tf-acc-test-update-i6nwty3ppd0y-host"}'
+    body: '{"task":{"id":"task_WKJ8F8GbxiJTYPJb","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_7mDbov0S9lUdCavC","state":"pending"},"virtual_machine_build":{"id":"vmbuild_7mDbov0S9lUdCavC","state":"pending"},"hostname":"tf-acc-test-update-zpuj8higs37z-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -243,9 +252,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"9e1f6ad9190c622ce28dadc8dc699475"
+      - W/"f35f096f513a1d87d6c871e4b40d1e69"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -253,9 +262,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "178"
+      - "177"
       X-Request-Id:
-      - eaa05808-207e-434b-b927-f5cd4bd3e62c
+      - 3a06850f-0325-4c4c-af30-eaf9d925f64d
     status: 201 Created
     code: 201
     duration: ""
@@ -267,10 +276,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_miuLb9xQVUcKpPMP
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_7mDbov0S9lUdCavC
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_miuLb9xQVUcKpPMP","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.123\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-i6nwty3ppd0y-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-i6nwty3ppd0y\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_7mDbov0S9lUdCavC","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-zpuj8higs37z-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-zpuj8higs37z\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -285,9 +301,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:12 GMT
+      - Thu, 25 Feb 2021 17:24:13 GMT
       Etag:
-      - W/"c522c0a28c91db004c4f04958525f69c"
+      - W/"aa1f887cacd1e7a37a74ea564adc6246"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -295,9 +311,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "172"
+      - "174"
       X-Request-Id:
-      - 911c8d82-1af6-4f18-b37e-60a84a0900e7
+      - dcc332fb-e21f-4b9e-81ff-7bfe7733c2a1
     status: 200 OK
     code: 200
     duration: ""
@@ -309,10 +325,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_miuLb9xQVUcKpPMP
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_7mDbov0S9lUdCavC
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_miuLb9xQVUcKpPMP","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.123\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-i6nwty3ppd0y-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-i6nwty3ppd0y\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_7mDbov0S9lUdCavC","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-zpuj8higs37z-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-zpuj8higs37z\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -327,9 +350,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:17 GMT
+      - Thu, 25 Feb 2021 17:24:18 GMT
       Etag:
-      - W/"f5f63bef515a56074ed6e446480f9431"
+      - W/"401503fda7653441b5e2be429497c9f9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -337,9 +360,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "168"
+      - "170"
       X-Request-Id:
-      - 1651084d-5f21-41b1-9e07-2a185e6a1305
+      - eae20583-742c-40bf-87b0-639b10214560
     status: 200 OK
     code: 200
     duration: ""
@@ -351,10 +374,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_miuLb9xQVUcKpPMP
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_7mDbov0S9lUdCavC
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_miuLb9xQVUcKpPMP","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.123\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-i6nwty3ppd0y-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-i6nwty3ppd0y\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_7mDbov0S9lUdCavC","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-zpuj8higs37z-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-zpuj8higs37z\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -369,9 +399,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:27 GMT
+      - Thu, 25 Feb 2021 17:24:28 GMT
       Etag:
-      - W/"f5f63bef515a56074ed6e446480f9431"
+      - W/"401503fda7653441b5e2be429497c9f9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -379,9 +409,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "164"
+      - "166"
       X-Request-Id:
-      - 14659d9e-e18f-49ab-b658-bcbcf0452c36
+      - a8d95b91-c2e3-4902-a8b8-de0749e5c3a4
     status: 200 OK
     code: 200
     duration: ""
@@ -393,10 +423,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_miuLb9xQVUcKpPMP
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_7mDbov0S9lUdCavC
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_miuLb9xQVUcKpPMP","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.123\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-i6nwty3ppd0y-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-i6nwty3ppd0y\u003c/Name\u003e\n  \u003cDescription\u003eA web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614083770}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_7mDbov0S9lUdCavC","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.195\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-zpuj8higs37z-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-zpuj8higs37z\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614273850}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -411,9 +448,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:37 GMT
+      - Thu, 25 Feb 2021 17:24:38 GMT
       Etag:
-      - W/"03bf87c29dc232f9dbd797045b6e4b7f"
+      - W/"950199a18e9749637d6670a380900808"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -421,15 +458,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "160"
+      - "135"
       X-Request-Id:
-      - 7a543007-1760-402b-94d3-0475d9a7d6dd
+      - a00388c5-def3-4ac5-8189-61a2d1801f00
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -441,7 +478,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -456,9 +501,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:38 GMT
+      - Thu, 25 Feb 2021 17:24:38 GMT
       Etag:
-      - W/"27aaccb784aadfa4f2f2798a420efb3f"
+      - W/"00334d77dfa0bdee02c7ae8594ba2ad9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -466,9 +511,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "158"
+      - "132"
       X-Request-Id:
-      - 7d17f30e-b898-49cc-b9f9-f0f5ec25d372
+      - c3f2a51a-3f47-45dc-84be-e676659b7096
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +525,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -498,9 +551,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
+      - Thu, 25 Feb 2021 17:24:40 GMT
       Etag:
-      - W/"27aaccb784aadfa4f2f2798a420efb3f"
+      - W/"00334d77dfa0bdee02c7ae8594ba2ad9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -508,9 +561,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "152"
+      - "121"
       X-Request-Id:
-      - 5ebb3f73-32cf-43fc-96e2-b9c7793bd75e
+      - 46a27d9b-6755-4888-ac2d-3fbc196ee87d
     status: 200 OK
     code: 200
     duration: ""
@@ -522,10 +575,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -540,306 +601,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
+      - Thu, 25 Feb 2021 17:24:40 GMT
       Etag:
-      - W/"27aaccb784aadfa4f2f2798a420efb3f"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "151"
-      X-Request-Id:
-      - cd57a036-87cd-437a-ab35-37bea1f19b91
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2342"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
-      Etag:
-      - W/"27aaccb784aadfa4f2f2798a420efb3f"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "147"
-      X-Request-Id:
-      - 729ab9db-dd5f-4e4b-b5cf-86f9dc66eb51
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JwebzioDv9ssOBwh
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "729"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:41 GMT
-      Etag:
-      - W/"02a7885c08683193c5967b5d09ee4ca6"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "139"
-      X-Request-Id:
-      - a2552bea-ed21-4774-b87b-6f8391175caf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2342"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:41 GMT
-      Etag:
-      - W/"27aaccb784aadfa4f2f2798a420efb3f"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "138"
-      X-Request-Id:
-      - b67f13ba-528c-4628-8e1f-3cb2fb82c06e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JwebzioDv9ssOBwh
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "729"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:43 GMT
-      Etag:
-      - W/"02a7885c08683193c5967b5d09ee4ca6"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "131"
-      X-Request-Id:
-      - 4d34a89d-3423-448f-bdfd-9db5754e94b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y","hostname":"tf-acc-test-update-i6nwty3ppd0y-host","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","description":"A web server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2342"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:43 GMT
-      Etag:
-      - W/"27aaccb784aadfa4f2f2798a420efb3f"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "130"
-      X-Request-Id:
-      - 8179ec21-7b82-48ed-a8f8-978ba6d5c4f9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj"},"properties":{"name":"tf-acc-test-update-i6nwty3ppd0y-diff","hostname":"tf-acc-test-update-i6nwty3ppd0y-host-diff","description":"A app server.","tag_names":["lb","app","web"]}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
-  response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y-diff","hostname":"tf-acc-test-update-i6nwty3ppd0y-host-diff","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","description":"A app server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2457"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
-      Etag:
-      - W/"bfbc4caae7f6aab6bb55850fcebcc6cc"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "125"
-      X-Request-Id:
-      - c523fe59-1235-4476-a072-e991c712d62f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y-diff","hostname":"tf-acc-test-update-i6nwty3ppd0y-host-diff","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","description":"A app server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2457"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
-      Etag:
-      - W/"bfbc4caae7f6aab6bb55850fcebcc6cc"
+      - W/"00334d77dfa0bdee02c7ae8594ba2ad9"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -849,7 +613,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "120"
       X-Request-Id:
-      - 2094ee4c-b222-4f44-91a1-265e405110d2
+      - 06b47604-e73e-460a-a42a-79369df8d9b3
     status: 200 OK
     code: 200
     duration: ""
@@ -861,10 +625,259 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y-diff","hostname":"tf-acc-test-update-i6nwty3ppd0y-host-diff","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","description":"A app server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:40 GMT
+      Etag:
+      - W/"00334d77dfa0bdee02c7ae8594ba2ad9"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "117"
+      X-Request-Id:
+      - a22ff8b7-4758-4c26-922f-c3a39b05c251
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z1WyabOhrawBfZBi
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "729"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:41 GMT
+      Etag:
+      - W/"1716acaa71a75fbdc4a5809307c19555"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "113"
+      X-Request-Id:
+      - 712bd885-953d-4699-97e5-3585f27c9be2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:41 GMT
+      Etag:
+      - W/"00334d77dfa0bdee02c7ae8594ba2ad9"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "110"
+      X-Request-Id:
+      - 65d00213-c38b-40f2-ad88-442aca5ded74
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z1WyabOhrawBfZBi
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "729"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:42 GMT
+      Etag:
+      - W/"1716acaa71a75fbdc4a5809307c19555"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "107"
+      X-Request-Id:
+      - 97ef3c7c-6007-48df-bc18-76895de5a69e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z","hostname":"tf-acc-test-update-zpuj8higs37z-host","fqdn":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:42 GMT
+      Etag:
+      - W/"00334d77dfa0bdee02c7ae8594ba2ad9"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "106"
+      X-Request-Id:
+      - b9f6b81c-3ff8-4d4d-bd81-50534e0d01fb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s"},"properties":{"name":"tf-acc-test-update-zpuj8higs37z-diff","hostname":"tf-acc-test-update-zpuj8higs37z-host-diff","description":"A app server.","tag_names":["lb","app","web"]}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
+  response:
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z-diff","hostname":"tf-acc-test-update-zpuj8higs37z-host-diff","fqdn":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -879,9 +892,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
+      - Thu, 25 Feb 2021 17:24:43 GMT
       Etag:
-      - W/"bfbc4caae7f6aab6bb55850fcebcc6cc"
+      - W/"eb3dbedc86a763fe30ff13e62476621f"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -889,9 +902,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "117"
+      - "101"
       X-Request-Id:
-      - 023e54c5-f349-40ca-8946-b27d3e09e74f
+      - 902a9116-98f3-4eb4-a746-2731ac105c06
     status: 200 OK
     code: 200
     duration: ""
@@ -903,10 +916,112 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JwebzioDv9ssOBwh
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y-diff"}}}'
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z-diff","hostname":"tf-acc-test-update-zpuj8higs37z-host-diff","fqdn":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2457"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:43 GMT
+      Etag:
+      - W/"eb3dbedc86a763fe30ff13e62476621f"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "100"
+      X-Request-Id:
+      - 9400661f-118a-49e1-995d-2bc08f1637e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z-diff","hostname":"tf-acc-test-update-zpuj8higs37z-host-diff","fqdn":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2457"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:43 GMT
+      Etag:
+      - W/"eb3dbedc86a763fe30ff13e62476621f"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "99"
+      X-Request-Id:
+      - f784d848-f26f-496f-8fa7-2ef8d5086f6c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z1WyabOhrawBfZBi
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z-diff"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -921,9 +1036,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:46 GMT
+      - Thu, 25 Feb 2021 17:24:43 GMT
       Etag:
-      - W/"d92b8c5ecfcee1ffc02cc3153643b129"
+      - W/"61d066bc9d8f0cd0f02bb7c84d3be47f"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -931,9 +1046,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "110"
+      - "96"
       X-Request-Id:
-      - d2c4a303-5122-414b-85aa-f867ad41a720
+      - f91818af-2104-42e2-86b8-bd6ff7db22d1
     status: 200 OK
     code: 200
     duration: ""
@@ -945,10 +1060,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y-diff","hostname":"tf-acc-test-update-i6nwty3ppd0y-host-diff","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","description":"A app server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z-diff","hostname":"tf-acc-test-update-zpuj8higs37z-host-diff","fqdn":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -963,9 +1086,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:46 GMT
+      - Thu, 25 Feb 2021 17:24:43 GMT
       Etag:
-      - W/"bfbc4caae7f6aab6bb55850fcebcc6cc"
+      - W/"eb3dbedc86a763fe30ff13e62476621f"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -973,9 +1096,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "109"
+      - "95"
       X-Request-Id:
-      - 1fd00c07-b08b-49ee-a0a0-1cd2d75561b5
+      - 18aaac94-f9e3-4186-bccc-de30ccb0961d
     status: 200 OK
     code: 200
     duration: ""
@@ -987,10 +1110,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y-diff","hostname":"tf-acc-test-update-i6nwty3ppd0y-host-diff","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","description":"A app server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z-diff","hostname":"tf-acc-test-update-zpuj8higs37z-host-diff","fqdn":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1005,9 +1136,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:47 GMT
+      - Thu, 25 Feb 2021 17:24:44 GMT
       Etag:
-      - W/"bfbc4caae7f6aab6bb55850fcebcc6cc"
+      - W/"eb3dbedc86a763fe30ff13e62476621f"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1015,9 +1146,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "102"
+      - "94"
       X-Request-Id:
-      - 11e6af69-c85a-4053-a7e5-608db3bfb54f
+      - 34ceb012-1292-40e8-9eca-d602236ef768
     status: 200 OK
     code: 200
     duration: ""
@@ -1029,10 +1160,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: POST
   response:
-    body: '{"task":{"id":"task_XOKhiOr14HVYOJlP","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_xDeCBGphVFjrgqao","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1047,9 +1178,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:47 GMT
+      - Thu, 25 Feb 2021 17:24:44 GMT
       Etag:
-      - W/"007879f17aa77e0e65b4ffc5946a48bd"
+      - W/"278fca79c02ea2103e534dfd7a9d555d"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1057,9 +1188,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "101"
+      - "93"
       X-Request-Id:
-      - 044a31c9-c828-42cf-94b1-cbf61c2b3afb
+      - 1347df7e-a4d4-4668-bca9-f80c5dbdde11
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,10 +1202,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/tasks/task_xDeCBGphVFjrgqao
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y-diff","hostname":"tf-acc-test-update-i6nwty3ppd0y-host-diff","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","description":"A app server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"task":{"id":"task_xDeCBGphVFjrgqao","name":"Stop virtual machine","status":"running","created_at":1614273884,"started_at":1614273885,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1085,13 +1216,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2457"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:49 GMT
+      - Thu, 25 Feb 2021 17:24:45 GMT
       Etag:
-      - W/"259dc2e3d8dd13b7c1300a5e44106f17"
+      - W/"7b638261c35f3439aca4a3d28b095169"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1099,9 +1230,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "90"
+      - "92"
       X-Request-Id:
-      - 6bd0d209-c441-4070-8815-2e1737c8e8d5
+      - bc7141ae-8cf1-4ac9-a308-bb274f57677c
     status: 200 OK
     code: 200
     duration: ""
@@ -1113,10 +1244,60 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/tasks/task_xDeCBGphVFjrgqao
+    method: GET
+  response:
+    body: '{"task":{"id":"task_xDeCBGphVFjrgqao","name":"Stop virtual machine","status":"completed","created_at":1614273884,"started_at":1614273885,"finished_at":1614273886,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:50 GMT
+      Etag:
+      - W/"af17106cc548eb9cc823bbc4465a3fd6"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "77"
+      X-Request-Id:
+      - f2883b40-354a-4e08-b14b-6f3d0dacb250
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_zHF3qoqQ0VyNdwdP","keep_until":1614256609,"object_id":"vm_wJ3AsedPKJzvk6Jj","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_wJ3AsedPKJzvk6Jj","name":"tf-acc-test-update-i6nwty3ppd0y-diff","hostname":"tf-acc-test-update-i6nwty3ppd0y-host-diff","fqdn":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","description":"A app server.","created_at":1614083771,"initial_root_password":"B5VOVC13u0hRTMT9","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_JwebzioDv9ssOBwh","address":"185.53.57.123","reverse_dns":"tf-acc-test-update-i6nwty3ppd0y-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.123/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wJ3AsedPKJzvk6Jj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"trash_object":{"id":"trsh_TN3YcDcD0q3HKssA","keep_until":1614446690,"object_id":"vm_etdw8jMhbW4qLb5s","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_etdw8jMhbW4qLb5s","name":"tf-acc-test-update-zpuj8higs37z-diff","hostname":"tf-acc-test-update-zpuj8higs37z-host-diff","fqdn":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1614273851,"initial_root_password":"m8x0CwoMTtI6eadn","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_Z1WyabOhrawBfZBi","address":"185.53.57.195","reverse_dns":"tf-acc-test-update-zpuj8higs37z-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.195/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_etdw8jMhbW4qLb5s","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1131,9 +1312,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:50 GMT
+      - Thu, 25 Feb 2021 17:24:51 GMT
       Etag:
-      - W/"0602e3f777286517ca50516ee9269be8"
+      - W/"5f8222e11b2d8abae1e234e598282da6"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1141,9 +1322,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "89"
+      - "76"
       X-Request-Id:
-      - b28bc2e4-7fe5-4ccf-aab7-bcc32248b341
+      - 2451bac2-c0d1-4dca-917d-1e14ad5e3581
     status: 200 OK
     code: 200
     duration: ""
@@ -1155,7 +1336,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_JwebzioDv9ssOBwh
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Z1WyabOhrawBfZBi
     method: POST
   response:
     body: '{}'
@@ -1173,7 +1354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:50 GMT
+      - Thu, 25 Feb 2021 17:24:51 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1183,9 +1364,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "85"
+      - "75"
       X-Request-Id:
-      - 1f7c9732-6c40-4596-b1a6-e7a55daf8540
+      - 0c057134-c7a4-4330-82ff-ed52790642fb
     status: 200 OK
     code: 200
     duration: ""
@@ -1197,10 +1378,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_zHF3qoqQ0VyNdwdP
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_TN3YcDcD0q3HKssA
     method: DELETE
   response:
-    body: '{"task":{"id":"task_dxYZjubtH7lsUQPx","name":"Purge items from trash","status":"pending","created_at":1614083810,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_UtCNiMGUKhjMOfpG","name":"Purge items from trash","status":"pending","created_at":1614273891,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1215,9 +1396,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:50 GMT
+      - Thu, 25 Feb 2021 17:24:51 GMT
       Etag:
-      - W/"ca9f91ef60326b9d64cc87e4473f69c2"
+      - W/"96d99f6b386afea7940eecf17d864c17"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1225,9 +1406,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "84"
+      - "74"
       X-Request-Id:
-      - e8e2161d-78ff-4275-943f-2e8a59999b2f
+      - f80813b6-6729-4ac0-8a50-c08b3bcd9fc3
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,10 +1420,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_dxYZjubtH7lsUQPx
+    url: https://api.katapult.io/core/v1/tasks/task_UtCNiMGUKhjMOfpG
     method: GET
   response:
-    body: '{"task":{"id":"task_dxYZjubtH7lsUQPx","name":"Purge items from trash","status":"pending","created_at":1614083810,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_UtCNiMGUKhjMOfpG","name":"Purge items from trash","status":"pending","created_at":1614273891,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1257,9 +1438,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:51 GMT
+      - Thu, 25 Feb 2021 17:24:52 GMT
       Etag:
-      - W/"ca9f91ef60326b9d64cc87e4473f69c2"
+      - W/"96d99f6b386afea7940eecf17d864c17"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1267,9 +1448,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "80"
+      - "72"
       X-Request-Id:
-      - a25ef448-fbe9-4dc8-81b0-c57db550b7bc
+      - 923dcd17-a41a-45c4-8c4c-450443964984
     status: 200 OK
     code: 200
     duration: ""
@@ -1281,10 +1462,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_dxYZjubtH7lsUQPx
+    url: https://api.katapult.io/core/v1/tasks/task_UtCNiMGUKhjMOfpG
     method: GET
   response:
-    body: '{"task":{"id":"task_dxYZjubtH7lsUQPx","name":"Purge items from trash","status":"pending","created_at":1614083810,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_UtCNiMGUKhjMOfpG","name":"Purge items from trash","status":"pending","created_at":1614273891,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1299,9 +1480,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:56 GMT
+      - Thu, 25 Feb 2021 17:24:57 GMT
       Etag:
-      - W/"ca9f91ef60326b9d64cc87e4473f69c2"
+      - W/"96d99f6b386afea7940eecf17d864c17"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1309,9 +1490,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "69"
+      - "64"
       X-Request-Id:
-      - 5e71c2be-69ae-41d6-949c-55afa682fba4
+      - 9fe80550-742b-4979-8d89-b43ab1cd2c8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1323,10 +1504,136 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_dxYZjubtH7lsUQPx
+    url: https://api.katapult.io/core/v1/tasks/task_UtCNiMGUKhjMOfpG
     method: GET
   response:
-    body: '{"task":{"id":"task_dxYZjubtH7lsUQPx","name":"Purge items from trash","status":"running","created_at":1614083810,"started_at":1614083825,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_UtCNiMGUKhjMOfpG","name":"Purge items from trash","status":"pending","created_at":1614273891,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:25:07 GMT
+      Etag:
+      - W/"96d99f6b386afea7940eecf17d864c17"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "197"
+      X-Request-Id:
+      - 04452775-4000-4390-8c14-1abc71dd80b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_UtCNiMGUKhjMOfpG
+    method: GET
+  response:
+    body: '{"task":{"id":"task_UtCNiMGUKhjMOfpG","name":"Purge items from trash","status":"pending","created_at":1614273891,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:25:17 GMT
+      Etag:
+      - W/"96d99f6b386afea7940eecf17d864c17"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "191"
+      X-Request-Id:
+      - 64e28c61-cb4d-46a7-84b6-0c3b0ee9da31
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_UtCNiMGUKhjMOfpG
+    method: GET
+  response:
+    body: '{"task":{"id":"task_UtCNiMGUKhjMOfpG","name":"Purge items from trash","status":"pending","created_at":1614273891,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:25:27 GMT
+      Etag:
+      - W/"96d99f6b386afea7940eecf17d864c17"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "186"
+      X-Request-Id:
+      - 48a26959-07ee-4991-bed3-88099fdf3740
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_UtCNiMGUKhjMOfpG
+    method: GET
+  response:
+    body: '{"task":{"id":"task_UtCNiMGUKhjMOfpG","name":"Purge items from trash","status":"running","created_at":1614273891,"started_at":1614273936,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1341,9 +1648,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:06 GMT
+      - Thu, 25 Feb 2021 17:25:37 GMT
       Etag:
-      - W/"91e15a1c2e144d7e169ca09424a6daec"
+      - W/"467abfeebed1f376bb68345ecba598bd"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1351,9 +1658,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "197"
+      - "185"
       X-Request-Id:
-      - 3a4fba91-c1f3-4a0a-a163-2b31b29912b9
+      - aabc2e06-9ce5-4e82-a10c-ffbb3c2b9a3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1365,10 +1672,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_dxYZjubtH7lsUQPx
+    url: https://api.katapult.io/core/v1/tasks/task_UtCNiMGUKhjMOfpG
     method: GET
   response:
-    body: '{"task":{"id":"task_dxYZjubtH7lsUQPx","name":"Purge items from trash","status":"completed","created_at":1614083810,"started_at":1614083825,"finished_at":1614083827,"progress":100}}'
+    body: '{"task":{"id":"task_UtCNiMGUKhjMOfpG","name":"Purge items from trash","status":"completed","created_at":1614273891,"started_at":1614273936,"finished_at":1614273937,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1383,9 +1690,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:16 GMT
+      - Thu, 25 Feb 2021 17:25:47 GMT
       Etag:
-      - W/"adffb88dc347aa696c69046a8eaa3d2d"
+      - W/"d7985ae3f817cd6624d992a93f0208a6"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1393,9 +1700,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "191"
+      - "184"
       X-Request-Id:
-      - cd573a28-2a19-42c1-b5b5-c26f79a4991e
+      - 3349fa60-893d-401d-8487-d6f6275139ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1407,7 +1714,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JwebzioDv9ssOBwh
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z1WyabOhrawBfZBi
     method: DELETE
   response:
     body: '{}'
@@ -1425,7 +1732,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:16 GMT
+      - Thu, 25 Feb 2021 17:25:48 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1435,9 +1742,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "190"
+      - "183"
       X-Request-Id:
-      - 09007187-b053-49c2-a0f7-5d8f3cb0804f
+      - fb967553-1e06-4f2f-a3b5-93fe71472f92
     status: 200 OK
     code: 200
     duration: ""
@@ -1449,10 +1756,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wJ3AsedPKJzvk6Jj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_etdw8jMhbW4qLb5s
     method: GET
   response:
-    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1467,7 +1775,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:16 GMT
+      - Thu, 25 Feb 2021 17:25:48 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1477,9 +1785,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "189"
+      - "182"
       X-Request-Id:
-      - 49e6a93c-4dae-4128-9143-02783ef77a59
+      - d2e2cd78-112b-438a-b827-29b6788e3659
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1491,10 +1799,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_JwebzioDv9ssOBwh
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z1WyabOhrawBfZBi
     method: GET
   response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses were found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1509,7 +1818,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:16 GMT
+      - Thu, 25 Feb 2021 17:25:48 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1519,9 +1828,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "188"
+      - "181"
       X-Request-Id:
-      - e00b9c96-0978-4c8c-9405-e29cf7ddd619
+      - fdeacef4-6c8e-467d-9a55-d8ea8bd97212
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_ips.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_ips.cassette.yaml
@@ -12,7 +12,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/available_networks?organization%5Bsub_domain%5D=terraform-acc-test
     method: GET
   response:
-    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
+    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public
+      Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New
+      York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -27,7 +29,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
       - W/"556a80fd56c052ba0c772f9d204cefad"
       Server:
@@ -37,9 +39,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "199"
+      - "196"
       X-Request-Id:
-      - e55f1bf9-3d23-48a4-994d-d47da7d6fa3d
+      - b0d6d9cf-0dbc-4e70-9693-b829236a0260
     status: 200 OK
     code: 200
     duration: ""
@@ -54,7 +56,8 @@ interactions:
     url: https://api.katapult.io/core/v1/data_centers/_?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom"}}}'
+    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -69,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
       - W/"472ac8fb76e85c650214cebfe1011d9e"
       Server:
@@ -79,9 +82,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "195"
+      - "193"
       X-Request-Id:
-      - 0e483d0f-f649-40ca-aeb7-34b840ec01ff
+      - 5ce5ae0f-fe02-46b6-b986-f47a4e97f218
     status: 200 OK
     code: 200
     duration: ""
@@ -99,727 +102,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"185-53-57-143.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "546"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
-      Etag:
-      - W/"ffbe9d965b9e07c2a69018f465dafc4c"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "192"
-      X-Request-Id:
-      - d68519a0-738f-4553-bfdf-d7ac380a6dd3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"185-53-57-143.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "564"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
-      Etag:
-      - W/"62258c6f41b413b682eecaa340789c8d"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "187"
-      X-Request-Id:
-      - 44e29c81-d067-482f-b20a-2a9b660f7e11
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"185-53-57-143.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "564"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
-      Etag:
-      - W/"62258c6f41b413b682eecaa340789c8d"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "185"
-      X-Request-Id:
-      - 2f276b2d-fd60-409a-9dd6-2b5aa9e89e70
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_bpYP90F18aLIqc6x</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-nervous-clean-mango</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
-    method: POST
-  response:
-    body: '{"task":{"id":"task_Sc7i8dvCmAcG9oIW","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_glixuUuuco3QA4V4","state":"pending"},"virtual_machine_build":{"id":"vmbuild_glixuUuuco3QA4V4","state":"pending"},"hostname":"tf-acc-test-nervous-clean-mango"}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "270"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:10 GMT
-      Etag:
-      - W/"50ecdf098dbfeadff536ce2a082a153c"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "184"
-      X-Request-Id:
-      - 82be385b-3f92-4c88-b21e-cd463dfa67c3
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_glixuUuuco3QA4V4
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_glixuUuuco3QA4V4","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.143\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-nervous-clean-mango\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1614083770}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1351"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:12 GMT
-      Etag:
-      - W/"0853e20eda816ba184def557bf3b96b8"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "175"
-      X-Request-Id:
-      - 6976dfb4-a0ff-4783-8e3a-b7f25479a538
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_glixuUuuco3QA4V4
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_glixuUuuco3QA4V4","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.143\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-nervous-clean-mango\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1554"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:17 GMT
-      Etag:
-      - W/"339c6a273a6409e9489463a6a5b72cc6"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "171"
-      X-Request-Id:
-      - 01c65a94-7fda-4999-a1c7-49a6c87d12f8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_glixuUuuco3QA4V4
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_glixuUuuco3QA4V4","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.143\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-nervous-clean-mango\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614083770}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1554"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:27 GMT
-      Etag:
-      - W/"339c6a273a6409e9489463a6a5b72cc6"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "167"
-      X-Request-Id:
-      - d44efb1d-860e-4daf-aca8-747f3be980d0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_glixuUuuco3QA4V4
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_glixuUuuco3QA4V4","spec_xml":"\u003c?xml version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.143\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-nervous-clean-mango\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1614083770}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1554"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:37 GMT
-      Etag:
-      - W/"b09e9004f9f913a3c4962eaf58d354b2"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "163"
-      X-Request-Id:
-      - bf172f83-d337-4be6-86c7-f25118c04e49
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2127"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:39 GMT
-      Etag:
-      - W/"66ae796b05d299f84475b4a07cf62c9a"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "157"
-      X-Request-Id:
-      - 0d4a05aa-c6b5-4df2-ae17-52e7261f15eb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2127"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:39 GMT
-      Etag:
-      - W/"66ae796b05d299f84475b4a07cf62c9a"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "155"
-      X-Request-Id:
-      - ee8b903f-757e-49d5-8331-369cb5327597
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2127"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:40 GMT
-      Etag:
-      - W/"66ae796b05d299f84475b4a07cf62c9a"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "148"
-      X-Request-Id:
-      - abfedcb2-6d12-4323-8534-8f75523f3c1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "724"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:41 GMT
-      Etag:
-      - W/"792c87cbeff741877a926119b3a5c786"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "143"
-      X-Request-Id:
-      - 9d189a2d-2df2-475c-ac5e-365cc633e471
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2127"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:41 GMT
-      Etag:
-      - W/"66ae796b05d299f84475b4a07cf62c9a"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "142"
-      X-Request-Id:
-      - 8f8f7eda-e375-4a72-9eee-486afc196a78
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "724"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:43 GMT
-      Etag:
-      - W/"792c87cbeff741877a926119b3a5c786"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "135"
-      X-Request-Id:
-      - 7e50102d-3aa9-465b-89c4-8573b83f88e4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2127"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:43 GMT
-      Etag:
-      - W/"66ae796b05d299f84475b4a07cf62c9a"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "134"
-      X-Request-Id:
-      - 7500d656-9d78-45c5-95d1-c86196af0625
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/available_networks?organization%5Bsub_domain%5D=terraform-acc-test
-    method: GET
-  response:
-    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:44 GMT
-      Etag:
-      - W/"556a80fd56c052ba0c772f9d204cefad"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "129"
-      X-Request-Id:
-      - 5c06618c-57d0-4d08-901d-893104210842
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/data_centers/_?data_center%5Bpermalink%5D=uk-lon-01
-    method: GET
-  response:
-    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "150"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:44 GMT
-      Etag:
-      - W/"472ac8fb76e85c650214cebfe1011d9e"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "128"
-      X-Request-Id:
-      - 04e33eca-8bc3-4ab2-bc99-0903188c162f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
-    method: POST
-  response:
-    body: '{"ip_address":{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"185-53-57-88.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    body: '{"ip_address":{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"185-53-57-76.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -834,9 +119,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:44 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"a7dd3097be7f9d43050b8532f3976cc0"
+      - W/"7d28e19c5e6372344bb7faad560e866e"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -844,9 +129,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "127"
+      - "190"
       X-Request-Id:
-      - 1fddf7ea-cf53-4d45-9cde-3d28061693c5
+      - 4cfe5673-255c-4584-b3ef-22a67b74428a
     status: 200 OK
     code: 200
     duration: ""
@@ -858,10 +143,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_0OIccaeAY2GoueKH
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"185-53-57-88.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"185-53-57-76.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -876,9 +163,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:44 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"1f49734af5dcd00b75d9aec217dce891"
+      - W/"a9601770d5108e02231dca43d8026ad7"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -886,9 +173,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "126"
+      - "187"
       X-Request-Id:
-      - e133afd7-130d-41bc-a3e9-282bf1dbba90
+      - 396ef046-82b3-4c57-b4c0-92ea4ba18242
     status: 200 OK
     code: 200
     duration: ""
@@ -900,52 +187,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2127"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:44 GMT
-      Etag:
-      - W/"66ae796b05d299f84475b4a07cf62c9a"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "124"
-      X-Request-Id:
-      - cdcb49f4-ac6b-4088-85b5-e1f075672d88
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_0OIccaeAY2GoueKH
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"185-53-57-88.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"ip_address":{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"185-53-57-76.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -960,9 +207,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:44 GMT
+      - Thu, 25 Feb 2021 17:24:10 GMT
       Etag:
-      - W/"1f49734af5dcd00b75d9aec217dce891"
+      - W/"a9601770d5108e02231dca43d8026ad7"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -970,57 +217,852 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "123"
+      - "183"
       X-Request-Id:
-      - 658a0189-6170-4df8-a074-bd4b4cbd3a4d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_HgCLwaTwp1jBUtzk","name":"Public Network on tf-acc-test-nervous-clean-mango","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network"},"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "358"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:44 GMT
-      Etag:
-      - W/"f71a89c8f93a3be300d9cb7420602944"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "122"
-      X-Request-Id:
-      - fd60089b-2bd8-42d4-ac87-0368e64c5e46
+      - 3f2ce1e4-d70b-4335-9a5e-cec4fad3ebde
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_HgCLwaTwp1jBUtzk"},"ip_address":{"id":"ip_0OIccaeAY2GoueKH"}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_fwiJuIDXpvrZoi2X</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-magnificent-purple-potato</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
+    method: POST
+  response:
+    body: '{"task":{"id":"task_Q7cGHPDVQRkkXGEi","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_x0PQrggFevheRkdv","state":"pending"},"virtual_machine_build":{"id":"vmbuild_x0PQrggFevheRkdv","state":"pending"},"hostname":"tf-acc-test-magnificent-purple-potato"}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "276"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:10 GMT
+      Etag:
+      - W/"b8a291b4bd91ef79f04eb03050512d51"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "179"
+      X-Request-Id:
+      - ed528115-e19f-46f5-9b2f-d19dcc61a7c8
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_x0PQrggFevheRkdv
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_x0PQrggFevheRkdv","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.76\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-magnificent-purple-potato\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273850}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "1577"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:12 GMT
+      Etag:
+      - W/"7d410a647d875e0faa651c7182cc8135"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "175"
+      X-Request-Id:
+      - c9c83221-41e2-41fd-862e-30eefc500423
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_x0PQrggFevheRkdv
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_x0PQrggFevheRkdv","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.76\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-magnificent-purple-potato\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1614273850}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "1577"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:17 GMT
+      Etag:
+      - W/"7d410a647d875e0faa651c7182cc8135"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "171"
+      X-Request-Id:
+      - e4225b55-e7cd-4bf7-80b2-e6afe91e7b04
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/vmbuild_x0PQrggFevheRkdv
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_x0PQrggFevheRkdv","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.76\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-magnificent-purple-potato\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1614273850}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "1578"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:27 GMT
+      Etag:
+      - W/"466634eed8392abc90bd689cdd88a57b"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "167"
+      X-Request-Id:
+      - 04cf42f7-b93e-4465-88d9-409f48c38263
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2149"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:30 GMT
+      Etag:
+      - W/"9915c74b613adc12486c33849b899c38"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "163"
+      X-Request-Id:
+      - 820f338d-b54b-45bc-8a7a-05548de1be8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2149"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:30 GMT
+      Etag:
+      - W/"9915c74b613adc12486c33849b899c38"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "162"
+      X-Request-Id:
+      - 8961117f-7b73-4bf3-aeab-646a64099e56
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2149"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:30 GMT
+      Etag:
+      - W/"9915c74b613adc12486c33849b899c38"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "161"
+      X-Request-Id:
+      - 2c1abae7-b961-42a6-acde-acd597cda941
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "734"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:30 GMT
+      Etag:
+      - W/"9ce843e765141a3323173051d092b25c"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "160"
+      X-Request-Id:
+      - f31dc8d1-5018-4162-821b-7886cdf83f36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2149"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:30 GMT
+      Etag:
+      - W/"9915c74b613adc12486c33849b899c38"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "159"
+      X-Request-Id:
+      - cacc07d6-d04e-48d1-974d-0d7d3d535f7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "734"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:31 GMT
+      Etag:
+      - W/"9ce843e765141a3323173051d092b25c"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "158"
+      X-Request-Id:
+      - b08c66f8-dff4-4281-b4cb-2e8ab2c37287
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2149"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:31 GMT
+      Etag:
+      - W/"9915c74b613adc12486c33849b899c38"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "157"
+      X-Request-Id:
+      - eff1a797-3265-4744-b5a0-8417cf552e98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/available_networks?organization%5Bsub_domain%5D=terraform-acc-test
+    method: GET
+  response:
+    body: '{"networks":[{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}},{"id":"netw_q0lBvtutvOjujgyO","name":"Public
+      Network - NYC","permalink":"us-nyc-01","data_center":{"id":"dc_TfDSMyVYoS3fJnSt","name":"New
+      York","permalink":"us-nyc-01"}}],"virtual_networks":[]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:32 GMT
+      Etag:
+      - W/"556a80fd56c052ba0c772f9d204cefad"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "156"
+      X-Request-Id:
+      - 7533f098-0453-4814-990d-1fcedcf79080
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/data_centers/_?data_center%5Bpermalink%5D=uk-lon-01
+    method: GET
+  response:
+    body: '{"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "150"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:32 GMT
+      Etag:
+      - W/"472ac8fb76e85c650214cebfe1011d9e"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "155"
+      X-Request-Id:
+      - 00245dae-a764-401f-bada-087fabbbde7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"185-53-57-198.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "546"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:32 GMT
+      Etag:
+      - W/"ed7f0b111c93f3766dfdbd41d1b76347"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "154"
+      X-Request-Id:
+      - 452e7e9f-4979-4296-b261-d2c340fc8cf6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_66POcm9rz1ndXSjy
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"185-53-57-198.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:32 GMT
+      Etag:
+      - W/"20c89643675823790ba81535a4c5e067"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "153"
+      X-Request-Id:
+      - 9e613c17-8cd5-485d-a084-cee729b1f6ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2149"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:32 GMT
+      Etag:
+      - W/"9915c74b613adc12486c33849b899c38"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "152"
+      X-Request-Id:
+      - c395e723-8e51-47ae-bbbc-0b4be8259d5a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_66POcm9rz1ndXSjy
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"185-53-57-198.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:32 GMT
+      Etag:
+      - W/"20c89643675823790ba81535a4c5e067"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "151"
+      X-Request-Id:
+      - f084bb23-abf1-4b9e-aed8-cfeea6827ef8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_scCYfiJKdMvZloQz","name":"Public
+      Network on tf-acc-test-magnificent-purple-potato","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "363"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:32 GMT
+      Etag:
+      - W/"0340299827f2ffa0e386928100b6fa9a"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "150"
+      X-Request-Id:
+      - 267ca912-d6d5-45c0-968e-8b964c2b8156
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine_network_interface":{"id":"vmnet_scCYfiJKdMvZloQz"},"ip_address":{"id":"ip_66POcm9rz1ndXSjy"}}
     form: {}
     headers:
       Accept:
@@ -1032,7 +1074,9 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/allocate_ip
     method: POST
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_HgCLwaTwp1jBUtzk","virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango"},"name":"Public Network on tf-acc-test-nervous-clean-mango","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network"},"mac_address":"3a:27:81:6f:34:1d","state":"attached","ip_addresses":[{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88"},{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_scCYfiJKdMvZloQz","virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato"},"name":"Public
+      Network on tf-acc-test-magnificent-purple-potato","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ee:8d:20:7c:92","state":"attached","ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76"},{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1043,13 +1087,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "460"
+      - "472"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
+      - Thu, 25 Feb 2021 17:24:33 GMT
       Etag:
-      - W/"edc3da6a19be275227520b4a3a1d8384"
+      - W/"1d605d7d0a71903efc77e1247aeb35b3"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1057,15 +1101,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "121"
+      - "149"
       X-Request-Id:
-      - 68b3eb3d-6b50-46e8-98bf-6602f05135fa
+      - 52a0e84a-c027-41e1-9cf5-503d89b64bd8
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q"},"properties":{}}
+      {"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm"},"properties":{}}
     form: {}
     headers:
       Accept:
@@ -1077,7 +1121,16 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1088,13 +1141,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2718"
+      - "2748"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
+      - Thu, 25 Feb 2021 17:24:33 GMT
       Etag:
-      - W/"e749b45308e3ae49a9b0c7efb323a99e"
+      - W/"a52520128dcfc186de910593a2439c88"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1102,9 +1155,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "119"
+      - "148"
       X-Request-Id:
-      - 074a7a3d-0ac8-4d85-b483-8095c322fe08
+      - 28e52ed3-1fb6-4dba-9788-bcb2998c1fa0
     status: 200 OK
     code: 200
     duration: ""
@@ -1116,10 +1169,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1130,13 +1192,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2718"
+      - "2748"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
+      - Thu, 25 Feb 2021 17:24:33 GMT
       Etag:
-      - W/"e749b45308e3ae49a9b0c7efb323a99e"
+      - W/"a52520128dcfc186de910593a2439c88"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1144,9 +1206,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "118"
+      - "147"
       X-Request-Id:
-      - 3dbb59b9-e426-48e7-a256-5b2578db5e41
+      - 805f0dcc-138e-485f-bd84-7176bf3a3b8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1158,10 +1220,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1172,13 +1243,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2718"
+      - "2748"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:45 GMT
+      - Thu, 25 Feb 2021 17:24:33 GMT
       Etag:
-      - W/"e749b45308e3ae49a9b0c7efb323a99e"
+      - W/"a52520128dcfc186de910593a2439c88"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1186,9 +1257,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "116"
+      - "146"
       X-Request-Id:
-      - 8cd01bae-b2bb-45f2-8827-931cd7e7b23d
+      - f7174bcb-b2ae-4a0d-889d-cb4ad1a5c7d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1200,10 +1271,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango"}}}'
+    body: '{"ip_address":{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1214,13 +1287,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "724"
+      - "734"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:46 GMT
+      - Thu, 25 Feb 2021 17:24:33 GMT
       Etag:
-      - W/"792c87cbeff741877a926119b3a5c786"
+      - W/"9ce843e765141a3323173051d092b25c"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1228,9 +1301,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "108"
+      - "145"
       X-Request-Id:
-      - ce3a9de4-9b52-4d19-b3c6-f2574355a372
+      - 859ecd97-082e-4809-968c-7af0299f6e65
     status: 200 OK
     code: 200
     duration: ""
@@ -1242,10 +1315,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_0OIccaeAY2GoueKH
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_66POcm9rz1ndXSjy
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango"}}}'
+    body: '{"ip_address":{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1256,13 +1331,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "722"
+      - "736"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:46 GMT
+      - Thu, 25 Feb 2021 17:24:33 GMT
       Etag:
-      - W/"cecfcc09f53fd302885c81c867bef616"
+      - W/"82b18fa7b38ac4170e8b097a43ea8044"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1270,9 +1345,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "107"
+      - "144"
       X-Request-Id:
-      - 1c4c7da0-1302-4d9e-8a8c-e84341704a6b
+      - 21582aee-d167-47ec-b975-5e8a4fd0bd18
     status: 200 OK
     code: 200
     duration: ""
@@ -1284,10 +1359,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1298,13 +1382,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2718"
+      - "2748"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:46 GMT
+      - Thu, 25 Feb 2021 17:24:33 GMT
       Etag:
-      - W/"e749b45308e3ae49a9b0c7efb323a99e"
+      - W/"a52520128dcfc186de910593a2439c88"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1312,9 +1396,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "106"
+      - "143"
       X-Request-Id:
-      - 9ed01796-a6cc-4cbc-84db-6d782db2a52f
+      - 239b120b-bc81-45f8-8112-a63cc9afd699
     status: 200 OK
     code: 200
     duration: ""
@@ -1326,10 +1410,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_0OIccaeAY2GoueKH
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_66POcm9rz1ndXSjy
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango"}}}'
+    body: '{"ip_address":{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1340,13 +1426,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "722"
+      - "736"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:47 GMT
+      - Thu, 25 Feb 2021 17:24:34 GMT
       Etag:
-      - W/"cecfcc09f53fd302885c81c867bef616"
+      - W/"82b18fa7b38ac4170e8b097a43ea8044"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1354,9 +1440,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "100"
+      - "142"
       X-Request-Id:
-      - ad2005d9-adc0-4dbc-af46-94b7f9b4576c
+      - 2d042a26-adb2-448b-8e97-8eb1599019b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,10 +1454,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango"}}}'
+    body: '{"ip_address":{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1382,13 +1470,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "724"
+      - "734"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:47 GMT
+      - Thu, 25 Feb 2021 17:24:34 GMT
       Etag:
-      - W/"792c87cbeff741877a926119b3a5c786"
+      - W/"9ce843e765141a3323173051d092b25c"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1396,9 +1484,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "99"
+      - "141"
       X-Request-Id:
-      - 7120760e-53a4-4517-856f-105abc466f46
+      - 5aeb7c9f-0092-4ddf-88f0-63570907888d
     status: 200 OK
     code: 200
     duration: ""
@@ -1410,10 +1498,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1424,13 +1521,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2718"
+      - "2748"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:48 GMT
+      - Thu, 25 Feb 2021 17:24:34 GMT
       Etag:
-      - W/"e749b45308e3ae49a9b0c7efb323a99e"
+      - W/"a52520128dcfc186de910593a2439c88"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1438,9 +1535,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "98"
+      - "140"
       X-Request-Id:
-      - ea3bd62e-1154-4efd-8544-3ee19f1e6160
+      - a065a41d-4786-4512-bd57-56699a9453da
     status: 200 OK
     code: 200
     duration: ""
@@ -1452,10 +1549,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1466,13 +1572,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2718"
+      - "2748"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:48 GMT
+      - Thu, 25 Feb 2021 17:24:35 GMT
       Etag:
-      - W/"e749b45308e3ae49a9b0c7efb323a99e"
+      - W/"a52520128dcfc186de910593a2439c88"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1480,9 +1586,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "95"
+      - "139"
       X-Request-Id:
-      - be99b269-5e69-490c-93fa-fd7557dddfdf
+      - 897cf15a-2ab2-4b61-a272-2e6e11d2f801
     status: 200 OK
     code: 200
     duration: ""
@@ -1494,7 +1600,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_0OIccaeAY2GoueKH
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_66POcm9rz1ndXSjy
     method: POST
   response:
     body: '{}'
@@ -1512,7 +1618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:48 GMT
+      - Thu, 25 Feb 2021 17:24:36 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1522,15 +1628,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "94"
+      - "138"
       X-Request-Id:
-      - 6796996e-fede-44a9-988a-4a8b6fa7a711
+      - cae6835e-ce39-4979-a622-518dc4dc06ba
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q"},"properties":{"tag_names":["lb","app","web"]}}
+      {"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm"},"properties":{"tag_names":["lb","app","web"]}}
     form: {}
     headers:
       Accept:
@@ -1542,7 +1648,14 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1553,13 +1666,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2411"
+      - "2433"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:49 GMT
+      - Thu, 25 Feb 2021 17:24:38 GMT
       Etag:
-      - W/"ebf3ebeb4aa9f5a9351920c62f7e5ace"
+      - W/"832f217dcaf1983072dcdb4771d264f7"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1567,9 +1680,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "93"
+      - "137"
       X-Request-Id:
-      - 67c4fab3-2985-4dcd-8b78-98e168589176
+      - e927ce60-8db8-4c75-880f-c2ed638de5bc
     status: 200 OK
     code: 200
     duration: ""
@@ -1581,10 +1694,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1595,13 +1715,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2411"
+      - "2433"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:49 GMT
+      - Thu, 25 Feb 2021 17:24:38 GMT
       Etag:
-      - W/"ebf3ebeb4aa9f5a9351920c62f7e5ace"
+      - W/"832f217dcaf1983072dcdb4771d264f7"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1609,9 +1729,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "92"
+      - "131"
       X-Request-Id:
-      - 3be31518-39e3-419e-88f6-b594e6e67583
+      - 263492cf-d000-4af8-a82c-5253138e4180
     status: 200 OK
     code: 200
     duration: ""
@@ -1623,10 +1743,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1637,13 +1764,367 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2411"
+      - "2433"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:49 GMT
+      - Thu, 25 Feb 2021 17:24:38 GMT
       Etag:
-      - W/"ebf3ebeb4aa9f5a9351920c62f7e5ace"
+      - W/"832f217dcaf1983072dcdb4771d264f7"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "130"
+      X-Request-Id:
+      - 02eef0ce-9eda-4570-9128-c998d7e1572e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_66POcm9rz1ndXSjy
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_66POcm9rz1ndXSjy","address":"185.53.57.198","reverse_dns":"185-53-57-198.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.198/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "564"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:39 GMT
+      Etag:
+      - W/"20c89643675823790ba81535a4c5e067"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "129"
+      X-Request-Id:
+      - d96cfcb0-ed64-44ab-8034-7beaab529f0a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "734"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:39 GMT
+      Etag:
+      - W/"9ce843e765141a3323173051d092b25c"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "128"
+      X-Request-Id:
+      - f7251032-0460-4858-ae75-5bfd0238b33f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2433"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:39 GMT
+      Etag:
+      - W/"832f217dcaf1983072dcdb4771d264f7"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "127"
+      X-Request-Id:
+      - 4cf76e2c-4aed-4a1c-be54-6c68219be1f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2433"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:40 GMT
+      Etag:
+      - W/"832f217dcaf1983072dcdb4771d264f7"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "125"
+      X-Request-Id:
+      - fc1eb2bd-e73e-4096-9eee-66c02fd46619
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
+    method: POST
+  response:
+    body: '{"task":{"id":"task_ncIUFppaMkjH982w","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:40 GMT
+      Etag:
+      - W/"70db71abe8195cf3061fe0e52f669de5"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "124"
+      X-Request-Id:
+      - a0d0ba6d-17c6-458d-8bfe-7604e2eec135
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_66POcm9rz1ndXSjy
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:40 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "126"
+      X-Request-Id:
+      - 5af1b888-b77d-4f67-aad8-b72764519626
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ncIUFppaMkjH982w
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ncIUFppaMkjH982w","name":"Stop virtual machine","status":"running","created_at":1614273880,"started_at":1614273880,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:41 GMT
+      Etag:
+      - W/"f00ae2586b9fe09912c443b1d6b079a2"
+      Server:
+      - nginx/1.14.0 (Ubuntu)
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "112"
+      X-Request-Id:
+      - c5ea2c8c-8b63-4dc0-88e3-791ec9af69cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ncIUFppaMkjH982w
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ncIUFppaMkjH982w","name":"Stop virtual machine","status":"completed","created_at":1614273880,"started_at":1614273880,"finished_at":1614273881,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Feb 2021 17:24:46 GMT
+      Etag:
+      - W/"8cb0e00ec215c5b81eb429d56149edf4"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1653,7 +2134,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "91"
       X-Request-Id:
-      - 9c8ff6a9-8448-45af-90fa-214797fd3936
+      - 1d4a82eb-46e7-4e9f-ba62-6b9bf594947e
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,220 +2146,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "724"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:50 GMT
-      Etag:
-      - W/"792c87cbeff741877a926119b3a5c786"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "88"
-      X-Request-Id:
-      - 913afb6b-6e81-45eb-9f49-334c2414691d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_0OIccaeAY2GoueKH
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_0OIccaeAY2GoueKH","address":"185.53.57.88","reverse_dns":"185-53-57-88.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.88/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "561"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:50 GMT
-      Etag:
-      - W/"1f49734af5dcd00b75d9aec217dce891"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "87"
-      X-Request-Id:
-      - 2095deb6-4500-431e-9487-403ddc6d29ed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2411"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:50 GMT
-      Etag:
-      - W/"ebf3ebeb4aa9f5a9351920c62f7e5ace"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "86"
-      X-Request-Id:
-      - 6f254eca-7e02-4aaf-8cb0-e05e48974a71
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2411"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:51 GMT
-      Etag:
-      - W/"ebf3ebeb4aa9f5a9351920c62f7e5ace"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "82"
-      X-Request-Id:
-      - 1a9ee226-6ad9-4944-bd71-b8f33be69b3b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: POST
-  response:
-    body: '{"task":{"id":"task_soUMJVs6cT78FW1M","name":"Stop virtual machine","status":"pending"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "88"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:51 GMT
-      Etag:
-      - W/"8cf896ae44beecfbd3bfbeaf2edbe327"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "81"
-      X-Request-Id:
-      - bfb50930-22da-44f9-a3f1-a5497a9e4621
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_0OIccaeAY2GoueKH
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: DELETE
   response:
-    body: '{}'
+    body: '{"trash_object":{"id":"trsh_BVsvejpW1CBbyRk2","keep_until":1614446686,"object_id":"vm_eLKsJfGj6MyQbvsm","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_eLKsJfGj6MyQbvsm","name":"tf-acc-test-magnificent-purple-potato","hostname":"tf-acc-test-magnificent-purple-potato","fqdn":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","description":null,"created_at":1614273851,"initial_root_password":"n7YmjinjDWDiNOEr","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_fwiJuIDXpvrZoi2X","address":"185.53.57.76","reverse_dns":"tf-acc-test-magnificent-purple-potato.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.76/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_eLKsJfGj6MyQbvsm","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1889,13 +2167,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "2"
+      - "2568"
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:51 GMT
+      - Thu, 25 Feb 2021 17:24:47 GMT
       Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
+      - W/"38cc035d3d5487d5dd66624ce4f31adf"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -1903,9 +2181,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "83"
+      - "90"
       X-Request-Id:
-      - 048af82e-9999-4116-a6da-de9bc042c17d
+      - e5c23ea4-62bd-4962-a130-aa8bb4ac6a11
     status: 200 OK
     code: 200
     duration: ""
@@ -1917,91 +2195,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2411"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:53 GMT
-      Etag:
-      - W/"082b9ae384d6941681e0fcdad3834055"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "74"
-      X-Request-Id:
-      - c473801d-b97f-4cde-804a-f1dcaf8f0fdd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
-    method: DELETE
-  response:
-    body: '{"trash_object":{"id":"trsh_jauEcMaIcuLCBbDb","keep_until":1614256613,"object_id":"vm_wL8zEAEq4mLBwj6q","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_wL8zEAEq4mLBwj6q","name":"tf-acc-test-nervous-clean-mango","hostname":"tf-acc-test-nervous-clean-mango","fqdn":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","description":null,"created_at":1614083771,"initial_root_password":"2mlwxzHACLdBeQvA","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V 2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bpYP90F18aLIqc6x","address":"185.53.57.143","reverse_dns":"tf-acc-test-nervous-clean-mango.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.143/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_wL8zEAEq4mLBwj6q","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2546"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:54 GMT
-      Etag:
-      - W/"f1b649cdc612877371e7e063e7ff2337"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "73"
-      X-Request-Id:
-      - 4402f60a-0a2c-44d4-807f-6800226d8674
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
     method: POST
   response:
     body: '{}'
@@ -2019,7 +2213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:54 GMT
+      - Thu, 25 Feb 2021 17:24:47 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2029,9 +2223,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "72"
+      - "89"
       X-Request-Id:
-      - 51642340-eb5f-4d1b-8f81-83b7ae6d50e5
+      - 6c78c677-b1e0-43d7-9bda-d22cd865d6eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2043,10 +2237,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_jauEcMaIcuLCBbDb
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_BVsvejpW1CBbyRk2
     method: DELETE
   response:
-    body: '{"task":{"id":"task_7lA8aSqTVatg18Fd","name":"Purge items from trash","status":"pending","created_at":1614083814,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_lY22ysaOi7C4P4B8","name":"Purge items from trash","status":"pending","created_at":1614273887,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2061,9 +2255,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:36:54 GMT
+      - Thu, 25 Feb 2021 17:24:47 GMT
       Etag:
-      - W/"394019ff5c7a4dcc4751309f4b7d69be"
+      - W/"39f0aefcc4cf660ac1a2f2e7029396f1"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -2071,9 +2265,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "71"
+      - "88"
       X-Request-Id:
-      - b1a8842e-b3b9-4a6f-a3ab-01e8ea445ada
+      - 76510e30-f459-4670-ab1e-d42a730ba1e9
     status: 200 OK
     code: 200
     duration: ""
@@ -2085,94 +2279,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7lA8aSqTVatg18Fd
+    url: https://api.katapult.io/core/v1/tasks/task_lY22ysaOi7C4P4B8
     method: GET
   response:
-    body: '{"task":{"id":"task_7lA8aSqTVatg18Fd","name":"Purge items from trash","status":"pending","created_at":1614083814,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:36:55 GMT
-      Etag:
-      - W/"394019ff5c7a4dcc4751309f4b7d69be"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "70"
-      X-Request-Id:
-      - 5d4c6097-99c5-423d-896c-603902bed87d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7lA8aSqTVatg18Fd
-    method: GET
-  response:
-    body: '{"task":{"id":"task_7lA8aSqTVatg18Fd","name":"Purge items from trash","status":"pending","created_at":1614083814,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 23 Feb 2021 12:37:00 GMT
-      Etag:
-      - W/"394019ff5c7a4dcc4751309f4b7d69be"
-      Server:
-      - nginx/1.14.0 (Ubuntu)
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "199"
-      X-Request-Id:
-      - e299ed69-15a7-45a2-903b-6fc42c62777f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7lA8aSqTVatg18Fd
-    method: GET
-  response:
-    body: '{"task":{"id":"task_7lA8aSqTVatg18Fd","name":"Purge items from trash","status":"running","created_at":1614083814,"started_at":1614083829,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_lY22ysaOi7C4P4B8","name":"Purge items from trash","status":"running","created_at":1614273887,"started_at":1614273887,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2187,9 +2297,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:10 GMT
+      - Thu, 25 Feb 2021 17:24:48 GMT
       Etag:
-      - W/"fc6167d064201e3e55d595290b278815"
+      - W/"2d83476d4b09242fcab80e7f72a51fb4"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -2197,9 +2307,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "196"
+      - "87"
       X-Request-Id:
-      - dac89a87-a4cc-4446-b1c6-259bd7ade885
+      - fc3ccbb9-8104-48a5-a9f3-70aa6834ffe7
     status: 200 OK
     code: 200
     duration: ""
@@ -2211,10 +2321,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7lA8aSqTVatg18Fd
+    url: https://api.katapult.io/core/v1/tasks/task_lY22ysaOi7C4P4B8
     method: GET
   response:
-    body: '{"task":{"id":"task_7lA8aSqTVatg18Fd","name":"Purge items from trash","status":"completed","created_at":1614083814,"started_at":1614083829,"finished_at":1614083831,"progress":100}}'
+    body: '{"task":{"id":"task_lY22ysaOi7C4P4B8","name":"Purge items from trash","status":"completed","created_at":1614273887,"started_at":1614273887,"finished_at":1614273889,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2229,9 +2339,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:20 GMT
+      - Thu, 25 Feb 2021 17:24:53 GMT
       Etag:
-      - W/"eae180e7c395d604b716df928d0c5760"
+      - W/"532668385cc8ba3a5c3c3dbc77668ae3"
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -2239,9 +2349,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "187"
+      - "71"
       X-Request-Id:
-      - 888af979-6856-4fad-a0f7-5edf434fec56
+      - 561da433-fa11-49aa-a086-8d789fe692e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2253,7 +2363,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/0.14.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
     method: DELETE
   response:
     body: '{}'
@@ -2271,7 +2381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:20 GMT
+      - Thu, 25 Feb 2021 17:24:53 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2281,9 +2391,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "186"
+      - "70"
       X-Request-Id:
-      - 49df6a11-12af-4791-927e-794bd97c3973
+      - e23e8a62-d7e5-4a90-96b9-9b7996a0c80e
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,10 +2405,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_wL8zEAEq4mLBwj6q
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_eLKsJfGj6MyQbvsm
     method: GET
   response:
-    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2313,7 +2424,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:20 GMT
+      - Thu, 25 Feb 2021 17:24:53 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -2323,9 +2434,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "185"
+      - "69"
       X-Request-Id:
-      - ec09175b-2bae-43d2-ad37-0b1d0b89de74
+      - 9dcdf397-2350-4a56-ae31-f321feb30d39
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2337,10 +2448,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_0OIccaeAY2GoueKH
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_66POcm9rz1ndXSjy
     method: GET
   response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses were found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2355,7 +2467,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:20 GMT
+      - Thu, 25 Feb 2021 17:24:53 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -2365,9 +2477,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "184"
+      - "68"
       X-Request-Id:
-      - 9d295749-15c6-4e35-a76b-8090fa7ee0f5
+      - 51f8a287-8e28-4eda-9d1d-d5c87e7cc54d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2379,10 +2491,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.3 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bpYP90F18aLIqc6x
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_fwiJuIDXpvrZoi2X
     method: GET
   response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses were found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2397,7 +2510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Feb 2021 12:37:21 GMT
+      - Thu, 25 Feb 2021 17:24:53 GMT
       Server:
       - nginx/1.14.0 (Ubuntu)
       Strict-Transport-Security:
@@ -2407,9 +2520,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "183"
+      - "67"
       X-Request-Id:
-      - 1062d6a3-ae3c-4ad4-ac97-f3bd0d2018c6
+      - 3952c5cf-220a-45a0-8766-6437f97fa0a1
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
When deleting a running VM, we used to simply issue a stop call to the VM, and
then monitor the VM status until it changed to stopped before moving on to
purging the VM.

On the backend, stopping a VM is handled by a background asynchronous task, and
there's a very tiny window between the VM reporting a stopped state, and the
task actually finishing. If a purge VM request is sent in that window, the purge
request will fail due to being blocked by stop task which has not been marked as
done yet.

Hence we take a more active approach here, and actually monitor the task
returned by the stop request, until it is marked as done.

There is still a tiny change this error could happen if Terraform tries to
delete a VM which is already in the middle of stopping or shutting down, as we
then do not know what the Task ID is which is responsible for the stop/shutdown
request. Hence we have to fall back to simply checking the VM state itself.
Ideally we could retry the purge request itself if it fails with a task blocked
error, but error reporting from the Katapult API client isn't not granular
enough for that yet.