### PR TITLE
ci(github): run acceptance tests against Terraform 0.14.x and 0.15.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
   test:
     name: Acceptance Test (VCR Replay)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform_version:
+          - "0.14.7"
+          - "0.15.0-beta1"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -69,6 +75,7 @@ jobs:
           KATAPULT_API_KEY: ${{ secrets.KATAPULT_API_KEY }}
           KATAPULT_ORGANIZATION: ${{ secrets.KATAPULT_ORGANIZATION }}
           KATAPULT_DATA_CENTER: ${{ secrets.KATAPULT_DATA_CENTER }}
+          TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform_version }}
 
   docs:
     name: Documentation


### PR DESCRIPTION
Expanding tests them to Terraform 0.12.x and 0.13.x too would be great, but the
CheckDestroy callbacks on data source tests fail on those versions saying the
resources were not deleted, when they actually were.

For now 0.12.x and 0.13.x are excluded and not "officially" supported as we
don't run our test suite against them.