### PR TITLE
fix(data/virtual_machine): populate network_speed_profile field

### DIFF
--- a/internal/provider/data_source_virtual_machine_test.go
+++ b/internal/provider/data_source_virtual_machine_test.go
@@ -41,6 +41,7 @@ func TestAccKatapultDataSourceVirtualMachine_by_id(t *testing.T) {
 						ip_address_ids = [katapult_ip.web.id]
 						group_id      = katapult_virtual_machine_group.web.id
 						tags = ["web", "public"]
+						network_speed_profile = "1gbps"
 					}
 
 					data "katapult_virtual_machine" "src" {
@@ -86,6 +87,10 @@ func TestAccKatapultDataSourceVirtualMachine_by_id(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(
 						"data.katapult_virtual_machine.src", "group_id",
 						"katapult_virtual_machine_group.web", "id",
+					),
+					resource.TestCheckResourceAttr(
+						"data.katapult_virtual_machine.src",
+						"network_speed_profile", "1gbps",
 					),
 					// TODO: populate and check disk_template and options when
 					// supported by the API.
@@ -136,6 +141,7 @@ func TestAccKatapultDataSourceVirtualMachine_by_fqdn(t *testing.T) {
 						ip_address_ids = [katapult_ip.web.id]
 						group_id      = katapult_virtual_machine_group.web.id
 						tags = ["web", "public"]
+						network_speed_profile = "1gbps"
 					}
 
 					data "katapult_virtual_machine" "src" {
@@ -181,6 +187,10 @@ func TestAccKatapultDataSourceVirtualMachine_by_fqdn(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(
 						"data.katapult_virtual_machine.src", "group_id",
 						"katapult_virtual_machine_group.web", "id",
+					),
+					resource.TestCheckResourceAttr(
+						"data.katapult_virtual_machine.src",
+						"network_speed_profile", "1gbps",
 					),
 					// TODO: populate and check disk_template and options when
 					// supported by the API.

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.rand_id
@@ -1,1 +1,1 @@
-abicj93c9moj
+3vacegc48pqd

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.yaml
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
@@ -20,32 +20,30 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "181"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:40:41 GMT
+      - Thu, 26 Jan 2023 14:33:36 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "98"
+      - "198"
       X-Request-Id:
-      - 202b1048-efdf-432d-be3f-b14e416437d1
+      - 1f19a813-b45d-4976-9b0b-953592d36333
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -53,11 +51,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -65,26 +63,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "158"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:40:41 GMT
+      - Thu, 26 Jan 2023 14:33:36 GMT
       Etag:
-      - W/"f55792ed30ae64b64719ffb9c9079289"
+      - W/"e68e9503ed0842d329bce502157c79ae"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "98"
+      - "199"
       X-Request-Id:
-      - a4d067bb-921b-473d-b81f-2132fa936ada
+      - 8c5f8da7-2ee7-488d-b67c-e7e55aa7d379
     status: 200 OK
     code: 200
     duration: ""
@@ -95,11 +91,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_GG5O1QQSxCajzkMa
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_W3x87lpfkj5MmK6h
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -107,26 +103,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "158"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:40:41 GMT
+      - Thu, 26 Jan 2023 14:33:36 GMT
       Etag:
-      - W/"f55792ed30ae64b64719ffb9c9079289"
+      - W/"e68e9503ed0842d329bce502157c79ae"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "95"
+      - "196"
       X-Request-Id:
-      - 3dc515eb-e087-418e-bc9e-e230d0de699f
+      - 0787b125-4917-43ef-ae63-31f06b232af6
     status: 200 OK
     code: 200
     duration: ""
@@ -140,11 +134,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"185-199-222-157.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"185-199-222-160.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -154,26 +148,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "552"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:40:42 GMT
+      - Thu, 26 Jan 2023 14:33:36 GMT
       Etag:
-      - W/"4cc55d0f96680ee07a09302105747a4a"
+      - W/"266cebb4e6bc8c0d2dd78e08aa96c442"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "96"
+      - "197"
       X-Request-Id:
-      - bdc8b90f-3b5c-4ae1-a975-b5fa4e947968
+      - 82e18ab7-17f4-49e8-89d8-480811953855
     status: 200 OK
     code: 200
     duration: ""
@@ -184,11 +176,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_x9iMDlteTm8oPcZa
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ry8HIOyZddBgZvZM
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"185-199-222-157.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"185-199-222-160.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -198,26 +190,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "570"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:40:42 GMT
+      - Thu, 26 Jan 2023 14:33:36 GMT
       Etag:
-      - W/"f966ae5a4b0fac007da08e09081232f9"
+      - W/"5542b64a9ddaaebccb8153d91b48093f"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "94"
+      - "195"
       X-Request-Id:
-      - d1578630-4048-463a-9f78-a1a4c92f8d63
+      - e0510eb9-c45d-4c44-8a81-bcd3c08c907a
     status: 200 OK
     code: 200
     duration: ""
@@ -228,11 +218,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_x9iMDlteTm8oPcZa
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ry8HIOyZddBgZvZM
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"185-199-222-157.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"185-199-222-160.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -242,32 +232,30 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "570"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:40:42 GMT
+      - Thu, 26 Jan 2023 14:33:36 GMT
       Etag:
-      - W/"f966ae5a4b0fac007da08e09081232f9"
+      - W/"5542b64a9ddaaebccb8153d91b48093f"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "93"
+      - "194"
       X-Request-Id:
-      - 9ac35735-5cc3-40a5-9aa0-b6b8b9cf782d
+      - 8a5c5fab-f1f6-41a3-8acc-30e9de280520
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_x9iMDlteTm8oPcZa</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-fqdn-abicj93c9moj-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-fqdn-abicj93c9moj</Name><Description>A web server.</Description><Group>vmgrp_GG5O1QQSxCajzkMa</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_ry8HIOyZddBgZvZM</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-fqdn-3vacegc48pqd</Name><Description>A web server.</Description><Group>vmgrp_W3x87lpfkj5MmK6h</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -275,11 +263,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Te2yXmEhlpVRgjbo","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_1oPuw6vGxKWOHRgm","state":"pending"},"virtual_machine_build":{"id":"vmbuild_1oPuw6vGxKWOHRgm","state":"pending"},"hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host"}'
+    body: '{"task":{"id":"task_bF8K15gc1ZcaUFie","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_HlHGXNz7jDzo9MbY","state":"pending"},"virtual_machine_build":{"id":"vmbuild_HlHGXNz7jDzo9MbY","state":"pending"},"hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -287,26 +275,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "288"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:40:42 GMT
+      - Thu, 26 Jan 2023 14:33:36 GMT
       Etag:
-      - W/"8ca7809b27e7b182168cda77b0d13de3"
+      - W/"bd45e63258f4a105332e3534f133c613"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "92"
+      - "193"
       X-Request-Id:
-      - 2d5a0fba-b0ee-480f-8adb-ff204cc2e3aa
+      - 9d790a30-9455-4542-9d47-ee188c779dd9
     status: 201 Created
     code: 201
     duration: ""
@@ -317,19 +303,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_1oPuw6vGxKWOHRgm
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_HlHGXNz7jDzo9MbY
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_1oPuw6vGxKWOHRgm","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_HlHGXNz7jDzo9MbY","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.157\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-abicj93c9moj-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-abicj93c9moj\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_GG5O1QQSxCajzkMa\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.160\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-3vacegc48pqd-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-3vacegc48pqd\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_W3x87lpfkj5MmK6h\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1622137242}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674743616}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -337,559 +323,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "1982"
+      - "2059"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:40:44 GMT
+      - Thu, 26 Jan 2023 14:33:38 GMT
       Etag:
-      - W/"8e912f9abf4c8e1698829e92dc04f0cb"
+      - W/"0e357348667580debc0a68eeb1e481da"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "91"
-      X-Request-Id:
-      - 9b1924a5-5e40-4003-8758-1fa7f942109d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_1oPuw6vGxKWOHRgm
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_1oPuw6vGxKWOHRgm","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.157\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-abicj93c9moj-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-abicj93c9moj\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_GG5O1QQSxCajzkMa\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1622137242}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1982"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:40:49 GMT
-      Etag:
-      - W/"8e912f9abf4c8e1698829e92dc04f0cb"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "90"
-      X-Request-Id:
-      - 5dfaf1d4-1470-4086-886a-3de409755c55
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_1oPuw6vGxKWOHRgm
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_1oPuw6vGxKWOHRgm","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.157\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-abicj93c9moj-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-abicj93c9moj\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_GG5O1QQSxCajzkMa\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1622137242}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "1982"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:40:59 GMT
-      Etag:
-      - W/"143a7a2c33a153710bd783e0e0182825"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "89"
-      X-Request-Id:
-      - a3ae4daf-5ae8-453b-8b85-f0d3dd0f46d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7"},"properties":{"tag_names":["web","public"]}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
-  response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2526"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:40:59 GMT
-      Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "88"
-      X-Request-Id:
-      - 025566b8-3658-42a4-87a0-60fa7bb69f67
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2526"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:41:01 GMT
-      Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "199"
-      X-Request-Id:
-      - 0c90b913-9a6d-4567-a72d-9a9d0db0dc9d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2526"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:41:01 GMT
-      Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "198"
-      X-Request-Id:
-      - 234b7792-f972-4e8b-8fae-ab0fc5b97689
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_5XldDw9nZO0iiIRw","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-abicj93c9moj","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "372"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:41:01 GMT
-      Etag:
-      - W/"45ad3a97512e1d17faafb098ad0702df"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "197"
-      X-Request-Id:
-      - 5b4a216e-7971-4b02-af0d-645db32df718
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_5XldDw9nZO0iiIRw
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_5XldDw9nZO0iiIRw","virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-abicj93c9moj","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:61:97:0d:d8","state":"attached","ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "517"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:41:01 GMT
-      Etag:
-      - W/"047bafbcc277ccd9547d7cf068b9db14"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "196"
-      X-Request-Id:
-      - b55f8cb8-dabc-40d1-aefe-6f192424a477
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2526"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:41:02 GMT
-      Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "195"
-      X-Request-Id:
-      - 4f161596-0090-4506-9768-73c178744f93
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2526"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:41:02 GMT
-      Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "194"
-      X-Request-Id:
-      - 51d8c4cf-b95d-4444-bfcd-789e851da076
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2526"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:41:02 GMT
-      Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "193"
-      X-Request-Id:
-      - 51f3ba2a-c197-4a5e-b469-68916eb409ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_GG5O1QQSxCajzkMa
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "158"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:41:02 GMT
-      Etag:
-      - W/"f55792ed30ae64b64719ffb9c9079289"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "192"
       X-Request-Id:
