### PR TITLE
chore(release): update tooling and docs around creating a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,3 +229,20 @@ check-tidy:
 		mv go.sum.tidy-check go.sum; \
 		exit 1 \
 	)
+
+#
+# Release
+#
+
+.PHONY: new-version
+new-version: check-npx
+	npx standard-version
+
+.PHONY: next-version
+next-version: check-npx
+	npx standard-version --dry-run
+
+.PHONY: check-npx
+check-npx:
+	$(if $(shell which npx),,\
+		$(error No npx found in PATH, please install NodeJS))

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ listed in the release notes and changelog.
 - [Terraform](https://www.terraform.io/downloads.html) 0.14.x
 - [Go](https://golang.org/dl/) 1.16 (to build the provider plugin)
 
+## Using the Provider
+
+To quickly get started with using the provider, please refer to the
+[official documentation](https://registry.terraform.io/providers/krystal/katapult/latest/docs)
+hosted on Terraform Registry.
+
+If you are new to Terraform itself, please refer to the official
+[Terraform Documentation](https://www.terraform.io/docs/index.html).
+
 ## Build the Provider
 
 Clone the provider to your machine, for example:
@@ -36,10 +45,17 @@ make build
 
 ## Developing the Provider
 
-To work on the provider, you will first need [Go](https://golang.org/dl/) (1.16
-or later is _required_), and also
-[Terraform](https://www.terraform.io/downloads.html) 0.14.x or later for
-acceptance tests.
+### Requirements
+
+- [Go](https://golang.org/dl/) 1.16 or later.
+- [Terraform](https://www.terraform.io/downloads.html) 0.14.x or later.
+
+### Rules
+
+- Always follow the
+  [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard
+  when writing your commit messages. This will among other things, ensure
+  relevant changes are automatically added to the Changelog.
 
 ### Make Targets
 
@@ -53,3 +69,94 @@ acceptance tests.
   record requests. To enable real requests against Katapult, set the `VCR`
   environment variable to `rec` to record requests, or `off` to disable the VCR
   request recording/playback all together.
+
+## Releasing the Provider
+
+Creating a new release is a semi-manual process with some tools to help along
+the way.
+
+All Terraform providers must follow [Semantic Versioning](https://semver.org),
+and this provider is no different. To help make this easier, we use the
+[Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) commit
+message format in combination with a tool called
+[`standard-version`](https://github.com/conventional-changelog/standard-version)
+for automatic version bumping and changelog generation.
+
+We use [GitHub Actions](https://github.com/features/actions) and
+[goreleaser](https://goreleaser.com) to build, sign, and publish binaries as
+GitHub Releases for all supported platforms.
+
+### Steps
+
+In your local development working directory:
+
+1. Ensure your working directory is on the `main` branch and fully to to date.
+2. Run `make next-version` to preview both the changelog update and next version
+   based on commits since the last release. If you need to override/customize
+   the changelog and/or automatically determined version, please see
+   [Customize Changelog or Version](#customize-changelog-or-version) below.
+3. Run `make new-version` from the root of your working directory. This will use
+   `standard-version` to:
+   1. Determine the current version by looking at the most recent Semantic
+      Version formatted git tag.
+   2. Look at the list of commits since the last version, and based on
+      conventional commit standards, determine if this next version is a new
+      PATCH, MINOR, or MAJOR version.
+   3. Update `CHANGELOG.md` based on all new commit messages of types `feat`,
+      `fix`, and `docs` since the last release.
+   4. Commit the changes to `CHANGELOG.md` with a commit message of:
+      ```
+      chore(release): <VERSION>
+      ```
+   5. Tag the release commit as `v<VERSION>`.
+4. Push the release commit and tag with:
+   ```
+   git push --follow-tags origin main
+   ```
+5. Wait for GitHub Actions to complete running for the tag you just pushed. The
+   final step called "release" will create a draft GitHub Release for the new
+   version.
+6. Go to
+   [Releases](https://github.com/krystal/terraform-provider-katapult/releases)
+   and edit the new draft release. Typically the release description/body should
+   be the same as the new changelog content for that version. So feel free to
+   copy/paste it. This will be automated at some point in the future.
+7. Publish the draft release.
+8. Wait 5-10 minutes, and the new version should appear on the
+   [Terraform Registry](https://registry.terraform.io/providers/krystal/katapult/latest).
+
+### Customize Changelog or Version
+
+To customize the changelog and/or version number picked by `standard-version`,
+instead of running `make new-version`, just run standard-version manually with
+additional options.
+
+Examples:
+
+- Preview what standard-version will do with `--dry-run`:
+  ```
+  npx standard-version --dry-run
+  ```
+- Customize changelog, by skipping the commit and tag steps:
+  ```
+  npx standard-version --skip.commit --skip.tag
+  ```
+- Override next version with the `-r` flag to be `v2.3.1`:
+  ```
+  npx standard-version -r 2.3.1
+  ```
+
+If you skipped the commit and/or tag stages, you will need to perform them
+manually.
+
+The Git tag **MUST** start with a `v` prefix, and be fully semantic version
+compatible.
+
+The commit message, assuming `v2.3.1`, should be:
+
+```
+chore(release): 2.3.1
+```
+
+Once done, simply push the commit and tag, and wait for the draft GitHub release
+to be created.


### PR DESCRIPTION
- **docs(readme): add details about how to create a new release**
- **chore(release): add next-version and new-version make targets**

  `next-version` will run standard-version in dry-run mode to preview what the
  next calculated version would be, and what the changelog would look like.

  `new-version` runns standard-version as normal, updating the changelog,
  commiting and tagging the changes.