### PR TITLE
ci(github): set acceptance tests parallel count to 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         env:
           VERBOSE: "true"
           VCR: "replay"
+          TESTARGS: "-parallel=10"
           KATAPULT_API_KEY: ${{ secrets.KATAPULT_API_KEY }}
           KATAPULT_ORGANIZATION: ${{ secrets.KATAPULT_ORGANIZATION }}
           KATAPULT_DATA_CENTER: ${{ secrets.KATAPULT_DATA_CENTER }}


### PR DESCRIPTION
As the acceptance tests should be reasonably light on CPU, let's try making the
overall test run faster by running 10 tests in parallel. By default it will use
the number of CPU cores reported on the machine, which for GitHub Actions I
believe is 2.