-      - 231be5ba-d690-4875-b5c6-8c359f5387c6
+      - 5d339337-ba96-4cc0-a2ff-0a4f9ef87fb2
     status: 200 OK
     code: 200
     duration: ""
@@ -900,13 +351,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_x9iMDlteTm8oPcZa
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_HlHGXNz7jDzo9MbY
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj"}}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_HlHGXNz7jDzo9MbY","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.160\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-3vacegc48pqd-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-3vacegc48pqd\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_W3x87lpfkj5MmK6h\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674743616}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -914,26 +371,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "759"
+      - "2059"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:02 GMT
+      - Thu, 26 Jan 2023 14:33:43 GMT
       Etag:
-      - W/"7da68f596e775aa4bc1e065fc4280183"
+      - W/"0e357348667580debc0a68eeb1e481da"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "191"
       X-Request-Id:
-      - 40a650ce-2504-4636-b44c-8fc7ed734e65
+      - e34f6856-f4b3-4aa5-bbdf-9896756acf9a
     status: 200 OK
     code: 200
     duration: ""
@@ -944,19 +399,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_HlHGXNz7jDzo9MbY
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_HlHGXNz7jDzo9MbY","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.160\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-3vacegc48pqd-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-3vacegc48pqd\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_W3x87lpfkj5MmK6h\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1674743616}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -964,43 +419,50 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2526"
+      - "2059"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:02 GMT
+      - Thu, 26 Jan 2023 14:33:53 GMT
       Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
+      - W/"6a1a10e871ee3b99a5491cec23193f87"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "190"
       X-Request-Id:
