### PR TITLE
ci(nightly): disable VCR request recording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [lint, lint-provider, tidy, test, docs]
-    if: contains(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
         run: make testacc
         env:
           VERBOSE: "true"
-          VCR: "rec"
+          VCR: "off"
           # TODO Remove parallel option when all parallel issues are resolved.
           TESTARGS: "-parallel=1"
           KATAPULT_API_KEY: ${{ secrets.KATAPULT_API_KEY }}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -162,7 +162,7 @@ func testDataFilePath(t *testing.T, suffix string) string {
 	return filepath.Join(".", "testdata", baseName)
 }
 
-func newVCRRecorder(t *testing.T) (*recorder.Recorder, func()) {
+func newVCRRecorder(t *testing.T) *recorder.Recorder {
 	cassettePath := testDataFilePath(t, ".cassette")
 
 	var mode recorder.Mode
@@ -170,13 +170,12 @@ func newVCRRecorder(t *testing.T) (*recorder.Recorder, func()) {
 
 	vcrMode := strings.ToLower(os.Getenv("VCR"))
 	switch vcrMode {
+	case "disabled", "off", "no", "0":
+		return nil
 	case "record", "rec":
 		mode = recorder.ModeRecording
-	case "disabled", "off", "no", "0":
-		mode = recorder.ModeDisabled
 	default:
-		// Prevent real requests unless VCR is explicitly set to record mode or
-		// disabled.
+		// Prevent real requests unless VCR is explicitly set to record mode.
 		transport = &stopRequests{}
 		mode = recorder.ModeReplaying
 	}
@@ -192,11 +191,11 @@ func newVCRRecorder(t *testing.T) (*recorder.Recorder, func()) {
 		return nil
 	})
 
-	stop := func() {
+	t.Cleanup(func() {
 		assert.NoError(t, r.Stop())
-	}
+	})
 
-	return r, stop
+	return r
 }
 
 //


### PR DESCRIPTION
The nightly tests run with VCR recording turned on. This is not needed, and adds
a bit of overhead and complexity.

This PR disables VCR recording in the nightly acceptance tests, but also tweaks
the test setup, so it completely bypasses the VCR recorder transport if VCR is
disabled. Previously it would still use the VCR transport, but configure it to
not record anything.

This might also hopefully help with the very rare nightly failures we've seen
where the Katapult API complains about no API key being provided. I don't know
if it might be related to the VCR recorder, but at the very least there are now
less moving parts which might be responsible for the failure.