### PR TITLE
feat(resource/virtual_machine): add support for setting number and size of disks during creation

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -47,6 +47,17 @@ resource "katapult_virtual_machine" "base" {
     install_agent = true
   }
 
+  # First defined disk becomes the boot disk that the OS is installed on.
+  disk {
+    name = "System Disk" # Optional
+    size = 20            # GB
+  }
+
+  disk {
+    name = "Data" # Optional
+    size = 100    # GB
+  }
+
   ip_address_ids = [
     katapult_ip.web-2.id,
     katapult_ip.web-2-internal.id
@@ -70,6 +81,7 @@ resource "katapult_virtual_machine" "base" {
 ### Optional
 
 - `description` (String)
+- `disk` (Block List) Specify one or more disks with custom sizes to create and attach to the Virtual Machine during creation. First defined disk will be used as the boot disk. If no disks are defined, a single disk will be created based on the chosen package. (see [below for nested schema](#nestedblock--disk))
 - `disk_template_options` (Map of String)
 - `group_id` (String)
 - `hostname` (String)
@@ -84,6 +96,18 @@ resource "katapult_virtual_machine" "base" {
 - `id` (String) The ID of this resource.
 - `ip_addresses` (Set of String)
 - `state` (String)
+
+<a id="nestedblock--disk"></a>
+### Nested Schema for `disk`
+
+Required:
+
+- `size` (Number) Size of the disk in GB.
+
+Optional:
+
+- `name` (String) Name of the disk.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/examples/resources/katapult_virtual_machine/resource.tf
+++ b/examples/resources/katapult_virtual_machine/resource.tf
@@ -32,6 +32,17 @@ resource "katapult_virtual_machine" "base" {
     install_agent = true
   }
 
+  # First defined disk becomes the boot disk that the OS is installed on.
+  disk {
+    name = "System Disk" # Optional
+    size = 20            # GB
+  }
+
+  disk {
+    name = "Data" # Optional
+    size = 100    # GB
+  }
+
   ip_address_ids = [
     katapult_ip.web-2.id,
     katapult_ip.web-2-internal.id

--- a/internal/provider/data_source_virtual_machine.go
+++ b/internal/provider/data_source_virtual_machine.go
@@ -20,6 +20,9 @@ func dataSourceVirtualMachine() *schema.Resource {
 
 	ds["fqdn"].Optional = true
 
+	// Remove creation-only fields which cannot be read back from the API.
+	delete(ds, "disk")
+
 	return &schema.Resource{
 		ReadContext: dataSourceVirtualMachineRead,
 		Schema:      ds,

--- a/internal/provider/testdata/VirtualMachine_custom_disks.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_custom_disks.cassette.rand_id
@@ -1,0 +1,1 @@
+mj1luon2gbp9

--- a/internal/provider/testdata/VirtualMachine_custom_disks.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_custom_disks.cassette.yaml
@@ -1,0 +1,2005 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
+    method: GET
+  response:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "181"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "183"
+      X-Request-Id:
+      - 17dc48af-9510-4450-b18b-0e0385c943f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
+    method: GET
+  response:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "181"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "183"
+      X-Request-Id:
+      - 10d665bd-f9ae-4b91-bb1f-79189aeeaa49
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
+    method: POST
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"0558b62dcbb2e0d913f7121c78dd1272"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "182"
+      X-Request-Id:
+      - 93ccaf38-46a2-4893-bda1-a173b44e4b2e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_b3kgNzr7Smx5Q3KU
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"0558b62dcbb2e0d913f7121c78dd1272"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "178"
+      X-Request-Id:
+      - babf034f-c723-4299-8d45-db4c1483aa6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"185-199-222-184.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "552"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"ba25ffdf74f560ea607b8a94ee417a64"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "180"
+      X-Request-Id:
+      - bc6e270b-2d78-4b00-9930-73da4e084a6a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"185-199-222-71.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "549"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"078baf5965609c6d5114ba416ace9443"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "179"
+      X-Request-Id:
+      - 44843768-a1ae-4492-824f-1f972aec6620
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Mlg4rRK50cDs2ZT5
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"185-199-222-184.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"a10b306dfe649e3a1c45d0e085fe0fc0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "177"
+      X-Request-Id:
+      - d5b22d1a-3561-43f2-848d-f60add48a7e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h2uLGUVZLOilCIBo
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"185-199-222-71.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "567"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"f759eeea69ce05052326c0d3b29a9b00"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "176"
+      X-Request-Id:
+      - 4552470b-5008-4cf9-b55b-82d1e9370d1a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Mlg4rRK50cDs2ZT5
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"185-199-222-184.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"a10b306dfe649e3a1c45d0e085fe0fc0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "175"
+      X-Request-Id:
+      - 7fca0257-c00c-4152-ba92-896537a87379
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h2uLGUVZLOilCIBo
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"185-199-222-71.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "567"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"f759eeea69ce05052326c0d3b29a9b00"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "174"
+      X-Request-Id:
+      - 1ddd3348-e1ed-41f3-b69e-4dd215528c9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><SystemDisks><Disk><Name>System</Name><Size>20</Size></Disk><Disk><Name>Data</Name><Size>10</Size></Disk><Disk><Name>Disk #3</Name><Size>10</Size></Disk></SystemDisks><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_Mlg4rRK50cDs2ZT5</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_h2uLGUVZLOilCIBo</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-custom-disks-mj1luon2gbp9-host</Hostname></Hostname><Name>tf-acc-test-custom-disks-mj1luon2gbp9</Name><Description>A web server.</Description><Group>vmgrp_b3kgNzr7Smx5Q3KU</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
+    method: POST
+  response:
+    body: '{"task":{"id":"task_0IMH8vUJ63QZWWs9","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_1aTRaU7V6RnrjAKB","state":"pending"},"virtual_machine_build":{"id":"vmbuild_1aTRaU7V6RnrjAKB","state":"pending"},"hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host"}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "281"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:43 GMT
+      Etag:
+      - W/"c4799fef6226a9adc5d57af761937778"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "173"
+      X-Request-Id:
+      - c4b6eaaf-6b06-44e4-b3f3-a4d693342a63
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_1aTRaU7V6RnrjAKB
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_1aTRaU7V6RnrjAKB","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
+      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.184\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-mj1luon2gbp9-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-mj1luon2gbp9\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_b3kgNzr7Smx5Q3KU\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"pending","virtual_machine":null,"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2430"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:45 GMT
+      Etag:
+      - W/"3244562e516a91840d827a06fa2026b0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "172"
+      X-Request-Id:
+      - 96858188-51d2-4ff5-a7b7-c671e5ebb66c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_1aTRaU7V6RnrjAKB
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_1aTRaU7V6RnrjAKB","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
+      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.184\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-mj1luon2gbp9-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-mj1luon2gbp9\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_b3kgNzr7Smx5Q3KU\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"pending","virtual_machine":null,"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2430"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:00:50 GMT
+      Etag:
+      - W/"3244562e516a91840d827a06fa2026b0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "171"
+      X-Request-Id:
+      - 7ec17a44-15c1-436c-8731-1da5a890ae57
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_1aTRaU7V6RnrjAKB
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_1aTRaU7V6RnrjAKB","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
+      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.184\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-mj1luon2gbp9-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-mj1luon2gbp9\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_b3kgNzr7Smx5Q3KU\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2662"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:00 GMT
+      Etag:
+      - W/"a3327ffcc9e0aa298575c8077c3bb754"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "199"
+      X-Request-Id:
+      - ce0d2764-33e2-4704-a392-794648a13946
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_1aTRaU7V6RnrjAKB
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_1aTRaU7V6RnrjAKB","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
+      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.184\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-mj1luon2gbp9-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-mj1luon2gbp9\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_b3kgNzr7Smx5Q3KU\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2662"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:10 GMT
+      Etag:
+      - W/"a3327ffcc9e0aa298575c8077c3bb754"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "198"
+      X-Request-Id:
+      - 3928e136-b738-4413-8630-7ce0004787e0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_1aTRaU7V6RnrjAKB
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_1aTRaU7V6RnrjAKB","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
+      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.184\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-mj1luon2gbp9-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-mj1luon2gbp9\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_b3kgNzr7Smx5Q3KU\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2662"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:20 GMT
+      Etag:
+      - W/"13f94201c8a76378fe570cab2aa06c65"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "197"
+      X-Request-Id:
+      - b127cb39-2b3e-45b6-8e4f-f34c9d1d4f55
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC"},"properties":{"tag_names":["web","public"]}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
+  response:
+    body: '{"virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674745254,"initial_root_password":"K3iDzZAX0qJwDxVT","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "3111"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:20 GMT
+      Etag:
+      - W/"042cadb47152013b2615e342d13eef36"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "196"
+      X-Request-Id:
+      - 4fef35e7-f66f-4485-9a7c-ce034757f34c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674745254,"initial_root_password":"K3iDzZAX0qJwDxVT","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "3111"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:22 GMT
+      Etag:
+      - W/"042cadb47152013b2615e342d13eef36"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "195"
+      X-Request-Id:
+      - 31c5aa86-c931-4b22-83c4-05e1dab3d990
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674745254,"initial_root_password":"K3iDzZAX0qJwDxVT","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "3111"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:22 GMT
+      Etag:
+      - W/"042cadb47152013b2615e342d13eef36"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "194"
+      X-Request-Id:
+      - f766d314-ac55-4803-b613-ff4361b78920
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_RwZa0pPGqpfTyo4W","name":"Public
+      Network on tf-acc-test-custom-disks-mj1luon2gbp9","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "421"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:22 GMT
+      Etag:
+      - W/"2d90e1efaec3b6a84985e132b36ab916"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "193"
+      X-Request-Id:
+      - e8f2df42-7435-4035-a767-400293097eb6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_RwZa0pPGqpfTyo4W
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_RwZa0pPGqpfTyo4W","virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9"},"name":"Public
+      Network on tf-acc-test-custom-disks-mj1luon2gbp9","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:96:59:b6:a3:31","state":"attached","ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:22 GMT
+      Etag:
+      - W/"9eb266c2a54b3806d8be82dbe7d35d87"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "192"
+      X-Request-Id:
+      - 1f647fbe-9071-4604-ad79-e3316e3dec03
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674745254,"initial_root_password":"K3iDzZAX0qJwDxVT","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "3111"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:23 GMT
+      Etag:
+      - W/"042cadb47152013b2615e342d13eef36"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "191"
+      X-Request-Id:
+      - 2d1d419d-5110-4c5a-8250-a99360429ab3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_b3kgNzr7Smx5Q3KU
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:23 GMT
+      Etag:
+      - W/"0558b62dcbb2e0d913f7121c78dd1272"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "190"
+      X-Request-Id:
+      - df744aee-2462-450f-a0c3-fbefa1d592c3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h2uLGUVZLOilCIBo
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "743"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:23 GMT
+      Etag:
+      - W/"eed8a3b9acf08e813dbc5d47bc7d168f"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "189"
+      X-Request-Id:
+      - dbfcc6ff-58f0-4e69-bbe3-824ebe39cb2b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Mlg4rRK50cDs2ZT5
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "745"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:23 GMT
+      Etag:
+      - W/"ab35db44dc53102b7401361c0aefeb32"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "188"
+      X-Request-Id:
+      - 103d270e-4316-4336-acfd-f0568232d408
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674745254,"initial_root_password":"K3iDzZAX0qJwDxVT","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "3111"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:23 GMT
+      Etag:
+      - W/"042cadb47152013b2615e342d13eef36"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "187"
+      X-Request-Id:
+      - 0fa110e6-8237-4952-bdc6-f68d5776a165
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_RwZa0pPGqpfTyo4W","name":"Public
+      Network on tf-acc-test-custom-disks-mj1luon2gbp9","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "421"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:23 GMT
+      Etag:
+      - W/"2d90e1efaec3b6a84985e132b36ab916"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "186"
+      X-Request-Id:
+      - 5bc13af5-8bc0-4d97-949e-3295cb54a45d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_RwZa0pPGqpfTyo4W
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_RwZa0pPGqpfTyo4W","virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9"},"name":"Public
+      Network on tf-acc-test-custom-disks-mj1luon2gbp9","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:96:59:b6:a3:31","state":"attached","ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:23 GMT
+      Etag:
+      - W/"9eb266c2a54b3806d8be82dbe7d35d87"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "185"
+      X-Request-Id:
+      - 2a427afe-48e1-448d-b646-c27cf8186f5e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674745254,"initial_root_password":"K3iDzZAX0qJwDxVT","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "3111"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:24 GMT
+      Etag:
+      - W/"042cadb47152013b2615e342d13eef36"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "184"
+      X-Request-Id:
+      - 1bf74289-1bb8-480b-b3f9-ca4e44ee867d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: POST
+  response:
+    body: '{"task":{"id":"task_8zcEjjNNqqbMR8ow","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:24 GMT
+      Etag:
+      - W/"e6620ace34eaa848cca6b9b0de11105d"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "183"
+      X-Request-Id:
+      - 7cbf9df2-9f86-46b0-a1aa-ffd3337d9fe1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_8zcEjjNNqqbMR8ow
+    method: GET
+  response:
+    body: '{"task":{"id":"task_8zcEjjNNqqbMR8ow","name":"Stop virtual machine","status":"pending","created_at":1674745284,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:25 GMT
+      Etag:
+      - W/"2a7503d2df92ec893c5c9ee0f49c173b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "182"
+      X-Request-Id:
+      - b32b9b04-39f6-4fbe-a097-61c6d632b44c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_8zcEjjNNqqbMR8ow
+    method: GET
+  response:
+    body: '{"task":{"id":"task_8zcEjjNNqqbMR8ow","name":"Stop virtual machine","status":"running","created_at":1674745284,"started_at":1674745285,"finished_at":null,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:30 GMT
+      Etag:
+      - W/"46739fc042a2246f9b0c4ab6bae8a89e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "181"
+      X-Request-Id:
+      - d56b911b-847e-4812-8e63-bf5f38854022
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_8zcEjjNNqqbMR8ow
+    method: GET
+  response:
+    body: '{"task":{"id":"task_8zcEjjNNqqbMR8ow","name":"Stop virtual machine","status":"completed","created_at":1674745284,"started_at":1674745285,"finished_at":1674745290,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:40 GMT
+      Etag:
+      - W/"98c6860b407a514d1e4b6d6002326e71"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "180"
+      X-Request-Id:
+      - a49694f6-bbbf-48ea-9cf3-76cad20805ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_8tHBBSRTKX1FDZmm","keep_until":1674918100,"object_id":"vm_qlPkfTNv5NkTcUfC","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_qlPkfTNv5NkTcUfC","name":"tf-acc-test-custom-disks-mj1luon2gbp9","hostname":"tf-acc-test-custom-disks-mj1luon2gbp9-host","fqdn":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1674745254,"initial_root_password":"K3iDzZAX0qJwDxVT","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"Kemp
+      House","address2":"152 - 160 City Road","address3":"London","address4":null,"postcode":"EC1V
+      2NX","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_h2uLGUVZLOilCIBo","address":"185.199.222.71","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.71/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"},{"id":"ip_Mlg4rRK50cDs2ZT5","address":"185.199.222.184","reverse_dns":"tf-acc-test-custom-disks-mj1luon2gbp9-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.184/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qlPkfTNv5NkTcUfC","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "3246"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:40 GMT
+      Etag:
+      - W/"953c95038cbffcbf2e060f1560fe5ae4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "179"
+      X-Request-Id:
+      - c91bf851-7833-438f-b986-5d9e496e2f4d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Mlg4rRK50cDs2ZT5
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:40 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "178"
+      X-Request-Id:
+      - df3ca97d-3cbd-4fac-867a-915c36ad69b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_h2uLGUVZLOilCIBo
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:40 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "177"
+      X-Request-Id:
+      - b9271f0b-0a92-4947-a10c-5c0ee837f5f0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_8tHBBSRTKX1FDZmm
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_CdGcoJ9sW5ULNqFQ","name":"Purge items from trash","status":"pending","created_at":1674745301,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:41 GMT
+      Etag:
+      - W/"d685e6e21c880f11ed97e5ca07f8f372"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "176"
+      X-Request-Id:
+      - bfec797b-c538-4b5b-806d-6051ff946576
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_CdGcoJ9sW5ULNqFQ
+    method: GET
+  response:
+    body: '{"task":{"id":"task_CdGcoJ9sW5ULNqFQ","name":"Purge items from trash","status":"running","created_at":1674745301,"started_at":1674745301,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:42 GMT
+      Etag:
+      - W/"8db109f98dfdf102c4a4ae86a3c24911"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "175"
+      X-Request-Id:
+      - 41581afd-d855-4380-b2ac-f639820345fe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_CdGcoJ9sW5ULNqFQ
+    method: GET
+  response:
+    body: '{"task":{"id":"task_CdGcoJ9sW5ULNqFQ","name":"Purge items from trash","status":"running","created_at":1674745301,"started_at":1674745301,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "170"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:47 GMT
+      Etag:
+      - W/"8db109f98dfdf102c4a4ae86a3c24911"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "174"
+      X-Request-Id:
+      - fd8fc747-3cdb-4779-9ac0-ff42522168d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_CdGcoJ9sW5ULNqFQ
+    method: GET
+  response:
+    body: '{"task":{"id":"task_CdGcoJ9sW5ULNqFQ","name":"Purge items from trash","status":"completed","created_at":1674745301,"started_at":1674745301,"finished_at":1674745307,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "180"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:57 GMT
+      Etag:
+      - W/"02f1d8f8e485e3e6a917db24d3601c9c"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "173"
+      X-Request-Id:
+      - bb6b2acd-1304-4b7c-9c22-9d448bcd00d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_b3kgNzr7Smx5Q3KU
+    method: DELETE
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_b3kgNzr7Smx5Q3KU","name":"tf-acc-test-custom-disks-mj1luon2gbp9-group","segregate":true,"created_at":1674745243}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:57 GMT
+      Etag:
+      - W/"0558b62dcbb2e0d913f7121c78dd1272"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "172"
+      X-Request-Id:
+      - 0730797c-d005-4862-8d38-93b02eeacaec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h2uLGUVZLOilCIBo
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:57 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "172"
+      X-Request-Id:
+      - 4c60f8e9-6f91-434e-b33c-ca0ac9a1f449
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Mlg4rRK50cDs2ZT5
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:57 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "170"
+      X-Request-Id:
+      - 5be2a5e0-a32f-4245-a513-1eabd6bac44a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qlPkfTNv5NkTcUfC
+    method: GET
+  response:
+    body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
+      machine was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:57 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "169"
+      X-Request-Id:
+      - 8bbc488e-cd97-45db-a474-76e6b6dc5084
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Mlg4rRK50cDs2ZT5
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:57 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "168"
+      X-Request-Id:
+      - 73bddfcc-342e-4788-a10d-4bf7eac1c58a
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_h2uLGUVZLOilCIBo
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 26 Jan 2023 15:01:57 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "200"
+      X-Ratelimit-Remaining:
+      - "167"
+      X-Request-Id:
+      - 2b1214e8-85f7-44e5-a9fb-8d0c971ad1b3
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
Adds a repeatable `disk` block with `name` and `size` fields which are used to
define what disks should be created and attached to the VM during creation.

Due to this not being a full disk resource implementation, but a creation-only
property of virtual machines, any changes to disk blocks after VM creation will
make Terraform want to replace the whole VM.

Fully managing disks as separate resources is planned, but out of scope of this
change.