-      - 299b37b3-b5ce-43b7-a661-2cf0809d41e9
+      - 89e09db8-8386-453c-9d3f-c93173ef2101
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: |
+      {"virtual_machine":{"id":"vm_m2J0NHluru02bR6F"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
       - application/json
+      Content-Type:
+      - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
-    method: GET
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_5XldDw9nZO0iiIRw","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-abicj93c9moj","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1008,26 +470,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "372"
+      - "2540"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:02 GMT
+      - Thu, 26 Jan 2023 14:33:53 GMT
       Etag:
-      - W/"45ad3a97512e1d17faafb098ad0702df"
+      - W/"1856519c26a557f856e71362d79993e0"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "189"
       X-Request-Id:
-      - a6d19c7c-24ac-48bb-b651-828a178f2697
+      - 4b3cecd5-3ee1-43d5-9b73-0f0a0ec74e4b
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,13 +498,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_5XldDw9nZO0iiIRw
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_5XldDw9nZO0iiIRw","virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-abicj93c9moj","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:61:97:0d:d8","state":"attached","ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1052,26 +518,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "517"
+      - "2540"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:02 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"047bafbcc277ccd9547d7cf068b9db14"
+      - W/"1856519c26a557f856e71362d79993e0"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "188"
       X-Request-Id:
-      - e4173cba-869f-408f-a415-3254600dfbad
+      - 29a3b31e-998d-4b44-b505-bb64b7692a6f
     status: 200 OK
     code: 200
     duration: ""
@@ -1082,19 +546,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1102,26 +566,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2526"
+      - "2540"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:02 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
+      - W/"1856519c26a557f856e71362d79993e0"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "187"
       X-Request-Id:
-      - ed92050e-2829-44fc-b2d8-e35983e99435
+      - c052c885-a408-45fb-be0b-1ab6f5e1d5b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1132,19 +594,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3pIvou4Iog1aZIWZ","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1152,26 +608,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2526"
+      - "372"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:03 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
+      - W/"9a5e1b4d943e9106e008b5de720fa569"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "186"
       X-Request-Id:
-      - 5c6b0c68-4add-44b7-8681-41bff92a33af
+      - 078ee749-aa05-4c29-9aa2-99cc38af36e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1182,19 +636,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3pIvou4Iog1aZIWZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3pIvou4Iog1aZIWZ","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c7:18:a2:d8:27","state":"attached","ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1202,26 +650,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2526"
+      - "515"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:03 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"d46e5e1ca581e64388da4571dabb34cc"
+      - W/"a84273134d82789902331926d88cf405"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "185"
       X-Request-Id:
-      - 65e5fc8d-4288-4284-a1cc-c0b28f1be43d
+      - d256c65b-9593-4c90-a038-f38b62fa78ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1232,11 +678,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
-    method: POST
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud
+    method: GET
   response:
-    body: '{"task":{"id":"task_pHnGjoP4YAOk9Dla","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1244,26 +698,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "88"
+      - "2540"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:03 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"29a6c9933c0d7d421cd67549f92d7ca4"
+      - W/"1856519c26a557f856e71362d79993e0"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "184"
       X-Request-Id:
-      - 30e9c16d-e902-482d-b9ae-e73033091229
+      - 9642b84d-313a-4e92-a069-3eb942021a0b
     status: 200 OK
     code: 200
     duration: ""
@@ -1274,11 +726,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_pHnGjoP4YAOk9Dla
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
     method: GET
   response:
-    body: '{"task":{"id":"task_pHnGjoP4YAOk9Dla","name":"Stop virtual machine","status":"pending","created_at":1622137263,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3pIvou4Iog1aZIWZ","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1286,26 +740,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "162"
+      - "372"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:04 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"e7f01f5d95af316a8c734d926a134c19"
+      - W/"9a5e1b4d943e9106e008b5de720fa569"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "183"
       X-Request-Id:
-      - fde09810-3b43-4b83-a63c-5df1136fb779
+      - 666cbd8f-ea03-4c53-8a01-855028b4ebdd
     status: 200 OK
     code: 200
     duration: ""
@@ -1316,11 +768,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_pHnGjoP4YAOk9Dla
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3pIvou4Iog1aZIWZ
     method: GET
   response:
-    body: '{"task":{"id":"task_pHnGjoP4YAOk9Dla","name":"Stop virtual machine","status":"pending","created_at":1622137263,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3pIvou4Iog1aZIWZ","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c7:18:a2:d8:27","state":"attached","ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1328,26 +782,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "162"
+      - "515"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:09 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"e7f01f5d95af316a8c734d926a134c19"
+      - W/"a84273134d82789902331926d88cf405"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "182"
       X-Request-Id:
-      - 590ff0f8-c98d-4617-8004-ebc1396ac696
+      - d1775398-c7af-4fc8-83e5-3fe2d06621cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1358,11 +810,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_pHnGjoP4YAOk9Dla
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
     method: GET
   response:
-    body: '{"task":{"id":"task_pHnGjoP4YAOk9Dla","name":"Stop virtual machine","status":"completed","created_at":1622137263,"started_at":1622137278,"finished_at":1622137279,"progress":100}}'
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1370,26 +830,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "178"
+      - "2540"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:19 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"c3eb2c4cca068f69b653b7d104f59a14"
+      - W/"1856519c26a557f856e71362d79993e0"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "181"
       X-Request-Id:
-      - 8ca8e7ed-e487-4330-a83f-c606ee0aca83
+      - 5cb900a1-2159-44a2-a977-49514fc581b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1400,19 +858,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
-    method: DELETE
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud
+    method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_KqWdNCTrKyab3578","keep_until":1622310079,"object_id":"vm_Zg1hqO7UaliVFhD7","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_Zg1hqO7UaliVFhD7","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj","hostname":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host","fqdn":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137243,"initial_root_password":"YDBUOCrtwY1edtbe","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_x9iMDlteTm8oPcZa","address":"185.199.222.157","reverse_dns":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.157/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Zg1hqO7UaliVFhD7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1420,26 +878,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2661"
+      - "2540"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:20 GMT
+      - Thu, 26 Jan 2023 14:33:56 GMT
       Etag:
-      - W/"d2daeb6c416cdf7bb2786fa174c286b3"
+      - W/"1856519c26a557f856e71362d79993e0"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "180"
       X-Request-Id:
-      - d019d601-5812-4a42-8644-b12f48d8e6f1
+      - 054b84d6-e58f-49eb-9898-766f070f6ba1
     status: 200 OK
     code: 200
     duration: ""
@@ -1450,8 +906,866 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_x9iMDlteTm8oPcZa
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3pIvou4Iog1aZIWZ","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "372"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"9a5e1b4d943e9106e008b5de720fa569"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "179"
+      X-Request-Id:
+      - 3e3cabd3-86e3-455a-84bb-c9c1eec4596e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3pIvou4Iog1aZIWZ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3pIvou4Iog1aZIWZ","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c7:18:a2:d8:27","state":"attached","ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"a84273134d82789902331926d88cf405"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "178"
+      X-Request-Id:
+      - e04f1363-b2f2-4b48-bf6d-2eba1852e883
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_W3x87lpfkj5MmK6h
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"e68e9503ed0842d329bce502157c79ae"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "177"
+      X-Request-Id:
+      - 5da7882e-1263-4210-88a6-2179d4f70fe8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ry8HIOyZddBgZvZM
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"869721060a04fb217adb2a085cebade4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "177"
+      X-Request-Id:
+      - d2ef17f3-4b75-4105-b5ca-3bde1a96b852
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2540"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"1856519c26a557f856e71362d79993e0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "175"
+      X-Request-Id:
+      - f2651cb8-8044-4e26-9968-8862cebf9723
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3pIvou4Iog1aZIWZ","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "372"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"9a5e1b4d943e9106e008b5de720fa569"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "174"
+      X-Request-Id:
+      - 28480858-e6e4-4ed7-92ba-a9793cbb3750
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3pIvou4Iog1aZIWZ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3pIvou4Iog1aZIWZ","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c7:18:a2:d8:27","state":"attached","ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"a84273134d82789902331926d88cf405"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "173"
+      X-Request-Id:
+      - 8a9e7280-1044-40f9-9a2c-0c5edfdc08c9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2540"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"1856519c26a557f856e71362d79993e0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "172"
+      X-Request-Id:
+      - 9247f008-c0c1-4c02-9617-377d6bd3c5d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3pIvou4Iog1aZIWZ","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "372"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:56 GMT
+      Etag:
+      - W/"9a5e1b4d943e9106e008b5de720fa569"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "171"
+      X-Request-Id:
+      - ddc34d10-4da8-4e75-9c15-6a6ef3d0ef36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3pIvou4Iog1aZIWZ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3pIvou4Iog1aZIWZ","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c7:18:a2:d8:27","state":"attached","ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:57 GMT
+      Etag:
+      - W/"a84273134d82789902331926d88cf405"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "170"
+      X-Request-Id:
+      - 20de5b1d-4df6-417f-86c4-50cf938d1b49
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2540"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:57 GMT
+      Etag:
+      - W/"1856519c26a557f856e71362d79993e0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "169"
+      X-Request-Id:
+      - 0cab91e1-403e-4564-a7f2-d505d361e1a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3pIvou4Iog1aZIWZ","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "372"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:57 GMT
+      Etag:
+      - W/"9a5e1b4d943e9106e008b5de720fa569"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "168"
+      X-Request-Id:
+      - d29a0c2c-c719-4de0-92ac-8d8807c28c99
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3pIvou4Iog1aZIWZ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3pIvou4Iog1aZIWZ","virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-3vacegc48pqd","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c7:18:a2:d8:27","state":"attached","ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:57 GMT
+      Etag:
+      - W/"a84273134d82789902331926d88cf405"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "167"
+      X-Request-Id:
+      - 219f0b58-ee19-407b-bbbe-73b21f209a26
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2540"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:57 GMT
+      Etag:
+      - W/"1856519c26a557f856e71362d79993e0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "166"
+      X-Request-Id:
+      - c38006ee-6d74-404f-b13d-0d1dc3eb8d9c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
+    method: POST
+  response:
+    body: '{"task":{"id":"task_9OgEoo7v7TSbCFFD","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:57 GMT
+      Etag:
+      - W/"db5e4d3f44c0905ebec160c0913e6cdf"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "165"
+      X-Request-Id:
+      - baf07dac-8459-4480-bd6c-4ce3762325b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_9OgEoo7v7TSbCFFD
+    method: GET
+  response:
+    body: '{"task":{"id":"task_9OgEoo7v7TSbCFFD","name":"Stop virtual machine","status":"pending","created_at":1674743637,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:33:58 GMT
+      Etag:
+      - W/"5db0d3d2c141242875fea186e473c084"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "164"
+      X-Request-Id:
+      - ef5c54a8-4f9b-4b36-91f9-ffd397d03a87
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_9OgEoo7v7TSbCFFD
+    method: GET
+  response:
+    body: '{"task":{"id":"task_9OgEoo7v7TSbCFFD","name":"Stop virtual machine","status":"pending","created_at":1674743637,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:34:03 GMT
+      Etag:
+      - W/"5db0d3d2c141242875fea186e473c084"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "199"
+      X-Request-Id:
+      - 2270e7fc-b902-46d4-a482-c2ef3f8c5c65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_9OgEoo7v7TSbCFFD
+    method: GET
+  response:
+    body: '{"task":{"id":"task_9OgEoo7v7TSbCFFD","name":"Stop virtual machine","status":"running","created_at":1674743637,"started_at":1674743652,"finished_at":null,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:34:13 GMT
+      Etag:
+      - W/"1a41b0463c1056efb69fe61395097a0f"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "198"
+      X-Request-Id:
+      - 1ae4ca8f-e0a0-4379-80d9-630c0227b5e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_9OgEoo7v7TSbCFFD
+    method: GET
+  response:
+    body: '{"task":{"id":"task_9OgEoo7v7TSbCFFD","name":"Stop virtual machine","status":"completed","created_at":1674743637,"started_at":1674743652,"finished_at":1674743654,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:34:23 GMT
+      Etag:
+      - W/"e603244e367002edbd4b1874ad1628fa"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "197"
+      X-Request-Id:
+      - 600838eb-e165-4135-8bb7-a3c1ba84f361
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_pAeKfqEcrujwJDJk","keep_until":1674916463,"object_id":"vm_m2J0NHluru02bR6F","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_m2J0NHluru02bR6F","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd","hostname":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host","fqdn":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743617,"initial_root_password":"hPsX8zGnQuEVw1Mb","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ry8HIOyZddBgZvZM","address":"185.199.222.160","reverse_dns":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.160/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_m2J0NHluru02bR6F","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2675"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:34:23 GMT
+      Etag:
+      - W/"35f5ebfedf1a2cff1596e207a80bfb32"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "196"
+      X-Request-Id:
+      - 8ace847b-7c0c-48d4-af19-8f17f5168be1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ry8HIOyZddBgZvZM
     method: POST
   response:
     body: '{}'
@@ -1462,26 +1776,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:20 GMT
+      - Thu, 26 Jan 2023 14:34:24 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "179"
+      - "195"
       X-Request-Id:
-      - ccfe5dae-0509-4cbe-8cfd-0e58390afda2
+      - 85bda510-99fa-4164-9510-869eecdb49dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1492,11 +1804,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_KqWdNCTrKyab3578
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_pAeKfqEcrujwJDJk
     method: DELETE
   response:
-    body: '{"task":{"id":"task_usKHlkoNsPIgLVlY","name":"Purge items from trash","status":"pending","created_at":1622137280,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_75b57EXEKwZ3zUsP","name":"Purge items from trash","status":"pending","created_at":1674743664,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1504,26 +1816,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "164"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:21 GMT
+      - Thu, 26 Jan 2023 14:34:24 GMT
       Etag:
-      - W/"745fc03fa610b3409f9c41dc68ea4b5a"
+      - W/"1beb7d599a1f6d8d4759303f8080c77c"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "178"
+      - "194"
       X-Request-Id:
-      - 0caf2b6a-609f-48ab-a2e1-b3c6399f1c9e
+      - 6b30c498-c57c-47a9-99af-1809e6708722
     status: 200 OK
     code: 200
     duration: ""
@@ -1534,11 +1844,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_usKHlkoNsPIgLVlY
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_75b57EXEKwZ3zUsP
     method: GET
   response:
-    body: '{"task":{"id":"task_usKHlkoNsPIgLVlY","name":"Purge items from trash","status":"running","created_at":1622137280,"started_at":1622137281,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_75b57EXEKwZ3zUsP","name":"Purge items from trash","status":"running","created_at":1674743664,"started_at":1674743664,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1546,26 +1856,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "170"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:22 GMT
+      - Thu, 26 Jan 2023 14:34:25 GMT
       Etag:
-      - W/"bebfbea99df7984b044dd832d8d8cbdc"
+      - W/"b70a41a346902b20d02bcbe5e071ab99"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "177"
+      - "193"
       X-Request-Id:
-      - 71f1e3e4-ed3a-42e0-a6ab-dfa0b55c3016
+      - a72db836-d2a0-44d1-94e8-1b56753dc084
     status: 200 OK
     code: 200
     duration: ""
@@ -1576,11 +1884,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_usKHlkoNsPIgLVlY
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_75b57EXEKwZ3zUsP
     method: GET
   response:
-    body: '{"task":{"id":"task_usKHlkoNsPIgLVlY","name":"Purge items from trash","status":"completed","created_at":1622137280,"started_at":1622137281,"finished_at":1622137283,"progress":100}}'
+    body: '{"task":{"id":"task_75b57EXEKwZ3zUsP","name":"Purge items from trash","status":"completed","created_at":1674743664,"started_at":1674743664,"finished_at":1674743667,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1588,26 +1896,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "180"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:27 GMT
+      - Thu, 26 Jan 2023 14:34:30 GMT
       Etag:
-      - W/"5cd81e6e6914353191ffebb7289191a8"
+      - W/"4c464a8b977739389324a9dab172f73d"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "176"
+      - "192"
       X-Request-Id:
-      - 4e5ac6d2-9ce0-44d5-80c0-613d4db54580
+      - b3d275f9-d513-44fb-a6dc-c32a5b9029d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1618,11 +1924,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_GG5O1QQSxCajzkMa
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_W3x87lpfkj5MmK6h
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_GG5O1QQSxCajzkMa","name":"tf-acc-test-data-source-by-fqdn-abicj93c9moj-group","segregate":true,"created_at":1622137241}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_W3x87lpfkj5MmK6h","name":"tf-acc-test-data-source-by-fqdn-3vacegc48pqd-group","segregate":true,"created_at":1674743616}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1630,26 +1936,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "158"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:27 GMT
+      - Thu, 26 Jan 2023 14:34:30 GMT
       Etag:
-      - W/"f55792ed30ae64b64719ffb9c9079289"
+      - W/"e68e9503ed0842d329bce502157c79ae"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "175"
+      - "191"
       X-Request-Id:
-      - e3f4294a-1bd1-434c-addf-1de35c788089
+      - c9b7b0fb-e46a-4b4d-8df7-ccb0f7e6b6a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1660,8 +1964,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_x9iMDlteTm8oPcZa
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ry8HIOyZddBgZvZM
     method: DELETE
   response:
     body: '{}'
@@ -1672,26 +1976,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:28 GMT
+      - Thu, 26 Jan 2023 14:34:30 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "175"
+      - "190"
       X-Request-Id:
-      - f68b7feb-be90-434e-a16a-df718272451f
+      - 5471ff5f-d52c-4ff3-996b-1433e5867954
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,8 +2004,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1715,26 +2017,24 @@ interactions:
       - '*'
       Cache-Control:
       - no-cache
-      Connection:
-      - keep-alive
       Content-Length:
       - "158"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:28 GMT
+      - Thu, 26 Jan 2023 14:34:30 GMT
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "173"
+      - "189"
       X-Request-Id:
-      - e4e0d702-e621-4886-9c83-ccd15b27e7b3
+      - 8b1fade0-452e-487d-a384-127d22932586
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1745,8 +2045,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Zg1hqO7UaliVFhD7
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_m2J0NHluru02bR6F
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1758,26 +2058,24 @@ interactions:
       - '*'
       Cache-Control:
       - no-cache
-      Connection:
-      - keep-alive
       Content-Length:
       - "158"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:28 GMT
+      - Thu, 26 Jan 2023 14:34:30 GMT
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "172"
+      - "188"
       X-Request-Id:
-      - ccf3da1c-f349-42ff-a297-f4650ca4f416
+      - 6efd41b0-ae49-4e4c-8de9-2dc88b0de7d2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1788,8 +2086,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_x9iMDlteTm8oPcZa
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ry8HIOyZddBgZvZM
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -1801,26 +2099,24 @@ interactions:
       - '*'
       Cache-Control:
       - no-cache
-      Connection:
-      - keep-alive
       Content-Length:
       - "151"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:28 GMT
+      - Thu, 26 Jan 2023 14:34:30 GMT
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "171"
+      - "187"
       X-Request-Id:
-      - 44ee1686-7759-4a4e-954f-1dfbe8640e5e
+      - f9fcd6cc-026c-4848-bdad-ef62a8fef544
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.rand_id
@@ -1,1 +1,1 @@
-lnkpr16xu7pq
+fj4sci0ts7pt

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.yaml
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
@@ -20,32 +20,30 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "181"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:31 GMT
+      - Thu, 26 Jan 2023 14:23:25 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "158"
+      - "198"
       X-Request-Id:
-      - afe3a623-016a-430f-904a-c1148360b100
+      - b4054937-3d89-479a-a63d-e3ae696ea487
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -53,11 +51,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -65,26 +63,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "156"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:31 GMT
+      - Thu, 26 Jan 2023 14:23:25 GMT
       Etag:
-      - W/"4ff9effb9e0e6c076fbf1425bf7ae7c0"
+      - W/"79cbed6c3fb9f57f59f010636197cd46"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "159"
+      - "199"
       X-Request-Id:
-      - 11086712-a73a-4573-bf0a-4f5ffbc05e94
+      - bba8c646-7f2f-4529-b7dc-e9b8bb8b5c15
     status: 200 OK
     code: 200
     duration: ""
@@ -95,11 +91,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_mlkldfFbt6ihhTA0
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_HML99Q0rZSxlkfQc
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -107,26 +103,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "156"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:31 GMT
+      - Thu, 26 Jan 2023 14:23:25 GMT
       Etag:
-      - W/"4ff9effb9e0e6c076fbf1425bf7ae7c0"
+      - W/"79cbed6c3fb9f57f59f010636197cd46"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "156"
+      - "196"
       X-Request-Id:
-      - c0d26968-0c3b-4e94-a261-f4376c371747
+      - 5518d5e4-f7f8-4265-8391-a3b0e4a0ccca
     status: 200 OK
     code: 200
     duration: ""
@@ -140,11 +134,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"185-199-222-212.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"185-199-222-207.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -154,26 +148,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "552"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:32 GMT
+      - Thu, 26 Jan 2023 14:23:25 GMT
       Etag:
-      - W/"3c0e29aab5277bd595ec3f78f87ed512"
+      - W/"f4022fb65d9c57600eb97fb05ed9a071"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "157"
+      - "197"
       X-Request-Id:
-      - bead766c-5537-47f6-b606-2a1816bf10b0
+      - 6a50342d-f149-4289-ab91-d716992d130f
     status: 200 OK
     code: 200
     duration: ""
@@ -184,11 +176,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_A0Fa4pEhrUIBJiCd
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_l6nhRtYivHosZ8wg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"185-199-222-212.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"185-199-222-207.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -198,26 +190,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "570"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:32 GMT
+      - Thu, 26 Jan 2023 14:23:25 GMT
       Etag:
-      - W/"166fb368e13d230a82f73070b56b6f5c"
+      - W/"5b28760ccbcd8944e8ebf4a29fb8b5fb"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "155"
+      - "195"
       X-Request-Id:
-      - 9413bcec-83e4-47f2-a205-b8ddeacb5b72
+      - 21850741-79f2-4ebe-ad12-5cccc551cd81
     status: 200 OK
     code: 200
     duration: ""
@@ -228,11 +218,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_A0Fa4pEhrUIBJiCd
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_l6nhRtYivHosZ8wg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"185-199-222-212.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"185-199-222-207.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -242,32 +232,30 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "570"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:32 GMT
+      - Thu, 26 Jan 2023 14:23:25 GMT
       Etag:
-      - W/"166fb368e13d230a82f73070b56b6f5c"
+      - W/"5b28760ccbcd8944e8ebf4a29fb8b5fb"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "154"
+      - "194"
       X-Request-Id:
-      - 28bd1d49-b441-47cd-8ef4-832f00f0000f
+      - 2a91243e-4834-4a61-b1c7-c043d01baa1d
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_A0Fa4pEhrUIBJiCd</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-id-lnkpr16xu7pq-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-id-lnkpr16xu7pq</Name><Description>A web server.</Description><Group>vmgrp_mlkldfFbt6ihhTA0</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_l6nhRtYivHosZ8wg</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-id-fj4sci0ts7pt-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-id-fj4sci0ts7pt</Name><Description>A web server.</Description><Group>vmgrp_HML99Q0rZSxlkfQc</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -275,11 +263,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Z9ttX6WRn0xPUQgr","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_AA4PAWLoLFZSys9q","state":"pending"},"virtual_machine_build":{"id":"vmbuild_AA4PAWLoLFZSys9q","state":"pending"},"hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host"}'
+    body: '{"task":{"id":"task_MQsyDP96MHijVMWW","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","state":"pending"},"virtual_machine_build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","state":"pending"},"hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -287,26 +275,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "286"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:32 GMT
+      - Thu, 26 Jan 2023 14:23:26 GMT
       Etag:
-      - W/"c334834d2e62b93d193d774ae312af19"
+      - W/"d26db601d18591fdb43c522ff5d86066"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "153"
+      - "193"
       X-Request-Id:
-      - d076640e-c4d8-4fe7-825f-1fc5aee65e8c
+      - a4353c20-f6fa-4868-b0b2-e93d1f46809b
     status: 201 Created
     code: 201
     duration: ""
@@ -317,19 +303,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_AA4PAWLoLFZSys9q
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_FEQK4NhRMvnkSPB2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_AA4PAWLoLFZSys9q","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.212\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-lnkpr16xu7pq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-lnkpr16xu7pq\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_mlkldfFbt6ihhTA0\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.207\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_HML99Q0rZSxlkfQc\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1622137292}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674743006}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -337,26 +323,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "1972"
+      - "2049"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:34 GMT
+      - Thu, 26 Jan 2023 14:23:28 GMT
       Etag:
-      - W/"a7ec5f8ccefaea4a5a906bf65f4ba7ef"
+      - W/"743a24b114fc1005f94b83bd63692a3a"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "152"
+      - "192"
       X-Request-Id:
-      - 62f97e0d-0c39-4583-8279-0677da32a123
+      - ec5ce764-af1e-48c3-b9f3-d0b03e9c288d
     status: 200 OK
     code: 200
     duration: ""
@@ -367,19 +351,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_AA4PAWLoLFZSys9q
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_FEQK4NhRMvnkSPB2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_AA4PAWLoLFZSys9q","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.212\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-lnkpr16xu7pq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-lnkpr16xu7pq\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_mlkldfFbt6ihhTA0\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.207\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_HML99Q0rZSxlkfQc\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1622137292}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674743006}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -387,26 +371,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "1972"
+      - "2049"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:39 GMT
+      - Thu, 26 Jan 2023 14:23:33 GMT
       Etag:
-      - W/"a7ec5f8ccefaea4a5a906bf65f4ba7ef"
+      - W/"743a24b114fc1005f94b83bd63692a3a"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "151"
+      - "191"
       X-Request-Id:
-      - fb0a19e0-edb0-4ac1-aa33-b1e6b3fedad2
+      - c343a101-c1c4-4bd1-8f4a-fc68e053c900
     status: 200 OK
     code: 200
     duration: ""
@@ -417,19 +399,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_AA4PAWLoLFZSys9q
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_FEQK4NhRMvnkSPB2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_AA4PAWLoLFZSys9q","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.212\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-lnkpr16xu7pq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-lnkpr16xu7pq\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_mlkldfFbt6ihhTA0\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.207\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_HML99Q0rZSxlkfQc\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1622137292}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674743006}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -437,32 +419,222 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "1972"
+      - "2049"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:49 GMT
+      - Thu, 26 Jan 2023 14:23:43 GMT
       Etag:
-      - W/"28a8d63c6a5c84f15008884f889b6e38"
+      - W/"743a24b114fc1005f94b83bd63692a3a"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "150"
+      - "190"
       X-Request-Id:
-      - a04145e3-7519-4702-a099-bf1183b46390
+      - b807f176-554a-41dc-8ca7-abad55ba2c6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_FEQK4NhRMvnkSPB2
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.207\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_HML99Q0rZSxlkfQc\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674743006}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2049"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:23:53 GMT
+      Etag:
+      - W/"743a24b114fc1005f94b83bd63692a3a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "189"
+      X-Request-Id:
+      - 8b40e678-06fc-45b9-8b30-a9b9bf00a22b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_FEQK4NhRMvnkSPB2
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.207\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_HML99Q0rZSxlkfQc\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674743006}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2049"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:03 GMT
+      Etag:
+      - W/"743a24b114fc1005f94b83bd63692a3a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "199"
+      X-Request-Id:
+      - f6a58468-5954-457d-b9de-6750a8b680e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_FEQK4NhRMvnkSPB2
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.207\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_HML99Q0rZSxlkfQc\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674743006}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2049"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:13 GMT
+      Etag:
+      - W/"743a24b114fc1005f94b83bd63692a3a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "198"
+      X-Request-Id:
+      - 0bba457d-a5a0-49b0-8c2c-aa797739ee9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_FEQK4NhRMvnkSPB2
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_FEQK4NhRMvnkSPB2","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.207\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-fj4sci0ts7pt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_HML99Q0rZSxlkfQc\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1674743006}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2050"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:23 GMT
+      Etag:
+      - W/"e04d25e24f369851e2e253473f87c8cc"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "197"
+      X-Request-Id:
+      - 638d3b42-4520-4628-89b3-94d8c4071c2a
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -470,19 +642,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -490,26 +662,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2531"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:49 GMT
+      - Thu, 26 Jan 2023 14:24:23 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"5cbb8758fa3b528d952b365faaa6814d"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "149"
+      - "196"
       X-Request-Id:
-      - 173cf981-9bdb-4409-b163-9cb8d584239e
+      - 268760db-54e1-4cd9-a0d1-6f2cd681f7d4
     status: 200 OK
     code: 200
     duration: ""
@@ -520,19 +690,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -540,26 +710,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:51 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "148"
+      - "195"
       X-Request-Id:
-      - 30c00e2b-0da3-4de0-aef1-70cd57025bb3
+      - 0dbc270a-52e7-42c9-8030-b0eb69708063
     status: 200 OK
     code: 200
     duration: ""
@@ -570,19 +738,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -590,26 +758,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:51 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "147"
+      - "194"
       X-Request-Id:
-      - a8cc9d8e-69cc-4c1d-b05e-9d6eafffde6a
+      - 3b4965c7-c6fb-4722-8174-219f2abe62aa
     status: 200 OK
     code: 200
     duration: ""
@@ -620,13 +786,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tYFWUeokA2InSQse","name":"Public
-      Network on tf-acc-test-data-source-by-id-lnkpr16xu7pq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yfzw6DIpMGAij76R","name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -634,26 +800,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "370"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:51 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"fd20e3126dd28b489339cb43f856c31d"
+      - W/"d07d0b5dfc39691a12689e1c7098593b"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "146"
+      - "193"
       X-Request-Id:
-      - 7a7cf97f-c2f1-4525-ae34-86332e3750c3
+      - 28ca6f70-4a42-4cd1-9c69-a4d8beb99e63
     status: 200 OK
     code: 200
     duration: ""
@@ -664,13 +828,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tYFWUeokA2InSQse
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yfzw6DIpMGAij76R
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_tYFWUeokA2InSQse","virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-lnkpr16xu7pq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a0:c4:6c:ad:68","state":"attached","ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yfzw6DIpMGAij76R","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c8:c5:c2:5d:8f","state":"attached","ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -678,26 +842,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "513"
+      - "511"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:51 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"b194c4387f154b0a3ea2c7efe01e1890"
+      - W/"1276bc20109bc864c7ced04da7d820fd"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "145"
+      - "192"
       X-Request-Id:
-      - 664f1d15-4ab8-4580-bd66-e0b2a05ad819
+      - 1a6b7f18-9da0-4867-bbc5-cb0b2ea2b247
     status: 200 OK
     code: 200
     duration: ""
@@ -708,19 +870,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -728,26 +890,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:51 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "144"
+      - "191"
       X-Request-Id:
-      - a7038b88-fa3f-403b-b9fc-a68482f921dc
+      - 6afe8f54-0b9e-4803-b845-7d3981296df4
     status: 200 OK
     code: 200
     duration: ""
@@ -758,19 +918,103 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yfzw6DIpMGAij76R","name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:25 GMT
+      Etag:
+      - W/"d07d0b5dfc39691a12689e1c7098593b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "190"
+      X-Request-Id:
+      - ae00173b-cfd9-416f-91fd-4e14ca6e6c3c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yfzw6DIpMGAij76R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yfzw6DIpMGAij76R","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c8:c5:c2:5d:8f","state":"attached","ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "511"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:25 GMT
+      Etag:
+      - W/"1276bc20109bc864c7ced04da7d820fd"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "189"
+      X-Request-Id:
+      - ac3c7029-22d8-4251-a629-30cd1e540c5f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -778,26 +1022,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:52 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "143"
+      - "188"
       X-Request-Id:
-      - 2334db4d-42e6-472a-a90a-49c64c2d0448
+      - 02a1fcca-f08e-4640-99eb-8445fa10bce8
     status: 200 OK
     code: 200
     duration: ""
@@ -808,19 +1050,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -828,26 +1070,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:52 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "142"
+      - "187"
       X-Request-Id:
-      - 61bdcf32-e97f-42dd-be98-1571a4ad5e8f
+      - bc928ccf-004f-444d-8988-a1e9069e7da1
     status: 200 OK
     code: 200
     duration: ""
@@ -858,11 +1098,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_mlkldfFbt6ihhTA0
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yfzw6DIpMGAij76R","name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -870,26 +1112,106 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:25 GMT
+      Etag:
+      - W/"d07d0b5dfc39691a12689e1c7098593b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "186"
+      X-Request-Id:
+      - b82d2d19-59d9-4b00-96d1-7a18df6c083a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yfzw6DIpMGAij76R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yfzw6DIpMGAij76R","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c8:c5:c2:5d:8f","state":"attached","ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "511"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:25 GMT
+      Etag:
+      - W/"1276bc20109bc864c7ced04da7d820fd"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "185"
+      X-Request-Id:
+      - 66e0d826-01b6-4e9e-966c-ffe637c27137
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_HML99Q0rZSxlkfQc
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
       Content-Length:
       - "156"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:52 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"4ff9effb9e0e6c076fbf1425bf7ae7c0"
+      - W/"79cbed6c3fb9f57f59f010636197cd46"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "140"
+      - "184"
       X-Request-Id:
-      - c2bf77a9-bd75-4845-8555-03c146918bfe
+      - 26070b95-d8c7-493c-8326-862b685b5b93
     status: 200 OK
     code: 200
     duration: ""
@@ -900,13 +1222,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_A0Fa4pEhrUIBJiCd
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_l6nhRtYivHosZ8wg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -919,19 +1241,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:52 GMT
+      - Thu, 26 Jan 2023 14:24:25 GMT
       Etag:
-      - W/"05e68ab3d3d9ee4eb969584451735997"
+      - W/"5112a30e66d0829e3aeccf11b4868250"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "141"
+      - "183"
       X-Request-Id:
-      - 509f4caf-da73-4e69-b285-c930e276340f
+      - adbc335f-3605-4aea-bf8c-d4d46027e69c
     status: 200 OK
     code: 200
     duration: ""
@@ -942,19 +1264,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -962,26 +1284,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:52 GMT
+      - Thu, 26 Jan 2023 14:24:26 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "139"
+      - "182"
       X-Request-Id:
-      - 202ec7a3-c94c-42f1-a4de-ee22483ad113
+      - ece22ae1-03aa-4b37-9b05-c1b6e295c3f3
     status: 200 OK
     code: 200
     duration: ""
@@ -992,13 +1312,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tYFWUeokA2InSQse","name":"Public
-      Network on tf-acc-test-data-source-by-id-lnkpr16xu7pq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yfzw6DIpMGAij76R","name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1006,26 +1326,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "370"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:52 GMT
+      - Thu, 26 Jan 2023 14:24:26 GMT
       Etag:
-      - W/"fd20e3126dd28b489339cb43f856c31d"
+      - W/"d07d0b5dfc39691a12689e1c7098593b"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "138"
+      - "181"
       X-Request-Id:
-      - 39129743-bb32-4803-a52f-e2e6d30c7833
+      - 964fe289-781a-4326-be68-b97dad8361e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,13 +1354,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tYFWUeokA2InSQse
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yfzw6DIpMGAij76R
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_tYFWUeokA2InSQse","virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-lnkpr16xu7pq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a0:c4:6c:ad:68","state":"attached","ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yfzw6DIpMGAij76R","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c8:c5:c2:5d:8f","state":"attached","ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1050,26 +1368,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "513"
+      - "511"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:52 GMT
+      - Thu, 26 Jan 2023 14:24:26 GMT
       Etag:
-      - W/"b194c4387f154b0a3ea2c7efe01e1890"
+      - W/"1276bc20109bc864c7ced04da7d820fd"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "137"
+      - "180"
       X-Request-Id:
-      - 12246082-e87a-4213-b05e-5111890b50ff
+      - 69fd912c-582d-45b9-a7bf-cf3587219698
     status: 200 OK
     code: 200
     duration: ""
@@ -1080,19 +1396,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1100,26 +1416,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:52 GMT
+      - Thu, 26 Jan 2023 14:24:26 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "136"
+      - "179"
       X-Request-Id:
-      - 96cbad93-11be-41ac-ba11-3602cc4ef0b6
+      - 33f8f7bc-adc1-48e7-bda0-4c0698feef8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1130,19 +1444,103 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yfzw6DIpMGAij76R","name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:26 GMT
+      Etag:
+      - W/"d07d0b5dfc39691a12689e1c7098593b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "178"
+      X-Request-Id:
+      - 436155fc-55f1-4e1d-8e02-b5d37c180a11
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yfzw6DIpMGAij76R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yfzw6DIpMGAij76R","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c8:c5:c2:5d:8f","state":"attached","ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "511"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:26 GMT
+      Etag:
+      - W/"1276bc20109bc864c7ced04da7d820fd"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "177"
+      X-Request-Id:
+      - 23d6d0e4-7fb5-4a26-85d5-aac247270815
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1150,26 +1548,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:53 GMT
+      - Thu, 26 Jan 2023 14:24:26 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "135"
+      - "176"
       X-Request-Id:
-      - b3ee7546-8822-455f-a2d7-c82e48438924
+      - 200fe528-6411-43fa-b585-35cb569a3577
     status: 200 OK
     code: 200
     duration: ""
@@ -1180,19 +1576,103 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yfzw6DIpMGAij76R","name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:26 GMT
+      Etag:
+      - W/"d07d0b5dfc39691a12689e1c7098593b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "175"
+      X-Request-Id:
+      - 1fc631a7-5129-4959-9548-f8c4a4fac4f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yfzw6DIpMGAij76R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yfzw6DIpMGAij76R","virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-fj4sci0ts7pt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:c8:c5:c2:5d:8f","state":"attached","ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "511"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:26 GMT
+      Etag:
+      - W/"1276bc20109bc864c7ced04da7d820fd"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "174"
+      X-Request-Id:
+      - ff922da8-3955-4a3a-9c7a-e9169b884858
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
       House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
       2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1200,26 +1680,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2516"
+      - "2530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:53 GMT
+      - Thu, 26 Jan 2023 14:24:26 GMT
       Etag:
-      - W/"d5e3de5f335cdfc8939f9254e2b15d25"
+      - W/"fbd8869f90687b0adcdf62f22324ba96"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "134"
+      - "173"
       X-Request-Id:
-      - 3d53eb04-a0a8-4978-bdd7-9e2f4e7f1d9c
+      - 61cdb566-bd41-469e-a487-28dcdcd24ead
     status: 200 OK
     code: 200
     duration: ""
@@ -1230,11 +1708,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: POST
   response:
-    body: '{"task":{"id":"task_IMkaVgTISJ6TkpD8","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_RHRvJ2fmksvZ1yzz","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1242,26 +1720,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "88"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:53 GMT
+      - Thu, 26 Jan 2023 14:24:26 GMT
       Etag:
-      - W/"b3edbb14e0d99f35b1f66a95ebb99a1d"
+      - W/"993d3876f72822244ec180149d201ef3"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "133"
+      - "172"
       X-Request-Id:
-      - 6dae1f0c-6990-4315-b6f8-3354057fb719
+      - 7e196532-6bef-4ac3-9e27-3eb64efbbbd1
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,11 +1748,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IMkaVgTISJ6TkpD8
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_RHRvJ2fmksvZ1yzz
     method: GET
   response:
-    body: '{"task":{"id":"task_IMkaVgTISJ6TkpD8","name":"Stop virtual machine","status":"pending","created_at":1622137313,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_RHRvJ2fmksvZ1yzz","name":"Stop virtual machine","status":"pending","created_at":1674743066,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1284,26 +1760,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "162"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:54 GMT
+      - Thu, 26 Jan 2023 14:24:27 GMT
       Etag:
-      - W/"a1c6fa90ec020c4e1b35a250a2a450af"
+      - W/"3c8f671b66f03488672a96e13ff821da"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "132"
+      - "171"
       X-Request-Id:
-      - 9852a501-5a23-46a0-9660-74ea5427b2a5
+      - f4953c17-3fab-4619-9fba-8c11ddaac3a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1314,11 +1788,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IMkaVgTISJ6TkpD8
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_RHRvJ2fmksvZ1yzz
     method: GET
   response:
-    body: '{"task":{"id":"task_IMkaVgTISJ6TkpD8","name":"Stop virtual machine","status":"pending","created_at":1622137313,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_RHRvJ2fmksvZ1yzz","name":"Stop virtual machine","status":"pending","created_at":1674743066,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1326,26 +1800,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "162"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:41:59 GMT
+      - Thu, 26 Jan 2023 14:24:32 GMT
       Etag:
-      - W/"a1c6fa90ec020c4e1b35a250a2a450af"
+      - W/"3c8f671b66f03488672a96e13ff821da"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "131"
+      - "170"
       X-Request-Id:
-      - b0312f0c-477e-4e09-8adf-39238a330678
+      - 1935a36a-9b81-4025-b437-8d945e93d761
     status: 200 OK
     code: 200
     duration: ""
@@ -1356,11 +1828,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IMkaVgTISJ6TkpD8
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_RHRvJ2fmksvZ1yzz
     method: GET
   response:
-    body: '{"task":{"id":"task_IMkaVgTISJ6TkpD8","name":"Stop virtual machine","status":"completed","created_at":1622137313,"started_at":1622137328,"finished_at":1622137329,"progress":100}}'
+    body: '{"task":{"id":"task_RHRvJ2fmksvZ1yzz","name":"Stop virtual machine","status":"pending","created_at":1674743066,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1368,26 +1840,104 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "178"
+      - "162"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:09 GMT
+      - Thu, 26 Jan 2023 14:24:42 GMT
       Etag:
-      - W/"3e465d49e7094bad875c28796208021a"
+      - W/"3c8f671b66f03488672a96e13ff821da"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "169"
+      X-Request-Id:
+      - 3b6bd875-cecb-443a-bed2-9c72ba1700cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_RHRvJ2fmksvZ1yzz
+    method: GET
+  response:
+    body: '{"task":{"id":"task_RHRvJ2fmksvZ1yzz","name":"Stop virtual machine","status":"running","created_at":1674743066,"started_at":1674743089,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:24:52 GMT
+      Etag:
+      - W/"8e99488218711df0849320d126cd7253"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "168"
+      X-Request-Id:
+      - 24865e8b-dbb9-4dc3-b59e-28ea0569f3b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_RHRvJ2fmksvZ1yzz
+    method: GET
+  response:
+    body: '{"task":{"id":"task_RHRvJ2fmksvZ1yzz","name":"Stop virtual machine","status":"running","created_at":1674743066,"started_at":1674743089,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:25:02 GMT
+      Etag:
+      - W/"8e99488218711df0849320d126cd7253"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "199"
       X-Request-Id:
-      - 20145f31-a6c7-44c7-986b-9ec682c5cff5
+      - 611b746e-8182-4e21-96b6-7262c49f9310
     status: 200 OK
     code: 200
     duration: ""
@@ -1398,19 +1948,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
-    method: DELETE
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_RHRvJ2fmksvZ1yzz
+    method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_jHk4ntIyb47RHh1l","keep_until":1622310129,"object_id":"vm_zjJHuyplZmpEuwrQ","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_zjJHuyplZmpEuwrQ","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq","hostname":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host","fqdn":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1622137293,"initial_root_password":"ALyKoaazUv6RPPaR","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","personal":false,"created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
-      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
-      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_A0Fa4pEhrUIBJiCd","address":"185.199.222.212","reverse_dns":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.212/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zjJHuyplZmpEuwrQ","allocation_type":"VirtualMachine"}]}}'
+    body: '{"task":{"id":"task_RHRvJ2fmksvZ1yzz","name":"Stop virtual machine","status":"running","created_at":1674743066,"started_at":1674743089,"finished_at":null,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1418,26 +1960,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "2651"
+      - "170"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:10 GMT
+      - Thu, 26 Jan 2023 14:25:12 GMT
       Etag:
-      - W/"8fd34b7809e5716674fd65b7dadc9d44"
+      - W/"550f04418380675154bdb6a46319ed19"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "198"
       X-Request-Id:
-      - 32427008-cdb4-477d-a51b-490d135aa71b
+      - ecaf2c4c-34b3-4729-8811-9c22c38476e9
     status: 200 OK
     code: 200
     duration: ""
@@ -1448,8 +1988,96 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_A0Fa4pEhrUIBJiCd
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_RHRvJ2fmksvZ1yzz
+    method: GET
+  response:
+    body: '{"task":{"id":"task_RHRvJ2fmksvZ1yzz","name":"Stop virtual machine","status":"completed","created_at":1674743066,"started_at":1674743089,"finished_at":1674743115,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:25:22 GMT
+      Etag:
+      - W/"0ff6a34054bdec4afc23560d08609986"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "197"
+      X-Request-Id:
+      - 1b1cffa4-d34a-4520-91c0-1a134af7be08
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_kEhO7LdKRfRkQgDD","keep_until":1674915922,"object_id":"vm_JDEtm7UoQGVTKNvy","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_JDEtm7UoQGVTKNvy","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt","hostname":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host","fqdn":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674743006,"initial_root_password":"gZNZcKmShBZcfNjK","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_l6nhRtYivHosZ8wg","address":"185.199.222.207","reverse_dns":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.207/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_JDEtm7UoQGVTKNvy","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2665"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:25:22 GMT
+      Etag:
+      - W/"de8563c92cafc6f336e64e1e6a9d8c2d"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "196"
+      X-Request-Id:
+      - c8881a23-7c69-4065-a23d-b023c7e54d8e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_l6nhRtYivHosZ8wg
     method: POST
   response:
     body: '{}'
@@ -1460,110 +2088,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:10 GMT
+      - Thu, 26 Jan 2023 14:25:23 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "197"
-      X-Request-Id:
-      - 7223bf1f-4453-418f-ba47-f17174c73332
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_jHk4ntIyb47RHh1l
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_BL4ynp3vQF9wsy2c","name":"Purge items from trash","status":"pending","created_at":1622137330,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:42:10 GMT
-      Etag:
-      - W/"f21d5f92bf020adc5caa5078746f35e1"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "200"
-      X-Ratelimit-Remaining:
-      - "196"
-      X-Request-Id:
-      - bcf64820-48e2-4e4f-a31c-ad9d1dfda8a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_BL4ynp3vQF9wsy2c
-    method: GET
-  response:
-    body: '{"task":{"id":"task_BL4ynp3vQF9wsy2c","name":"Purge items from trash","status":"running","created_at":1622137330,"started_at":1622137331,"finished_at":null,"progress":5}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "170"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 27 May 2021 17:42:11 GMT
-      Etag:
-      - W/"4b653886ee284e547285251d943102a5"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "195"
       X-Request-Id:
-      - b148594e-ee12-4363-b7f2-485e3b48a966
+      - 4c27d867-386d-4fc0-a44a-1ff2fe8a7e06
     status: 200 OK
     code: 200
     duration: ""
@@ -1574,11 +2116,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_BL4ynp3vQF9wsy2c
-    method: GET
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_kEhO7LdKRfRkQgDD
+    method: DELETE
   response:
-    body: '{"task":{"id":"task_BL4ynp3vQF9wsy2c","name":"Purge items from trash","status":"completed","created_at":1622137330,"started_at":1622137331,"finished_at":1622137333,"progress":100}}'
+    body: '{"task":{"id":"task_kKyjMLpn4iNcCbDS","name":"Purge items from trash","status":"pending","created_at":1674743123,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1586,26 +2128,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "180"
+      - "164"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:16 GMT
+      - Thu, 26 Jan 2023 14:25:23 GMT
       Etag:
-      - W/"fd72eef3388877f2300130d97d5f16c7"
+      - W/"16ed73e43ee40b8d85e291f4748a99c3"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
       - "194"
       X-Request-Id:
-      - 67b852b1-25c0-4b65-a694-9039cd1c5c2a
+      - ce876964-c30f-4726-aa05-19174891afc6
     status: 200 OK
     code: 200
     duration: ""
@@ -1616,11 +2156,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_mlkldfFbt6ihhTA0
-    method: DELETE
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_kKyjMLpn4iNcCbDS
+    method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_mlkldfFbt6ihhTA0","name":"tf-acc-test-data-source-by-id-lnkpr16xu7pq-group","segregate":true,"created_at":1622137291}}'
+    body: '{"task":{"id":"task_kKyjMLpn4iNcCbDS","name":"Purge items from trash","status":"running","created_at":1674743123,"started_at":1674743123,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1628,26 +2168,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
-      - "156"
+      - "170"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:17 GMT
+      - Thu, 26 Jan 2023 14:25:24 GMT
       Etag:
-      - W/"4ff9effb9e0e6c076fbf1425bf7ae7c0"
+      - W/"152906187de43f3c140cf91ca8528ec0"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "192"
+      - "193"
       X-Request-Id:
-      - d10e5f26-33ae-4f24-bb25-ba89033d01bb
+      - 744ab326-2eee-4581-b281-38c87771693a
     status: 200 OK
     code: 200
     duration: ""
@@ -1658,8 +2196,88 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/0.15.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_A0Fa4pEhrUIBJiCd
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_kKyjMLpn4iNcCbDS
+    method: GET
+  response:
+    body: '{"task":{"id":"task_kKyjMLpn4iNcCbDS","name":"Purge items from trash","status":"completed","created_at":1674743123,"started_at":1674743123,"finished_at":1674743126,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "180"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:25:29 GMT
+      Etag:
+      - W/"720c7cf6dcec0359a5aa358f9fe379dc"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "192"
+      X-Request-Id:
+      - e535aa68-d9f6-4fcb-b380-e98c866f1cfb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_HML99Q0rZSxlkfQc
+    method: DELETE
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_HML99Q0rZSxlkfQc","name":"tf-acc-test-data-source-by-id-fj4sci0ts7pt-group","segregate":true,"created_at":1674743005}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "156"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 14:25:29 GMT
+      Etag:
+      - W/"79cbed6c3fb9f57f59f010636197cd46"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "190"
+      X-Request-Id:
+      - e69f10f9-288e-4d3e-b8ad-8cde8eab83b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_l6nhRtYivHosZ8wg
     method: DELETE
   response:
     body: '{}'
@@ -1670,26 +2288,24 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:17 GMT
+      - Thu, 26 Jan 2023 14:25:29 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "193"
+      - "191"
       X-Request-Id:
-      - cc3ed67b-f968-4daa-9167-1234563caf6e
+      - 41a7f481-1a3f-457a-827d-9175cd186c4a
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,8 +2316,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1713,26 +2329,24 @@ interactions:
       - '*'
       Cache-Control:
       - no-cache
-      Connection:
-      - keep-alive
       Content-Length:
       - "158"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:17 GMT
+      - Thu, 26 Jan 2023 14:25:29 GMT
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "191"
+      - "189"
       X-Request-Id:
-      - 7598a2b2-4c63-4804-8d81-90bfdc2ef76a
+      - f47c8cff-cf85-425c-b0f3-1a9f1a36cca7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1743,8 +2357,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zjJHuyplZmpEuwrQ
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_JDEtm7UoQGVTKNvy
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1756,26 +2370,24 @@ interactions:
       - '*'
       Cache-Control:
       - no-cache
-      Connection:
-      - keep-alive
       Content-Length:
       - "158"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:17 GMT
+      - Thu, 26 Jan 2023 14:25:29 GMT
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "190"
+      - "188"
       X-Request-Id:
-      - 30e9cc73-9a6c-4c63-91ac-829a9525fcfd
+      - 32c9cc81-b72e-4594-9a88-51b4a76aec22
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1786,8 +2398,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.6.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_A0Fa4pEhrUIBJiCd
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_l6nhRtYivHosZ8wg
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -1799,26 +2411,24 @@ interactions:
       - '*'
       Cache-Control:
       - no-cache
-      Connection:
-      - keep-alive
       Content-Length:
       - "151"
       Content-Type:
       - application/json
       Date:
-      - Thu, 27 May 2021 17:42:17 GMT
+      - Thu, 26 Jan 2023 14:25:29 GMT
       Server:
-      - nginx
+      - Caddy
       Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - max-age=63072000; includeSubDomains
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "200"
       X-Ratelimit-Remaining:
-      - "189"
+      - "187"
       X-Request-Id:
-      - f345fa84-c95c-4d54-8a12-4eb906b0d975
+      - 19f61c76-b860-46c8-9a16-3569b61be010
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
The `network_speed_profile` field was always empty, as we never performed the
require lookups to populate it during the data source read operation.