### PR TITLE
chore(destroy): more reliably wait for trash objects to be removed

### DIFF
--- a/internal/provider/resource_virtual_machine_test.go
+++ b/internal/provider/resource_virtual_machine_test.go
@@ -997,10 +997,29 @@ func testAccCheckKatapultVirtualMachineDestroy(
 			vm, _, err := m.Core.VirtualMachines.GetByID(
 				tt.Ctx, rs.Primary.ID,
 			)
-			if err == nil && vm != nil {
+			if !errors.Is(err, katapult.ErrNotFound) {
+				if err != nil {
+					return err
+				}
+
 				return fmt.Errorf(
 					"katapult_virtual_machine %s (%s) was not destroyed",
 					rs.Primary.ID, vm.Name,
+				)
+			}
+
+			_, _, err = m.Core.TrashObjects.GetByObjectID(
+				tt.Ctx, rs.Primary.ID,
+			)
+			if !errors.Is(err, katapult.ErrNotFound) {
+				if err != nil {
+					return err
+				}
+
+				return fmt.Errorf(
+					"katapult_virtual_machine %s was deleted, but not "+
+						"purged from trash",
+					rs.Primary.ID,
 				)
 			}
 		}

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.rand_id
@@ -1,1 +1,1 @@
-n4qxaic67vkx
+lhrxoro9urjt

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.yaml
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,15 +35,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "999"
       X-Request-Id:
-      - 5c5df44c-315c-4013-8b04-2ecf0f6ea243
+      - 41d5a6de-562c-4c8e-824e-c394047ebc87
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -68,9 +68,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"f3562f85cf3113f21950627cb989f016"
+      - W/"3aa59d4b7a06da3f35b1f4fd9db03103"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -78,9 +78,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "996"
       X-Request-Id:
-      - ff4fb0ea-f495-434e-a8d6-a3d74f522e2f
+      - 679bfc9f-2ce3-4e80-8a83-6231b4ef62ea
     status: 200 OK
     code: 200
     duration: ""
@@ -92,10 +92,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_6LP3CXeQiErnlKtb
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_epkzgGMC28Ql10Ye
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -108,9 +108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"f3562f85cf3113f21950627cb989f016"
+      - W/"3aa59d4b7a06da3f35b1f4fd9db03103"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "918"
+      - "992"
       X-Request-Id:
-      - 747dd876-2ea4-41fe-8791-ae5f287e05ba
+      - bd03fab2-6fab-4692-919d-4b0a741250ae
     status: 200 OK
     code: 200
     duration: ""
@@ -138,7 +138,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"185-199-222-66.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -153,9 +153,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"f5b290483afbe49e6053cffa2935d095"
+      - W/"70ae5cda48cd0cdf599bd81704faa419"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -163,9 +163,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "919"
+      - "995"
       X-Request-Id:
-      - c1de0efa-19b9-4825-b792-58aae85e83b0
+      - c76ed4c3-2dc6-452e-a02c-65e276a14aa0
     status: 200 OK
     code: 200
     duration: ""
@@ -177,10 +177,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_cpzb9l4zG2oY6zlg
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"185-199-222-66.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -195,9 +195,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"b5682d7f3798ee5bdad1c0a13a48a49f"
+      - W/"7367639e17424126d908b7a96b17219f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -205,9 +205,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "991"
       X-Request-Id:
-      - f6262f33-9c1a-4578-990a-86e5df0437e5
+      - fa1c456c-ae6d-4163-984f-70b1f0048916
     status: 200 OK
     code: 200
     duration: ""
@@ -219,10 +219,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_cpzb9l4zG2oY6zlg
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"185-199-222-66.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -237,9 +237,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"b5682d7f3798ee5bdad1c0a13a48a49f"
+      - W/"7367639e17424126d908b7a96b17219f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -247,15 +247,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "916"
+      - "990"
       X-Request-Id:
-      - 9223a18f-d98a-45a7-a2a7-a59d99f528d6
+      - 16bfdaf0-f7d7-4393-849d-e657fbb54949
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_cpzb9l4zG2oY6zlg</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-fqdn-n4qxaic67vkx</Name><Description>A web server.</Description><Group>vmgrp_6LP3CXeQiErnlKtb</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_2bjWpH3KQBlrSjJ0</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-fqdn-lhrxoro9urjt</Name><Description>A web server.</Description><Group>vmgrp_epkzgGMC28Ql10Ye</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -267,7 +267,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_VBk5z9cDGNsBrt3h","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_23aaavjH4uY9g7Nw","state":"pending"},"virtual_machine_build":{"id":"vmbuild_23aaavjH4uY9g7Nw","state":"pending"},"hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host"}'
+    body: '{"task":{"id":"task_6KxGAMwtLPwkMWA2","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_vwhbeHoe7VoFrCkk","state":"pending"},"virtual_machine_build":{"id":"vmbuild_vwhbeHoe7VoFrCkk","state":"pending"},"hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -280,9 +280,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"8692aa2655649d6d7b063b490b554131"
+      - W/"fc4a0e98c74e9105353a535f7f8453e4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -290,9 +290,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "915"
+      - "989"
       X-Request-Id:
-      - d81cd9df-5cd9-4ded-974a-e03588e308ce
+      - cec54c84-1148-4e8c-9f7c-b48c229e72a1
     status: 201 Created
     code: 201
     duration: ""
@@ -304,18 +304,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_23aaavjH4uY9g7Nw
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_vwhbeHoe7VoFrCkk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_23aaavjH4uY9g7Nw","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_vwhbeHoe7VoFrCkk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.66\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-n4qxaic67vkx\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_6LP3CXeQiErnlKtb\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-lhrxoro9urjt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_epkzgGMC28Ql10Ye\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031309}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -324,13 +324,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2058"
+      - "1806"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:11 GMT
+      - Thu, 23 Mar 2023 10:57:05 GMT
       Etag:
-      - W/"4fec24e873749f4c7ec0092d34683f08"
+      - W/"f99a26982df64b82ec042d6e6417d860"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -338,9 +338,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "903"
+      - "985"
       X-Request-Id:
-      - fcf1081c-efc8-4b9a-91fb-6ba7b7cbdd86
+      - e599f535-17b6-4d2d-8fb2-ba5e1fc9be06
     status: 200 OK
     code: 200
     duration: ""
@@ -352,18 +352,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_23aaavjH4uY9g7Nw
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_vwhbeHoe7VoFrCkk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_23aaavjH4uY9g7Nw","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_vwhbeHoe7VoFrCkk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.66\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-n4qxaic67vkx\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_6LP3CXeQiErnlKtb\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-lhrxoro9urjt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_epkzgGMC28Ql10Ye\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031309}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -376,9 +376,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:16 GMT
+      - Thu, 23 Mar 2023 10:57:10 GMT
       Etag:
-      - W/"4fec24e873749f4c7ec0092d34683f08"
+      - W/"734c06ba9345670e46db6353b6046b1a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -386,9 +386,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "896"
+      - "983"
       X-Request-Id:
-      - f60d20be-a905-4c8a-ba98-94bb28e1cc8a
+      - b3c57c32-99db-4542-b3af-580d48671ad7
     status: 200 OK
     code: 200
     duration: ""
@@ -400,18 +400,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_23aaavjH4uY9g7Nw
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_vwhbeHoe7VoFrCkk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_23aaavjH4uY9g7Nw","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_vwhbeHoe7VoFrCkk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.66\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-n4qxaic67vkx\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_6LP3CXeQiErnlKtb\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-lhrxoro9urjt\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_epkzgGMC28Ql10Ye\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1676031309}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -420,13 +420,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2058"
+      - "2059"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:27 GMT
+      - Thu, 23 Mar 2023 10:57:20 GMT
       Etag:
-      - W/"b705d404d336bf35a15874af81a42065"
+      - W/"4bbe5cbf1003836a239fdbc4458068bf"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -434,15 +434,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "881"
+      - "981"
       X-Request-Id:
-      - 7e7a1a57-5da1-47bb-9252-2c8dc58184b0
+      - 28fbcd96-69f2-4646-9875-6ea2de2d2321
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -454,15 +454,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -471,13 +471,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2594"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:27 GMT
+      - Thu, 23 Mar 2023 10:57:20 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"3a5ae88153ca6c173a454c434b82a634"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -485,9 +485,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "880"
+      - "980"
       X-Request-Id:
-      - 81851267-3d4f-4da5-977a-e5ef76182dc3
+      - fbd95dbf-1ce3-44d0-aa88-4591477a5047
     status: 200 OK
     code: 200
     duration: ""
@@ -499,18 +499,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -519,13 +519,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:22 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -533,9 +533,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "877"
+      - "977"
       X-Request-Id:
-      - 9815e449-9b9d-4ab5-8430-888eaec69814
+      - 68bf70db-ddf2-42da-b582-8e649382345b
     status: 200 OK
     code: 200
     duration: ""
@@ -547,18 +547,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -567,13 +567,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:22 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -581,9 +581,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "876"
+      - "976"
       X-Request-Id:
-      - 4febe658-0edc-49ea-acf2-5adac31f0bee
+      - cb85345c-2e7f-4dd4-bd13-6e085c2bbeb4
     status: 200 OK
     code: 200
     duration: ""
@@ -595,12 +595,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_OGFqYBR7SJD6CQeA","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jHwHRbUSdabba0OA","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -613,9 +613,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:22 GMT
       Etag:
-      - W/"2561946ae886f44e209f58fa8aeb51ee"
+      - W/"ae837f4be080bfe4999d4dd7f0e0b49b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -623,9 +623,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "875"
+      - "975"
       X-Request-Id:
-      - be7e5763-5df3-47de-bf22-961e492d40be
+      - 02ee8750-7038-49ff-9cf9-cfe98153af5d
     status: 200 OK
     code: 200
     duration: ""
@@ -637,12 +637,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_OGFqYBR7SJD6CQeA
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jHwHRbUSdabba0OA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_OGFqYBR7SJD6CQeA","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:9d:c0:65:10","state":"attached","ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_jHwHRbUSdabba0OA","virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ea:75:d8:38:71","state":"_none","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -651,13 +651,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "514"
+      - "511"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:22 GMT
       Etag:
-      - W/"5c5fdffd4f1bc49197738a86ae3c40a9"
+      - W/"49db568a35438a599399661a6162d356"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -665,9 +665,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "874"
+      - "974"
       X-Request-Id:
-      - 9e8e82f2-15e6-45ae-b2a3-28b6d7ba21fd
+      - 42563326-65f0-4f12-9540-56c974e8004b
     status: 200 OK
     code: 200
     duration: ""
@@ -679,18 +679,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -699,13 +699,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:22 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -713,9 +713,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "873"
+      - "972"
       X-Request-Id:
-      - d522ad84-b65f-4321-bb92-76e1dbe3a3bb
+      - fc703299-88a7-4f1c-9cc3-11beaa08cb76
     status: 200 OK
     code: 200
     duration: ""
@@ -727,12 +727,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_OGFqYBR7SJD6CQeA","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jHwHRbUSdabba0OA","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -745,9 +745,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:22 GMT
       Etag:
-      - W/"2561946ae886f44e209f58fa8aeb51ee"
+      - W/"ae837f4be080bfe4999d4dd7f0e0b49b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -755,9 +755,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "872"
+      - "971"
       X-Request-Id:
-      - 02972598-dc73-4c8b-ab6c-ff8cee480264
+      - a397a199-1aeb-4157-be0d-392a539a26b4
     status: 200 OK
     code: 200
     duration: ""
@@ -769,12 +769,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_OGFqYBR7SJD6CQeA
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jHwHRbUSdabba0OA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_OGFqYBR7SJD6CQeA","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:9d:c0:65:10","state":"attached","ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_jHwHRbUSdabba0OA","virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ea:75:d8:38:71","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -787,9 +787,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"5c5fdffd4f1bc49197738a86ae3c40a9"
+      - W/"12204db984c217ebaf23e6157681e3e4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -797,9 +797,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "871"
+      - "970"
       X-Request-Id:
-      - 53353f75-d774-42f5-a14a-2fa22390255a
+      - f12018c2-16c7-409a-8e34-5598bed50dcf
     status: 200 OK
     code: 200
     duration: ""
@@ -811,18 +811,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -831,13 +831,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -845,9 +845,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "870"
+      - "969"
       X-Request-Id:
-      - ece5c04e-6de6-43a1-a320-00a4a1c10506
+      - f052bb8a-f643-43cb-906a-c401e3897f6c
     status: 200 OK
     code: 200
     duration: ""
@@ -859,18 +859,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -879,13 +879,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -893,9 +893,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "869"
+      - "968"
       X-Request-Id:
-      - 0487328e-4159-46b1-a88f-b9f2df6ee8dc
+      - 5cb14e49-ecc1-4d78-b871-179668a22b12
     status: 200 OK
     code: 200
     duration: ""
@@ -907,12 +907,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_OGFqYBR7SJD6CQeA","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jHwHRbUSdabba0OA","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -925,9 +925,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"2561946ae886f44e209f58fa8aeb51ee"
+      - W/"ae837f4be080bfe4999d4dd7f0e0b49b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -935,9 +935,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "868"
+      - "967"
       X-Request-Id:
-      - bb962051-608d-4b6d-a2b9-ab3b75d46f90
+      - c7c734fa-70d2-4bcb-835c-a9076bc98b98
     status: 200 OK
     code: 200
     duration: ""
@@ -949,12 +949,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_OGFqYBR7SJD6CQeA
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jHwHRbUSdabba0OA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_OGFqYBR7SJD6CQeA","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:9d:c0:65:10","state":"attached","ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_jHwHRbUSdabba0OA","virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ea:75:d8:38:71","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -967,9 +967,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"5c5fdffd4f1bc49197738a86ae3c40a9"
+      - W/"12204db984c217ebaf23e6157681e3e4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -977,9 +977,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "867"
+      - "966"
       X-Request-Id:
-      - e3369a51-3e7d-42b8-882b-40cc264fb03c
+      - 1dbe6991-6249-484c-9be8-e9e2575c1207
     status: 200 OK
     code: 200
     duration: ""
@@ -991,12 +991,52 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_cpzb9l4zG2oY6zlg
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_epkzgGMC28Ql10Ye
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"virtual_machine_group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "158"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:57:23 GMT
+      Etag:
+      - W/"3aa59d4b7a06da3f35b1f4fd9db03103"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 04446dd3-0bea-4147-9dd6-9c907d1e2716
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1009,9 +1049,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"bcf436feb6ed08fba337ebfcef299d42"
+      - W/"4f3650afdc9053f5917406691b048a34"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1019,9 +1059,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "866"
+      - "965"
       X-Request-Id:
-      - d07c52ca-594c-4cff-8bd2-a0c2d519f4fc
+      - 7a48a167-05ab-4b06-9b0b-a978716e29d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1033,58 +1073,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_6LP3CXeQiErnlKtb
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "158"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
-      Etag:
-      - W/"f3562f85cf3113f21950627cb989f016"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "865"
-      X-Request-Id:
-      - 9dacefca-32cd-45a5-9c60-5f11fcedcd31
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1093,13 +1093,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1107,9 +1107,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "864"
+      - "963"
       X-Request-Id:
-      - 76004873-fe46-4229-829e-0b3639889ada
+      - 03793d20-2521-42bd-8592-8f235fa09f16
     status: 200 OK
     code: 200
     duration: ""
@@ -1121,12 +1121,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_OGFqYBR7SJD6CQeA","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jHwHRbUSdabba0OA","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1139,9 +1139,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:29 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"2561946ae886f44e209f58fa8aeb51ee"
+      - W/"ae837f4be080bfe4999d4dd7f0e0b49b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1149,9 +1149,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "863"
+      - "962"
       X-Request-Id:
-      - d475e59f-527b-4320-8fc5-73a1f964af6b
+      - 350e8560-69b3-406d-9218-aa3c9b602aa6
     status: 200 OK
     code: 200
     duration: ""
@@ -1163,12 +1163,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_OGFqYBR7SJD6CQeA
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jHwHRbUSdabba0OA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_OGFqYBR7SJD6CQeA","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:9d:c0:65:10","state":"attached","ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_jHwHRbUSdabba0OA","virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ea:75:d8:38:71","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1181,9 +1181,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"5c5fdffd4f1bc49197738a86ae3c40a9"
+      - W/"12204db984c217ebaf23e6157681e3e4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1191,9 +1191,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "862"
+      - "961"
       X-Request-Id:
-      - 7cc30e52-355a-4a57-aa5e-29953d9d4ca1
+      - cb497ec7-f9cd-44d3-8b61-70906d8e2099
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,18 +1205,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1225,13 +1225,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1239,9 +1239,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "861"
+      - "960"
       X-Request-Id:
-      - d67b0f11-a8cc-4a8b-90c9-935b174d9fc9
+      - e85e91d4-fa30-48e9-829a-3d9eb63ff9bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1253,12 +1253,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_OGFqYBR7SJD6CQeA","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jHwHRbUSdabba0OA","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1271,9 +1271,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"2561946ae886f44e209f58fa8aeb51ee"
+      - W/"ae837f4be080bfe4999d4dd7f0e0b49b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1281,9 +1281,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "860"
+      - "959"
       X-Request-Id:
-      - b412cfc3-3c22-4c48-83f8-b3b616cfce5b
+      - aea23221-a912-4afb-9762-b35e78c6a508
     status: 200 OK
     code: 200
     duration: ""
@@ -1295,12 +1295,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_OGFqYBR7SJD6CQeA
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jHwHRbUSdabba0OA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_OGFqYBR7SJD6CQeA","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:9d:c0:65:10","state":"attached","ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_jHwHRbUSdabba0OA","virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ea:75:d8:38:71","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1313,9 +1313,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"5c5fdffd4f1bc49197738a86ae3c40a9"
+      - W/"12204db984c217ebaf23e6157681e3e4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1323,9 +1323,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "859"
+      - "958"
       X-Request-Id:
-      - ee6f244b-6891-4b7a-b5b6-ca49a514abde
+      - 12af8cc0-bb68-411d-8125-7dd8fdb6996b
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,18 +1337,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1357,13 +1357,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1371,9 +1371,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "858"
+      - "957"
       X-Request-Id:
-      - 19fc1fe0-d8c9-4691-9898-8f9d2aee269e
+      - 2a0d8f53-6ac5-40bc-a417-2b32e8095ba9
     status: 200 OK
     code: 200
     duration: ""
@@ -1385,12 +1385,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_OGFqYBR7SJD6CQeA","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jHwHRbUSdabba0OA","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1403,9 +1403,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"2561946ae886f44e209f58fa8aeb51ee"
+      - W/"ae837f4be080bfe4999d4dd7f0e0b49b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1413,9 +1413,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "857"
+      - "956"
       X-Request-Id:
-      - cd7b8d0a-4738-4f80-a5cb-56087a0b31e7
+      - 2a42f4f1-af75-4c9e-b1d5-07ff2622990e
     status: 200 OK
     code: 200
     duration: ""
@@ -1427,12 +1427,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_OGFqYBR7SJD6CQeA
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jHwHRbUSdabba0OA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_OGFqYBR7SJD6CQeA","virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:9d:c0:65:10","state":"attached","ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_jHwHRbUSdabba0OA","virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ea:75:d8:38:71","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1445,9 +1445,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"5c5fdffd4f1bc49197738a86ae3c40a9"
+      - W/"12204db984c217ebaf23e6157681e3e4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1455,9 +1455,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "856"
+      - "955"
       X-Request-Id:
-      - ca26d777-c8ad-4f45-a961-35fcfa6426d0
+      - 3a7b5bbb-c826-4f15-8e0a-f4231de240d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,18 +1469,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1489,13 +1489,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2552"
+      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:23 GMT
       Etag:
-      - W/"48ada2dba333164d894e8ccb49dba361"
+      - W/"97e301135cc21dd6dae6e8fdcf405ed7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1503,9 +1503,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "854"
+      - "954"
       X-Request-Id:
-      - 70ba41ee-e67e-42c5-b168-3e242d063ba4
+      - 606cb796-6bd4-4d79-be69-4fa63025baf0
     status: 200 OK
     code: 200
     duration: ""
@@ -1517,10 +1517,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: POST
   response:
-    body: '{"task":{"id":"task_VzGBORhDhHNaYVyp","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_1gaRYxaoaUvtvKjv","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1533,9 +1533,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:24 GMT
       Etag:
-      - W/"c0a9d9d6fca9a592b088f7f33a1f0310"
+      - W/"04aad65709505740f722cfaae9bf86a2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1543,9 +1543,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "853"
+      - "953"
       X-Request-Id:
-      - a951944a-bbcf-4701-b17f-af4c7750754f
+      - a724566b-39e1-4f89-9e25-5da69cc93323
     status: 200 OK
     code: 200
     duration: ""
@@ -1557,10 +1557,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_VzGBORhDhHNaYVyp
+    url: https://api.katapult.io/core/v1/tasks/task_1gaRYxaoaUvtvKjv
     method: GET
   response:
-    body: '{"task":{"id":"task_VzGBORhDhHNaYVyp","name":"Stop virtual machine","status":"pending","created_at":1676031330,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_1gaRYxaoaUvtvKjv","name":"Stop virtual machine","status":"pending","created_at":1679569043,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1573,9 +1573,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:25 GMT
       Etag:
-      - W/"98b70b1a4d774d6bc59fd9f083f25d6e"
+      - W/"e7de1bcd78ecd220b4247630527c30ab"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1583,9 +1583,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "830"
+      - "952"
       X-Request-Id:
-      - c8c390b3-0116-4654-baf2-4b901b965497
+      - 9fd63d92-debf-4c5f-b130-eadfe111b7f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,10 +1597,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_VzGBORhDhHNaYVyp
+    url: https://api.katapult.io/core/v1/tasks/task_1gaRYxaoaUvtvKjv
     method: GET
   response:
-    body: '{"task":{"id":"task_VzGBORhDhHNaYVyp","name":"Stop virtual machine","status":"pending","created_at":1676031330,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_1gaRYxaoaUvtvKjv","name":"Stop virtual machine","status":"pending","created_at":1679569043,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1613,9 +1613,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:36 GMT
+      - Thu, 23 Mar 2023 10:57:30 GMT
       Etag:
-      - W/"98b70b1a4d774d6bc59fd9f083f25d6e"
+      - W/"e7de1bcd78ecd220b4247630527c30ab"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1623,9 +1623,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "826"
+      - "927"
       X-Request-Id:
-      - db8e7bbb-d363-409e-a85a-d8fc70c4764a
+      - 97497abf-9d9c-4d87-9744-d02003586ba5
     status: 200 OK
     code: 200
     duration: ""
@@ -1637,10 +1637,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_VzGBORhDhHNaYVyp
+    url: https://api.katapult.io/core/v1/tasks/task_1gaRYxaoaUvtvKjv
     method: GET
   response:
-    body: '{"task":{"id":"task_VzGBORhDhHNaYVyp","name":"Stop virtual machine","status":"running","created_at":1676031330,"started_at":1676031345,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_1gaRYxaoaUvtvKjv","name":"Stop virtual machine","status":"running","created_at":1679569043,"started_at":1679569059,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1649,13 +1649,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:46 GMT
+      - Thu, 23 Mar 2023 10:57:40 GMT
       Etag:
-      - W/"84407eb6a14df1c375f81ce2d9966bf8"
+      - W/"9e683792c7d7cc3e1dc48108a8052f3b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1663,9 +1663,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "823"
+      - "924"
       X-Request-Id:
-      - 15c93a96-286b-4ddd-8898-a24561790d68
+      - f7b99e11-b4b6-43f4-a3b2-911628a6bbb8
     status: 200 OK
     code: 200
     duration: ""
@@ -1677,10 +1677,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_VzGBORhDhHNaYVyp
+    url: https://api.katapult.io/core/v1/tasks/task_1gaRYxaoaUvtvKjv
     method: GET
   response:
-    body: '{"task":{"id":"task_VzGBORhDhHNaYVyp","name":"Stop virtual machine","status":"completed","created_at":1676031330,"started_at":1676031345,"finished_at":1676031347,"progress":100}}'
+    body: '{"task":{"id":"task_1gaRYxaoaUvtvKjv","name":"Stop virtual machine","status":"completed","created_at":1679569043,"started_at":1679569059,"finished_at":1679569061,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1693,9 +1693,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:56 GMT
+      - Thu, 23 Mar 2023 10:57:50 GMT
       Etag:
-      - W/"00d5765df4ea7653b32a5eca531e2eac"
+      - W/"602a4d8174064df0b19ae901556fcb2d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1703,9 +1703,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "816"
+      - "922"
       X-Request-Id:
-      - 86b85992-87cb-4ecd-9895-d52465bbfc25
+      - a03f1d8c-4d33-46eb-a95c-7296f552f587
     status: 200 OK
     code: 200
     duration: ""
@@ -1717,18 +1717,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_3WlJ6lanrqlb0cqW","keep_until":1676204156,"object_id":"vm_7t80Yj9aL4tQRcSR","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_7t80Yj9aL4tQRcSR","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx","hostname":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host","fqdn":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031310,"initial_root_password":"zYS3vlHT5ZDK5LOb","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_yz5cUtwyY1qRKMDt","keep_until":1679741870,"object_id":"vm_0SZ1uJEWvQrE2SuN","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_0SZ1uJEWvQrE2SuN","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt","hostname":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host","fqdn":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569024,"initial_root_password":"VUsK80XSkkTZO8VU","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_cpzb9l4zG2oY6zlg","address":"185.199.222.66","reverse_dns":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.66/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7t80Yj9aL4tQRcSR","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0SZ1uJEWvQrE2SuN","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1737,13 +1737,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2687"
+      - "2728"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:56 GMT
+      - Thu, 23 Mar 2023 10:57:50 GMT
       Etag:
-      - W/"e68f72b5b6bd4465ff6dff8147863d52"
+      - W/"76106774a9ae0287e6a9c0a194c2e689"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1751,9 +1751,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "815"
+      - "921"
       X-Request-Id:
-      - 722e86d8-3285-471b-9881-182689f9facc
+      - c3fa5a9e-04ef-451f-94e8-1460046aa4f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1765,7 +1765,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_cpzb9l4zG2oY6zlg
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: POST
   response:
     body: '{}'
@@ -1781,7 +1781,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:57 GMT
+      - Thu, 23 Mar 2023 10:57:50 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1791,9 +1791,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "814"
+      - "920"
       X-Request-Id:
-      - 2289c495-8ca6-4649-a610-f349d490497a
+      - 4a695490-de9e-4fbd-be88-b74e0899360f
     status: 200 OK
     code: 200
     duration: ""
@@ -1805,10 +1805,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_3WlJ6lanrqlb0cqW
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_yz5cUtwyY1qRKMDt
     method: DELETE
   response:
-    body: '{"task":{"id":"task_0Cxk82wuhHeUzclw","name":"Purge items from trash","status":"pending","created_at":1676031357,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_f6FNp5JfuCQ9bQVV","name":"Purge items from trash","status":"pending","created_at":1679569070,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1821,9 +1821,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:57 GMT
+      - Thu, 23 Mar 2023 10:57:50 GMT
       Etag:
-      - W/"354d0e7dd52b1ccbdce00f36f09f1c6d"
+      - W/"0de22722373337abb265e0c4d8eb72da"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1831,9 +1831,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "813"
+      - "919"
       X-Request-Id:
-      - b5be55f3-c3a9-47f7-8ecd-ebea52c900f4
+      - 6ad7de19-d550-4e1a-85e5-13cd92aab3c6
     status: 200 OK
     code: 200
     duration: ""
@@ -1845,10 +1845,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_0Cxk82wuhHeUzclw
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_yz5cUtwyY1qRKMDt
     method: GET
   response:
-    body: '{"task":{"id":"task_0Cxk82wuhHeUzclw","name":"Purge items from trash","status":"running","created_at":1676031357,"started_at":1676031357,"finished_at":null,"progress":5}}'
+    body: '{"trash_object":{"id":"trsh_yz5cUtwyY1qRKMDt","keep_until":1679741870,"object_id":"vm_0SZ1uJEWvQrE2SuN","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1857,13 +1857,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:58 GMT
+      - Thu, 23 Mar 2023 10:57:51 GMT
       Etag:
-      - W/"89a39a23fbbf361921f6dceb3057a004"
+      - W/"53e18422fca7a222694a40f092fec9bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1871,9 +1871,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "805"
+      - "918"
       X-Request-Id:
-      - a39a45ae-db99-4b91-8d59-1e1e2c1b569d
+      - 5be277c4-b5b5-4d18-a16f-b283debc6bf7
     status: 200 OK
     code: 200
     duration: ""
@@ -1885,37 +1885,38 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_0Cxk82wuhHeUzclw
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_yz5cUtwyY1qRKMDt
     method: GET
   response:
-    body: '{"task":{"id":"task_0Cxk82wuhHeUzclw","name":"Purge items from trash","status":"completed","created_at":1676031357,"started_at":1676031357,"finished_at":1676031360,"progress":100}}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "180"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:03 GMT
-      Etag:
-      - W/"e7ee7d396754c933dfdd6d860562ce05"
+      - Thu, 23 Mar 2023 10:57:56 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "913"
       X-Request-Id:
-      - 9a9c10ca-b35c-4e41-8cd4-942d589557a5
-    status: 200 OK
-    code: 200
+      - 96edb3fc-81a8-4a52-b2bd-8a1f7cfeb027
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -1925,10 +1926,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_6LP3CXeQiErnlKtb
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_epkzgGMC28Ql10Ye
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_6LP3CXeQiErnlKtb","name":"tf-acc-test-data-source-by-fqdn-n4qxaic67vkx-group","segregate":true,"created_at":1676031309}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_epkzgGMC28Ql10Ye","name":"tf-acc-test-data-source-by-fqdn-lhrxoro9urjt-group","segregate":true,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1941,9 +1942,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:03 GMT
+      - Thu, 23 Mar 2023 10:57:56 GMT
       Etag:
-      - W/"f3562f85cf3113f21950627cb989f016"
+      - W/"3aa59d4b7a06da3f35b1f4fd9db03103"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1951,9 +1952,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "912"
       X-Request-Id:
-      - 3cf6c43b-4369-4054-8392-62ea3b0b014b
+      - 807500e8-cf7d-459a-b0b6-0951ca27d161
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,7 +1966,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_cpzb9l4zG2oY6zlg
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: DELETE
   response:
     body: '{}'
@@ -1981,7 +1982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:03 GMT
+      - Thu, 23 Mar 2023 10:57:56 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1991,9 +1992,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "911"
       X-Request-Id:
-      - 5316d403-8fce-4a5c-852e-725b1761d935
+      - f3f9277c-e50c-4dc2-b246-c00edc23dcfb
     status: 200 OK
     code: 200
     duration: ""
@@ -2005,7 +2006,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2022,7 +2023,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:03 GMT
+      - Thu, 23 Mar 2023 10:57:56 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2032,9 +2033,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "910"
       X-Request-Id:
-      - 8b8039a2-d1e9-493e-8dfb-b29db9ed0681
+      - 2a12c6de-f2f5-48be-ae89-bbcd33a280a7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2046,7 +2047,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7t80Yj9aL4tQRcSR
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_0SZ1uJEWvQrE2SuN
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:57:56 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "909"
+      X-Request-Id:
+      - d8c8edd0-870b-49ec-a00f-7211f9e53891
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0SZ1uJEWvQrE2SuN
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2063,7 +2105,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:03 GMT
+      - Thu, 23 Mar 2023 10:57:56 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2073,9 +2115,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "907"
       X-Request-Id:
-      - 804edad8-d246-401d-8644-51ae1230dfdb
+      - 76d633dc-fb40-479e-a6b7-3ad4858ae2f2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2087,7 +2129,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_cpzb9l4zG2oY6zlg
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_0SZ1uJEWvQrE2SuN
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:57:56 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "906"
+      X-Request-Id:
+      - 9dc688b5-8a79-41d6-acf4-87c40c783321
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2104,7 +2187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:03 GMT
+      - Thu, 23 Mar 2023 10:57:56 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2114,9 +2197,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "905"
       X-Request-Id:
-      - f92a1f49-278d-49b2-b8ec-148971e0f334
+      - a398b09f-6658-427d-a868-257729aca79d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.rand_id
@@ -1,1 +1,1 @@
-gy92g0cx0xee
+dyskmkf0oiel

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.yaml
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:10 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,15 +35,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "910"
+      - "997"
       X-Request-Id:
-      - d960c39e-3bbd-4189-afba-9fd51bd48155
+      - dd677cf5-c454-4c6a-9d2a-285faec74982
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -68,9 +68,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:10 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"bb403fb04fca7b4c214c405b3235836e"
+      - W/"e9905d89fd3613645040dd6e1280a53f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -78,9 +78,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "910"
+      - "999"
       X-Request-Id:
-      - 7ac64edc-b198-4cba-ad91-ec3c362c9760
+      - ca93b009-ec60-47d6-a5dc-95875f868c2b
     status: 200 OK
     code: 200
     duration: ""
@@ -92,10 +92,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_bvX4MGmrVaaWyc6L
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_lgQHO0QGmVdvWn2h
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -108,9 +108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:11 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"bb403fb04fca7b4c214c405b3235836e"
+      - W/"e9905d89fd3613645040dd6e1280a53f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "907"
+      - "993"
       X-Request-Id:
-      - 3258ec3c-f6a8-446c-91d1-4e9c79c9eea0
+      - 668aa362-043b-4970-867e-30d073c2c5a4
     status: 200 OK
     code: 200
     duration: ""
@@ -138,7 +138,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -149,13 +149,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "549"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:11 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"83ea4f34a8ce0d2edaa0f1a799893caa"
+      - W/"137b10129b421fd5b21a6014fed1266d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -163,9 +163,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "908"
+      - "994"
       X-Request-Id:
-      - 5665a0ba-3240-4800-92c6-18b2fbbc43dd
+      - c01b0dfe-6e83-492f-8827-02e37a709cef
     status: 200 OK
     code: 200
     duration: ""
@@ -177,10 +177,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -191,13 +191,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:11 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"64dd313fd865984b592937218047f068"
+      - W/"e2dd9834428ed6e25c43af1579322fc9"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -205,9 +205,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "906"
+      - "988"
       X-Request-Id:
-      - e5a5effc-3900-41e4-ab22-c3c160470db5
+      - e4f3c627-ddc0-4afb-8551-9959885ea3cc
     status: 200 OK
     code: 200
     duration: ""
@@ -219,10 +219,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -233,13 +233,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:11 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"64dd313fd865984b592937218047f068"
+      - W/"e2dd9834428ed6e25c43af1579322fc9"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -247,15 +247,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "905"
+      - "987"
       X-Request-Id:
-      - 297e52cd-0594-4b8c-a855-84a9be9825db
+      - e48b10fe-8624-441e-9094-65e8aa9ad1b0
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_Z5FLGs1qY5Mhtbwz</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-id-gy92g0cx0xee-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-id-gy92g0cx0xee</Name><Description>A web server.</Description><Group>vmgrp_bvX4MGmrVaaWyc6L</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_hc3GUyhBe6toov2e</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-id-dyskmkf0oiel-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-id-dyskmkf0oiel</Name><Description>A web server.</Description><Group>vmgrp_lgQHO0QGmVdvWn2h</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -267,7 +267,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_IDnW4SRWeqKfQ53v","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_67pfG0CCpEOhCBVA","state":"pending"},"virtual_machine_build":{"id":"vmbuild_67pfG0CCpEOhCBVA","state":"pending"},"hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host"}'
+    body: '{"task":{"id":"task_1nNjoF3xdRlDl4gF","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_bItK3j8EHL7vY7JG","state":"pending"},"virtual_machine_build":{"id":"vmbuild_bItK3j8EHL7vY7JG","state":"pending"},"hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -280,9 +280,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:11 GMT
+      - Thu, 23 Mar 2023 10:57:03 GMT
       Etag:
-      - W/"98e13d209ebe883707e1f93cd49c3a79"
+      - W/"4d15979e604b8dbdaac9c1913d6d5046"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -290,9 +290,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "904"
+      - "986"
       X-Request-Id:
-      - 60dbcd8c-7a06-42cd-94a8-f37791f19ec4
+      - bd380bbc-0318-47bb-bf34-afb1b1408f06
     status: 201 Created
     code: 201
     duration: ""
@@ -304,18 +304,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_67pfG0CCpEOhCBVA
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_bItK3j8EHL7vY7JG
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_67pfG0CCpEOhCBVA","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_bItK3j8EHL7vY7JG","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-gy92g0cx0xee-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-gy92g0cx0xee\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_bvX4MGmrVaaWyc6L\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-dyskmkf0oiel-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-dyskmkf0oiel\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_lgQHO0QGmVdvWn2h\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1676031311}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -324,13 +324,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1803"
+      - "1802"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:13 GMT
+      - Thu, 23 Mar 2023 10:57:05 GMT
       Etag:
-      - W/"f35f355c692d0e2c983840d2140df399"
+      - W/"e4178c277539312b4143b31e82266f18"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -338,9 +338,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "897"
+      - "984"
       X-Request-Id:
-      - 6e0e375a-0fc1-4865-b45d-5a0a5e8d3e42
+      - 3973af88-72d8-41ab-a54b-76b67d7b4e99
     status: 200 OK
     code: 200
     duration: ""
@@ -352,18 +352,66 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_67pfG0CCpEOhCBVA
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_bItK3j8EHL7vY7JG
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_67pfG0CCpEOhCBVA","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_bItK3j8EHL7vY7JG","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-gy92g0cx0xee-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-gy92g0cx0xee\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_bvX4MGmrVaaWyc6L\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-dyskmkf0oiel-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-dyskmkf0oiel\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_lgQHO0QGmVdvWn2h\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031311}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679569023}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2048"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:57:10 GMT
+      Etag:
+      - W/"43b57e2f0bda5753baa53d6f4b12e080"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 08f11481-6488-4439-b561-1ba6a24cbd2e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_bItK3j8EHL7vY7JG
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_bItK3j8EHL7vY7JG","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-dyskmkf0oiel-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-dyskmkf0oiel\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_lgQHO0QGmVdvWn2h\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -376,9 +424,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:18 GMT
+      - Thu, 23 Mar 2023 10:57:20 GMT
       Etag:
-      - W/"d982c0c2d04f3872c61478e7aefd527c"
+      - W/"01e5219c1c38fa4dd5cc3a17623d12b8"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -386,63 +434,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "895"
+      - "979"
       X-Request-Id:
-      - 628c2311-6a8a-402b-9e01-6af90fa0cf26
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_67pfG0CCpEOhCBVA
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_67pfG0CCpEOhCBVA","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-gy92g0cx0xee-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-gy92g0cx0xee\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_bvX4MGmrVaaWyc6L\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1676031311}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2050"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:15:28 GMT
-      Etag:
-      - W/"99900d09a0c92d7e1f8c8b095ec148b7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "879"
-      X-Request-Id:
-      - f569d367-731b-46da-b1fb-ede5d1889c13
+      - 6e259d64-9668-4a24-b237-7fd417df0dbd
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -454,15 +454,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -471,13 +471,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2545"
+      - "2584"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:28 GMT
+      - Thu, 23 Mar 2023 10:57:20 GMT
       Etag:
-      - W/"3f5855aa668df17abc150161ebc0ab99"
+      - W/"c568e5dd8484ef0b422b6dae5149a7bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -485,9 +485,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "878"
+      - "978"
       X-Request-Id:
-      - a87e4255-a092-4c7c-b64d-9a2d3c81faaf
+      - cb313100-7ec9-431a-99be-32b80e6a12c1
     status: 200 OK
     code: 200
     duration: ""
@@ -499,18 +499,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -519,13 +519,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2584"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:22 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"c568e5dd8484ef0b422b6dae5149a7bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -533,9 +533,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "855"
+      - "974"
       X-Request-Id:
-      - 2bf1bcdc-167c-464f-877d-d11e4b8db3a3
+      - a005257c-8261-4d98-b131-d1f4ddea908f
     status: 200 OK
     code: 200
     duration: ""
@@ -547,18 +547,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -567,13 +567,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:27 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"5dd33ca26f77dd777598c34660b99740"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -581,9 +581,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "852"
+      - "951"
       X-Request-Id:
-      - 4ac19402-86e2-40f8-868b-a9bb41f0e2b6
+      - 6b1826f8-b9b0-43a8-9877-20a9e769bb85
     status: 200 OK
     code: 200
     duration: ""
@@ -595,102 +595,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bCimAB6dG7rWrJVU","name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "370"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
-      Etag:
-      - W/"78180128a6a7bc0b8604c31eb06af1bd"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "851"
-      X-Request-Id:
-      - 4a4badc9-3e05-4bea-8123-de9de94f445f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bCimAB6dG7rWrJVU
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_bCimAB6dG7rWrJVU","virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a7:2a:41:c6:7c","state":"detached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "511"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
-      Etag:
-      - W/"c2be1632ddcf54327067c1331b09de87"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "850"
-      X-Request-Id:
-      - 561ae702-bdff-4fff-a8cf-21c82a501082
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -699,13 +615,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"5dd33ca26f77dd777598c34660b99740"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -713,9 +629,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "849"
+      - "950"
       X-Request-Id:
-      - 8915dc9c-6757-45ea-ad4f-6b73d6df74fa
+      - ddd195b4-0ad4-4a03-80d8-13aff579886a
     status: 200 OK
     code: 200
     duration: ""
@@ -727,12 +643,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bCimAB6dG7rWrJVU","name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_FeMU3vn0xmVfMCbF","name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -741,13 +657,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "370"
+      - "369"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"78180128a6a7bc0b8604c31eb06af1bd"
+      - W/"1e230492f6b85639f14888c1fbc05215"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -755,9 +671,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "848"
+      - "949"
       X-Request-Id:
-      - 63109f10-c006-44a9-8ead-fc4e0e0477ac
+      - 9ae47a43-cfe0-4c31-a997-331b5459fbd6
     status: 200 OK
     code: 200
     duration: ""
@@ -769,12 +685,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bCimAB6dG7rWrJVU
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_FeMU3vn0xmVfMCbF
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_bCimAB6dG7rWrJVU","virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a7:2a:41:c6:7c","state":"detached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_FeMU3vn0xmVfMCbF","virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:d6:07:e1:9a:16","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -783,13 +699,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "511"
+      - "510"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"c2be1632ddcf54327067c1331b09de87"
+      - W/"e37d053dc3d9b7cd79fc2f133440d87e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -797,9 +713,141 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "847"
+      - "948"
       X-Request-Id:
-      - a12660a7-ea62-48d7-9eba-853e9ac3a805
+      - 5754431f-9edf-4127-98e3-5a2db821d907
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2583"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:57:28 GMT
+      Etag:
+      - W/"5dd33ca26f77dd777598c34660b99740"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - 6e2f3127-8a4b-4dad-be2f-ff35b054fe9e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_FeMU3vn0xmVfMCbF","name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "369"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:57:28 GMT
+      Etag:
+      - W/"1e230492f6b85639f14888c1fbc05215"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - e5d6d201-5654-46dd-9b6b-916b70bade8c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_FeMU3vn0xmVfMCbF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_FeMU3vn0xmVfMCbF","virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:d6:07:e1:9a:16","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "510"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:57:28 GMT
+      Etag:
+      - W/"e37d053dc3d9b7cd79fc2f133440d87e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 960b9253-825e-4ec5-85c4-3fd2f7d66224
     status: 200 OK
     code: 200
     duration: ""
@@ -811,18 +859,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -831,13 +879,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"5dd33ca26f77dd777598c34660b99740"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -845,9 +893,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "846"
+      - "944"
       X-Request-Id:
-      - 95fc5243-d19a-4a9e-9e2e-573e28352d3c
+      - 903d2303-b475-428d-966e-97baa906c3cc
     status: 200 OK
     code: 200
     duration: ""
@@ -859,18 +907,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -879,13 +927,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"5dd33ca26f77dd777598c34660b99740"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -893,9 +941,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "844"
+      - "943"
       X-Request-Id:
-      - 778890f1-4815-463f-b9c0-87078c824ab0
+      - 064af030-8b02-43a9-b28a-ba757ce43b43
     status: 200 OK
     code: 200
     duration: ""
@@ -907,12 +955,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bCimAB6dG7rWrJVU","name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_FeMU3vn0xmVfMCbF","name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -921,13 +969,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "370"
+      - "369"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"78180128a6a7bc0b8604c31eb06af1bd"
+      - W/"1e230492f6b85639f14888c1fbc05215"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -935,9 +983,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "843"
+      - "942"
       X-Request-Id:
-      - 656b97c2-b0c8-45a1-a208-060428db8a2d
+      - f62fec9d-3890-4630-b175-395cdf8d5e9e
     status: 200 OK
     code: 200
     duration: ""
@@ -949,12 +997,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bCimAB6dG7rWrJVU
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_FeMU3vn0xmVfMCbF
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_bCimAB6dG7rWrJVU","virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a7:2a:41:c6:7c","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_FeMU3vn0xmVfMCbF","virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:d6:07:e1:9a:16","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -963,13 +1011,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "511"
+      - "510"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"e933b883c637eacf66047e7901af2ccf"
+      - W/"e37d053dc3d9b7cd79fc2f133440d87e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -977,9 +1025,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "842"
+      - "941"
       X-Request-Id:
-      - cd325108-91cf-4918-8bd2-9534440e0051
+      - 3a4dd0c6-9bdc-4fd4-82d1-c947795988d8
     status: 200 OK
     code: 200
     duration: ""
@@ -991,10 +1039,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_bvX4MGmrVaaWyc6L
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_lgQHO0QGmVdvWn2h
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1007,9 +1055,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"bb403fb04fca7b4c214c405b3235836e"
+      - W/"e9905d89fd3613645040dd6e1280a53f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1017,9 +1065,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "840"
+      - "940"
       X-Request-Id:
-      - 95e8279e-9318-4b12-949d-c0ddd5b4be23
+      - 48655f60-8f9a-4233-87a4-5bfd647b5ff4
     status: 200 OK
     code: 200
     duration: ""
@@ -1031,12 +1079,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1045,13 +1093,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "755"
+      - "753"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"0c82021f1061f827a1d1fe6c7f978106"
+      - W/"7c71d705ee512a1c52eee7e6faa675b7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1059,9 +1107,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "841"
+      - "940"
       X-Request-Id:
-      - 26d5c619-b66f-4af8-af3b-f878db4dcab0
+      - 0cbf2fa9-b0b9-4402-9c68-c1e4c3b1a5eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1073,18 +1121,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1093,13 +1141,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"5dd33ca26f77dd777598c34660b99740"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1107,9 +1155,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "839"
+      - "938"
       X-Request-Id:
-      - e1cfd939-d0e7-4d0b-af7f-b4d61d1eacc8
+      - 078f36f9-825c-4cf0-9f41-d2d04e28be61
     status: 200 OK
     code: 200
     duration: ""
@@ -1121,12 +1169,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bCimAB6dG7rWrJVU","name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_FeMU3vn0xmVfMCbF","name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1135,13 +1183,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "370"
+      - "369"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"78180128a6a7bc0b8604c31eb06af1bd"
+      - W/"1e230492f6b85639f14888c1fbc05215"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1149,9 +1197,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "838"
+      - "937"
       X-Request-Id:
-      - df0b4689-5590-49aa-9ae2-9193a6a7f852
+      - fe5907af-5e0c-40db-bd0f-852a0a6d68f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1163,12 +1211,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bCimAB6dG7rWrJVU
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_FeMU3vn0xmVfMCbF
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_bCimAB6dG7rWrJVU","virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a7:2a:41:c6:7c","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_FeMU3vn0xmVfMCbF","virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:d6:07:e1:9a:16","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1177,13 +1225,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "511"
+      - "510"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"e933b883c637eacf66047e7901af2ccf"
+      - W/"e37d053dc3d9b7cd79fc2f133440d87e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1191,9 +1239,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "837"
+      - "936"
       X-Request-Id:
-      - ce5380f8-f2af-4085-8169-03cd2d08cfef
+      - 523a1160-bbb7-48a5-956a-b78d3d8112d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,18 +1253,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1225,13 +1273,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"5dd33ca26f77dd777598c34660b99740"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1239,9 +1287,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "836"
+      - "935"
       X-Request-Id:
-      - c4ce065e-65d1-408a-a940-e87dd663214d
+      - bb55baf4-c979-4be8-a289-ca7cacee152b
     status: 200 OK
     code: 200
     duration: ""
@@ -1253,12 +1301,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bCimAB6dG7rWrJVU","name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_FeMU3vn0xmVfMCbF","name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1267,13 +1315,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "370"
+      - "369"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"78180128a6a7bc0b8604c31eb06af1bd"
+      - W/"1e230492f6b85639f14888c1fbc05215"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1281,9 +1329,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "835"
+      - "934"
       X-Request-Id:
-      - 169eff99-93b7-4a6e-8828-77f5e120404f
+      - b23d7ef8-a891-4eaa-b1cb-a0e4772ccd87
     status: 200 OK
     code: 200
     duration: ""
@@ -1295,12 +1343,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bCimAB6dG7rWrJVU
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_FeMU3vn0xmVfMCbF
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_bCimAB6dG7rWrJVU","virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a7:2a:41:c6:7c","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_FeMU3vn0xmVfMCbF","virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:d6:07:e1:9a:16","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1309,13 +1357,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "511"
+      - "510"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"e933b883c637eacf66047e7901af2ccf"
+      - W/"e37d053dc3d9b7cd79fc2f133440d87e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1323,9 +1371,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "834"
+      - "933"
       X-Request-Id:
-      - f2b2459c-8cd9-4bd4-808a-4809229a5624
+      - bde610ac-6049-4b07-b6ab-57f9ca1dbfbd
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,18 +1385,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1357,13 +1405,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"5dd33ca26f77dd777598c34660b99740"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1371,9 +1419,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "833"
+      - "932"
       X-Request-Id:
-      - 6e8a5a16-9099-449e-8675-1ffacc0ef0a6
+      - 2e052e44-c3c9-4852-aa43-7ef3545045e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1385,12 +1433,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bCimAB6dG7rWrJVU","name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_FeMU3vn0xmVfMCbF","name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1399,13 +1447,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "370"
+      - "369"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"78180128a6a7bc0b8604c31eb06af1bd"
+      - W/"1e230492f6b85639f14888c1fbc05215"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1413,9 +1461,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "832"
+      - "931"
       X-Request-Id:
-      - e3f3a263-4095-4093-af75-a8bfda3be738
+      - 016b3198-83e6-4cd6-834a-c123b5c43f69
     status: 200 OK
     code: 200
     duration: ""
@@ -1427,12 +1475,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bCimAB6dG7rWrJVU
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_FeMU3vn0xmVfMCbF
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_bCimAB6dG7rWrJVU","virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-gy92g0cx0xee","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a7:2a:41:c6:7c","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_FeMU3vn0xmVfMCbF","virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-dyskmkf0oiel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:d6:07:e1:9a:16","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1441,13 +1489,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "511"
+      - "510"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:28 GMT
       Etag:
-      - W/"e933b883c637eacf66047e7901af2ccf"
+      - W/"e37d053dc3d9b7cd79fc2f133440d87e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1455,9 +1503,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "831"
+      - "930"
       X-Request-Id:
-      - 5548b8a7-b83e-421d-a263-d5b18760b668
+      - cd9ad4b6-8cc5-4e2b-b8f2-03dac6d103c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,18 +1517,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1489,13 +1537,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2544"
+      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:29 GMT
       Etag:
-      - W/"c8f400849f666ea4425effdeed17685b"
+      - W/"5dd33ca26f77dd777598c34660b99740"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1503,9 +1551,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "829"
+      - "929"
       X-Request-Id:
-      - f4e4e45a-a2fc-4030-9581-161f18527438
+      - 2dea250d-ac47-4995-8bb9-9725c35c1cdd
     status: 200 OK
     code: 200
     duration: ""
@@ -1517,10 +1565,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: POST
   response:
-    body: '{"task":{"id":"task_HfmjnK4qWYM5fT4R","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_VU46WJCqpkIWsalF","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1533,9 +1581,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:31 GMT
+      - Thu, 23 Mar 2023 10:57:29 GMT
       Etag:
-      - W/"408b09cf0362396be2312f3993254314"
+      - W/"58aca94a766903c43f2e4d9288e54fe3"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1543,9 +1591,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "828"
+      - "928"
       X-Request-Id:
-      - 4963dee4-a664-498f-a64a-280da56a3fba
+      - 1d494050-9e7e-45f5-a97b-e4d3eeb68e6f
     status: 200 OK
     code: 200
     duration: ""
@@ -1557,10 +1605,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_HfmjnK4qWYM5fT4R
+    url: https://api.katapult.io/core/v1/tasks/task_VU46WJCqpkIWsalF
     method: GET
   response:
-    body: '{"task":{"id":"task_HfmjnK4qWYM5fT4R","name":"Stop virtual machine","status":"pending","created_at":1676031331,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_VU46WJCqpkIWsalF","name":"Stop virtual machine","status":"pending","created_at":1679569049,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1573,9 +1621,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:32 GMT
+      - Thu, 23 Mar 2023 10:57:30 GMT
       Etag:
-      - W/"f3ffe72599266fedba66b2cac6149eb1"
+      - W/"59432f12d571d2a721303ae4a08fe364"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1583,9 +1631,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "827"
+      - "926"
       X-Request-Id:
-      - 5d1461ec-b1d9-4383-8898-5398d5426e8f
+      - 7b870976-0252-4abf-a509-e3503390dbba
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,10 +1645,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_HfmjnK4qWYM5fT4R
+    url: https://api.katapult.io/core/v1/tasks/task_VU46WJCqpkIWsalF
     method: GET
   response:
-    body: '{"task":{"id":"task_HfmjnK4qWYM5fT4R","name":"Stop virtual machine","status":"pending","created_at":1676031331,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_VU46WJCqpkIWsalF","name":"Stop virtual machine","status":"pending","created_at":1679569049,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1613,9 +1661,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:37 GMT
+      - Thu, 23 Mar 2023 10:57:35 GMT
       Etag:
-      - W/"f3ffe72599266fedba66b2cac6149eb1"
+      - W/"59432f12d571d2a721303ae4a08fe364"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1623,9 +1671,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "825"
+      - "925"
       X-Request-Id:
-      - a16250b9-4b5e-47ae-8256-b344f1afb13a
+      - 94128c41-8db5-42d3-bfa7-bfb2bf04ae54
     status: 200 OK
     code: 200
     duration: ""
@@ -1637,10 +1685,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_HfmjnK4qWYM5fT4R
+    url: https://api.katapult.io/core/v1/tasks/task_VU46WJCqpkIWsalF
     method: GET
   response:
-    body: '{"task":{"id":"task_HfmjnK4qWYM5fT4R","name":"Stop virtual machine","status":"running","created_at":1676031331,"started_at":1676031346,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_VU46WJCqpkIWsalF","name":"Stop virtual machine","status":"running","created_at":1679569049,"started_at":1679569064,"finished_at":null,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1653,9 +1701,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:48 GMT
+      - Thu, 23 Mar 2023 10:57:45 GMT
       Etag:
-      - W/"1355fd9052abd04b31a9252f95e8c280"
+      - W/"82d9336523feb7e8d64e756ac853772b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1663,9 +1711,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "822"
+      - "923"
       X-Request-Id:
-      - f7cda8ba-300e-4611-ac3d-bda7fdaefcd4
+      - d8e72da7-d730-400e-aa0c-5a40971e21f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1677,10 +1725,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_HfmjnK4qWYM5fT4R
+    url: https://api.katapult.io/core/v1/tasks/task_VU46WJCqpkIWsalF
     method: GET
   response:
-    body: '{"task":{"id":"task_HfmjnK4qWYM5fT4R","name":"Stop virtual machine","status":"completed","created_at":1676031331,"started_at":1676031346,"finished_at":1676031349,"progress":100}}'
+    body: '{"task":{"id":"task_VU46WJCqpkIWsalF","name":"Stop virtual machine","status":"completed","created_at":1679569049,"started_at":1679569064,"finished_at":1679569066,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1693,9 +1741,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:58 GMT
+      - Thu, 23 Mar 2023 10:57:55 GMT
       Etag:
-      - W/"f7af6d3c7eb0ce1a238b0b74be1acce3"
+      - W/"f33bb4aaaee761cc1b037513d382d19b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1703,9 +1751,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "808"
+      - "917"
       X-Request-Id:
-      - e72ab598-f04c-479e-829e-0e5cf894de28
+      - 3889ac2d-28ea-4dc9-a87e-e5e103507eee
     status: 200 OK
     code: 200
     duration: ""
@@ -1717,18 +1765,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_3mmQFePYZZEfNXcT","keep_until":1676204158,"object_id":"vm_XGsVpsyw1O9CVayx","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_XGsVpsyw1O9CVayx","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee","hostname":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host","fqdn":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031311,"initial_root_password":"mNecenq36vybMmpc","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_kN5a9E7C5y1E1PYX","keep_until":1679741875,"object_id":"vm_iENlXc7q2zzmV0Ne","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_iENlXc7q2zzmV0Ne","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel","hostname":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host","fqdn":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679569025,"initial_root_password":"56RG4gMRa8qLaYWZ","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-data-source-by-id-gy92g0cx0xee-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-dyskmkf0oiel-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XGsVpsyw1O9CVayx","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_iENlXc7q2zzmV0Ne","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1737,13 +1785,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2679"
+      - "2718"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:58 GMT
+      - Thu, 23 Mar 2023 10:57:55 GMT
       Etag:
-      - W/"f4f9f2ba7f2233724f5e93080c51bba4"
+      - W/"3f2a937157d8a2db3b82b7aacdbc1829"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1751,9 +1799,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "807"
+      - "916"
       X-Request-Id:
-      - d1179b85-0d9c-4473-b2f2-95298dd7fbd1
+      - 90056f7f-0a1d-452c-9cfe-06e331839b18
     status: 200 OK
     code: 200
     duration: ""
@@ -1765,7 +1813,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: POST
   response:
     body: '{}'
@@ -1781,7 +1829,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:58 GMT
+      - Thu, 23 Mar 2023 10:57:55 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1791,9 +1839,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "806"
+      - "915"
       X-Request-Id:
-      - 639d9839-d344-45bb-b18a-cf13f398317a
+      - 8ae96ae8-5b1b-4865-84a3-e42a72eea32a
     status: 200 OK
     code: 200
     duration: ""
@@ -1805,10 +1853,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_3mmQFePYZZEfNXcT
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_kN5a9E7C5y1E1PYX
     method: DELETE
   response:
-    body: '{"task":{"id":"task_MmbqLtJo7g9k45rZ","name":"Purge items from trash","status":"pending","created_at":1676031358,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_HglHp9sF7m3y90jO","name":"Purge items from trash","status":"pending","created_at":1679569075,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1821,9 +1869,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:58 GMT
+      - Thu, 23 Mar 2023 10:57:55 GMT
       Etag:
-      - W/"4dee6e08b83033fe6ab6d0f6e1acfdaf"
+      - W/"8e73d993399a9dc1fbbd6f840e2c72ef"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1831,9 +1879,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "804"
+      - "914"
       X-Request-Id:
-      - b586a7f1-b7b5-473e-9483-071f894a0f6f
+      - 206d4743-ee82-4510-8500-ca02efe38abb
     status: 200 OK
     code: 200
     duration: ""
@@ -1845,10 +1893,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_MmbqLtJo7g9k45rZ
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_kN5a9E7C5y1E1PYX
     method: GET
   response:
-    body: '{"task":{"id":"task_MmbqLtJo7g9k45rZ","name":"Purge items from trash","status":"pending","created_at":1676031358,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"trash_object":{"id":"trsh_kN5a9E7C5y1E1PYX","keep_until":1679741875,"object_id":"vm_iENlXc7q2zzmV0Ne","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1857,13 +1905,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "164"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:59 GMT
+      - Thu, 23 Mar 2023 10:57:56 GMT
       Etag:
-      - W/"4dee6e08b83033fe6ab6d0f6e1acfdaf"
+      - W/"9f53a0d75de69eedc13499969202678c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1871,9 +1919,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "803"
+      - "908"
       X-Request-Id:
-      - 9e333ef9-ffcc-47c6-8cce-0a51d925e69c
+      - 3b556630-fbaa-4327-a5e5-e8cb7692dc2c
     status: 200 OK
     code: 200
     duration: ""
@@ -1885,37 +1933,38 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_MmbqLtJo7g9k45rZ
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_kN5a9E7C5y1E1PYX
     method: GET
   response:
-    body: '{"task":{"id":"task_MmbqLtJo7g9k45rZ","name":"Purge items from trash","status":"pending","created_at":1676031358,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "164"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:04 GMT
-      Etag:
-      - W/"4dee6e08b83033fe6ab6d0f6e1acfdaf"
+      - Thu, 23 Mar 2023 10:58:01 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "999"
       X-Request-Id:
-      - 2a13512d-a3bc-441c-a07b-09b18ccd70b9
-    status: 200 OK
-    code: 200
+      - 5dd1a7a7-6b65-44f5-a772-3de0b85218b2
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -1925,90 +1974,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_MmbqLtJo7g9k45rZ
-    method: GET
-  response:
-    body: '{"task":{"id":"task_MmbqLtJo7g9k45rZ","name":"Purge items from trash","status":"running","created_at":1676031358,"started_at":1676031373,"finished_at":null,"progress":5}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "170"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:16:14 GMT
-      Etag:
-      - W/"2218948fe20ae396097463514d9d4980"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - 850961bd-2cf1-4f1b-ac06-29ebbdd9e5ed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_MmbqLtJo7g9k45rZ
-    method: GET
-  response:
-    body: '{"task":{"id":"task_MmbqLtJo7g9k45rZ","name":"Purge items from trash","status":"completed","created_at":1676031358,"started_at":1676031373,"finished_at":1676031376,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "180"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:16:24 GMT
-      Etag:
-      - W/"c7dd1d398f7fb3c3d7811986fca1c2b5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "991"
-      X-Request-Id:
-      - 53724670-d768-47cb-a989-2d3e3226bddc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_bvX4MGmrVaaWyc6L
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_lgQHO0QGmVdvWn2h
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_bvX4MGmrVaaWyc6L","name":"tf-acc-test-data-source-by-id-gy92g0cx0xee-group","segregate":true,"created_at":1676031310}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_lgQHO0QGmVdvWn2h","name":"tf-acc-test-data-source-by-id-dyskmkf0oiel-group","segregate":true,"created_at":1679569023}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2021,9 +1990,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:24 GMT
+      - Thu, 23 Mar 2023 10:58:01 GMT
       Etag:
-      - W/"bb403fb04fca7b4c214c405b3235836e"
+      - W/"e9905d89fd3613645040dd6e1280a53f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2031,9 +2000,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "998"
       X-Request-Id:
-      - 76600339-5feb-4317-a06b-0b7c29b2f1fa
+      - 5420fc64-36ea-4f36-86e7-1e57b51f15ae
     status: 200 OK
     code: 200
     duration: ""
@@ -2045,7 +2014,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: DELETE
   response:
     body: '{}'
@@ -2061,7 +2030,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:24 GMT
+      - Thu, 23 Mar 2023 10:58:03 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2071,9 +2040,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "998"
       X-Request-Id:
-      - b2ff4306-6641-460e-844d-4cd622566a2b
+      - 20d467b3-01c9-45b2-89e4-ceec01ae5af9
     status: 200 OK
     code: 200
     duration: ""
@@ -2085,7 +2054,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2102,7 +2071,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:24 GMT
+      - Thu, 23 Mar 2023 10:58:03 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2112,9 +2081,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "996"
       X-Request-Id:
-      - 1baad64a-5882-4025-becf-14929168fcd4
+      - 3064c857-ce4f-49f1-a65f-97ed3ef66b2f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2126,7 +2095,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XGsVpsyw1O9CVayx
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_iENlXc7q2zzmV0Ne
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:58:03 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 9cf174f9-fc08-4d28-98ca-a209d4eb2847
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_iENlXc7q2zzmV0Ne
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2143,7 +2153,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:24 GMT
+      - Thu, 23 Mar 2023 10:58:03 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2153,9 +2163,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "994"
       X-Request-Id:
-      - 32a1ff12-139e-4179-9809-240ac3f53bb2
+      - 4891d2fa-c18d-4537-9d24-9bcce1955703
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2167,7 +2177,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_iENlXc7q2zzmV0Ne
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:58:03 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - ba211974-89e3-4de0-afaa-5f9d8b2713a0
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2184,7 +2235,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:16:24 GMT
+      - Thu, 23 Mar 2023 10:58:03 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2194,9 +2245,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "992"
       X-Request-Id:
-      - 5991005c-6e92-4e34-946d-4ac12707c002
+      - e4007998-4dad-46e0-a184-d26cec694b9a
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_basic.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_basic.cassette.rand_id
@@ -1,1 +1,1 @@
-aoa3htg7gjfe
+dwbb232cyc76

--- a/internal/provider/testdata/VirtualMachine_basic.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_basic.cassette.rand_id
@@ -1,1 +1,1 @@
-dwbb232cyc76
+ns7mthflgzpf

--- a/internal/provider/testdata/VirtualMachine_basic.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_basic.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:44 GMT
+      - Wed, 22 Mar 2023 17:39:21 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "824"
+      - "912"
       X-Request-Id:
-      - 682a8b6b-f39e-481b-9b0b-911f76fb8b5d
+      - 668f1a66-a9e7-4371-ac92-2ac34506e7f6
     status: 200 OK
     code: 200
     duration: ""
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:44 GMT
+      - Wed, 22 Mar 2023 17:39:21 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -75,15 +75,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "824"
+      - "911"
       X-Request-Id:
-      - aefafde8-7849-431f-bb00-cb006924211f
+      - 8a03bcea-af81-4287-ac52-f9afd5656ee2
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -95,7 +95,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -108,9 +108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:44 GMT
+      - Wed, 22 Mar 2023 17:39:21 GMT
       Etag:
-      - W/"725a1dd118c2e2780ca172dd675d906e"
+      - W/"9df7de160e7675268f7d4ae2f532447a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "824"
+      - "913"
       X-Request-Id:
-      - 33ddb224-6911-46af-9931-55c8e5edc1fb
+      - bb17da91-0022-49ff-a5a4-102bd9f8aff7
     status: 200 OK
     code: 200
     duration: ""
@@ -132,10 +132,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_zcwZDZQcTvxvVOsv
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_NTWwHydGbH8aVzTD
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -148,9 +148,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:39:21 GMT
       Etag:
-      - W/"725a1dd118c2e2780ca172dd675d906e"
+      - W/"9df7de160e7675268f7d4ae2f532447a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "815"
+      - "908"
       X-Request-Id:
-      - bc75eb06-2905-4402-8db2-bf2a4cb24b25
+      - 759f8bfc-6d8a-4b96-8d15-d6ba4dfb265f
     status: 200 OK
     code: 200
     duration: ""
@@ -178,7 +178,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"185-199-222-61.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -189,13 +189,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "549"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:39:25 GMT
       Etag:
-      - W/"83ea4f34a8ce0d2edaa0f1a799893caa"
+      - W/"04cb2602005af9ef28a94a2bae5c5eea"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -203,9 +203,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "819"
+      - "910"
       X-Request-Id:
-      - b7bcb028-3d89-47aa-9bda-543e0e4f63d9
+      - aa9f5fe7-39e3-4c52-bd10-156e5dda418e
     status: 200 OK
     code: 200
     duration: ""
@@ -217,10 +217,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"185-199-222-61.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -231,13 +231,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:39:25 GMT
       Etag:
-      - W/"64dd313fd865984b592937218047f068"
+      - W/"12922e2443b262436d64329e7aa2a01a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -245,9 +245,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "810"
+      - "907"
       X-Request-Id:
-      - 7d17ad74-c933-4610-a1c5-f61fe8a73560
+      - 7a456e66-97ec-4389-a181-98d7e4919e75
     status: 200 OK
     code: 200
     duration: ""
@@ -265,7 +265,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"185-199-222-100.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"185-199-222-97.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -276,13 +276,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "549"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:39:28 GMT
       Etag:
-      - W/"deb166982e6d33821f62e61b2ba189f0"
+      - W/"e4c5c4245ffa90fccf4d87c5130d81f3"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -290,9 +290,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "816"
+      - "909"
       X-Request-Id:
-      - 2caf2dc6-b903-48d6-a492-07a994c09872
+      - 94b6c2ff-14b3-4a30-bf9d-df2b9b729b01
     status: 200 OK
     code: 200
     duration: ""
@@ -304,10 +304,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_5KQyws2YivDGFxbC
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"185-199-222-100.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"185-199-222-97.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -318,13 +318,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:39:28 GMT
       Etag:
-      - W/"12dc4cdc9d6e7c7b049af2a17d0b0d85"
+      - W/"4d887cde476eaedf3439c8af2b92d954"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -332,9 +332,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "806"
+      - "905"
       X-Request-Id:
-      - 76847798-11f1-48bb-87f9-535e5a6136bb
+      - c7ebaeab-9684-42fc-8e60-5d7503f7ed15
     status: 200 OK
     code: 200
     duration: ""
@@ -346,10 +346,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"185-199-222-61.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -360,13 +360,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:39:28 GMT
       Etag:
-      - W/"64dd313fd865984b592937218047f068"
+      - W/"12922e2443b262436d64329e7aa2a01a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -374,9 +374,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "804"
+      - "904"
       X-Request-Id:
-      - a54fa93c-ed0e-4b06-a164-a8edea198b8a
+      - 9617485a-1667-4274-ba15-a4630698746b
     status: 200 OK
     code: 200
     duration: ""
@@ -388,10 +388,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_5KQyws2YivDGFxbC
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"185-199-222-100.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"185-199-222-97.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -402,13 +402,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:39:28 GMT
       Etag:
-      - W/"12dc4cdc9d6e7c7b049af2a17d0b0d85"
+      - W/"4d887cde476eaedf3439c8af2b92d954"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -416,15 +416,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "802"
+      - "903"
       X-Request-Id:
-      - 085608ee-01af-4bb3-a924-cc78ac2adfb7
+      - 2c95551d-6a88-4002-b838-682ef210f054
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_Z5FLGs1qY5Mhtbwz</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_5KQyws2YivDGFxbC</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-basic-aoa3htg7gjfe-host</Hostname></Hostname><Name>tf-acc-test-basic-aoa3htg7gjfe</Name><Description>A web server.</Description><Group>vmgrp_zcwZDZQcTvxvVOsv</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_AuDgNPM5YokLXM3Q</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_wLnEBwjoU5QWfRrr</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-basic-dwbb232cyc76-host</Hostname></Hostname><Name>tf-acc-test-basic-dwbb232cyc76</Name><Description>A web server.</Description><Group>vmgrp_NTWwHydGbH8aVzTD</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -436,7 +436,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_VXrTCuYLYNKIJjef","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_iu9xrnDmZktd6Ipa","state":"pending"},"virtual_machine_build":{"id":"vmbuild_iu9xrnDmZktd6Ipa","state":"pending"},"hostname":"tf-acc-test-basic-aoa3htg7gjfe-host"}'
+    body: '{"task":{"id":"task_qVSkKv8yQH4pYPvF","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_GQikmVmANYGuwzVU","state":"pending"},"virtual_machine_build":{"id":"vmbuild_GQikmVmANYGuwzVU","state":"pending"},"hostname":"tf-acc-test-basic-dwbb232cyc76-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -449,9 +449,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:39:28 GMT
       Etag:
-      - W/"b894b60bdff00058e87e6f842fbe0ffd"
+      - W/"1dc55b46ca78019e22a4e24102fc0f9d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -459,9 +459,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "801"
+      - "902"
       X-Request-Id:
-      - 1b50fd13-7af0-4561-bd63-58dfaf986fb9
+      - 4f6edaec-1f35-4159-b856-1c8c48de6045
     status: 201 Created
     code: 201
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_iu9xrnDmZktd6Ipa
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GQikmVmANYGuwzVU
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_iu9xrnDmZktd6Ipa","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_GQikmVmANYGuwzVU","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.100\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-aoa3htg7gjfe-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-aoa3htg7gjfe\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_zcwZDZQcTvxvVOsv\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.97\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dwbb232cyc76-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dwbb232cyc76\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_NTWwHydGbH8aVzTD\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1676031225}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679506768}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -494,13 +494,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1959"
+      - "1957"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:47 GMT
+      - Wed, 22 Mar 2023 17:39:30 GMT
       Etag:
-      - W/"746a8e86cc7a44f7e2f527f71371bf87"
+      - W/"174b882c3b61c2c1be7aa630b05ed8d4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -508,9 +508,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "793"
+      - "899"
       X-Request-Id:
-      - c98f0eb7-1252-40d4-acd4-0dc90c73780f
+      - 0f5f1a79-7003-423b-9d6a-902bbf3e8c22
     status: 200 OK
     code: 200
     duration: ""
@@ -522,19 +522,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_iu9xrnDmZktd6Ipa
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GQikmVmANYGuwzVU
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_iu9xrnDmZktd6Ipa","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_GQikmVmANYGuwzVU","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.100\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-aoa3htg7gjfe-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-aoa3htg7gjfe\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_zcwZDZQcTvxvVOsv\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.97\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dwbb232cyc76-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dwbb232cyc76\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_NTWwHydGbH8aVzTD\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1676031225}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506768}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -543,13 +543,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1959"
+      - "2167"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:52 GMT
+      - Wed, 22 Mar 2023 17:39:35 GMT
       Etag:
-      - W/"746a8e86cc7a44f7e2f527f71371bf87"
+      - W/"50c9d43273522a49011872b160111b31"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -557,9 +557,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "789"
+      - "881"
       X-Request-Id:
-      - 2cc39133-ffda-4f1c-9a99-a0613d0aee98
+      - 19d412f2-e0ff-403b-aaac-92d7ea9e4a0b
     status: 200 OK
     code: 200
     duration: ""
@@ -571,19 +571,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_iu9xrnDmZktd6Ipa
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GQikmVmANYGuwzVU
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_iu9xrnDmZktd6Ipa","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_GQikmVmANYGuwzVU","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.100\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-aoa3htg7gjfe-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-aoa3htg7gjfe\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_zcwZDZQcTvxvVOsv\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.97\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dwbb232cyc76-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dwbb232cyc76\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_NTWwHydGbH8aVzTD\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031225}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679506768}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -592,13 +592,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2169"
+      - "2168"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:02 GMT
+      - Wed, 22 Mar 2023 17:39:45 GMT
       Etag:
-      - W/"cd9d6ced71b6ccd234f1cbb1f05bc918"
+      - W/"b0dd8843b294130b3abb9a2332f6d8d1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -606,64 +606,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "858"
       X-Request-Id:
-      - cb4a6389-d653-4eee-853d-07b4678294fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_iu9xrnDmZktd6Ipa
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_iu9xrnDmZktd6Ipa","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.100\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-aoa3htg7gjfe-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-aoa3htg7gjfe\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_zcwZDZQcTvxvVOsv\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1676031225}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2169"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:12 GMT
-      Etag:
-      - W/"e939e5a74e48c3a7af545a7b86287192"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "918"
-      X-Request-Id:
-      - 303358a1-cd4c-4bb6-bff6-c997f866c2a5
+      - af292386-f926-46f3-b54e-0d4e5e3098c9
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -675,17 +626,17 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031226,"initial_root_password":"tS0FDrSXWFonWTBf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -694,13 +645,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3085"
+      - "3123"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:12 GMT
+      - Wed, 22 Mar 2023 17:39:45 GMT
       Etag:
-      - W/"540dd5b3e44bcbeb009963f896681b1b"
+      - W/"3cf8878f41896945190debeef85240bc"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -708,9 +659,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "857"
       X-Request-Id:
-      - 42870b74-04d1-4f82-967d-535b6a8eea4f
+      - 00f4e70b-d8c1-4d69-86eb-c1e3aaa706f1
     status: 200 OK
     code: 200
     duration: ""
@@ -722,20 +673,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031226,"initial_root_password":"tS0FDrSXWFonWTBf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -744,13 +695,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3085"
+      - "3123"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:14 GMT
+      - Wed, 22 Mar 2023 17:39:47 GMT
       Etag:
-      - W/"540dd5b3e44bcbeb009963f896681b1b"
+      - W/"3cf8878f41896945190debeef85240bc"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -758,9 +709,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "912"
+      - "848"
       X-Request-Id:
-      - 7803b22d-eee8-4102-9a3c-2c9af52c38bd
+      - a00978db-a19f-48c0-854d-07439160bef8
     status: 200 OK
     code: 200
     duration: ""
@@ -772,20 +723,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031226,"initial_root_password":"tS0FDrSXWFonWTBf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -794,13 +745,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3085"
+      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:14 GMT
+      - Wed, 22 Mar 2023 17:39:52 GMT
       Etag:
-      - W/"540dd5b3e44bcbeb009963f896681b1b"
+      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -808,9 +759,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "910"
+      - "845"
       X-Request-Id:
-      - 9bc2ae02-49cc-45cd-aadc-bfcc830e1405
+      - 9f75bb68-c4e9-4c60-a474-98f2bcbf1fb6
     status: 200 OK
     code: 200
     duration: ""
@@ -822,12 +773,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_ewbT3uKsI4VXxYfe","name":"Public
-      Network on tf-acc-test-basic-aoa3htg7gjfe","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -836,13 +795,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "415"
+      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:14 GMT
+      - Wed, 22 Mar 2023 17:39:52 GMT
       Etag:
-      - W/"3ad572eb278699c9e51cacd6642227c7"
+      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -850,9 +809,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "909"
+      - "844"
       X-Request-Id:
-      - cc0fc89c-abba-49dc-ba83-5b17827cbd06
+      - 87d0fe2e-85b9-4f30-9892-bd594f009272
     status: 200 OK
     code: 200
     duration: ""
@@ -864,12 +823,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_ewbT3uKsI4VXxYfe
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_ewbT3uKsI4VXxYfe","virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe"},"name":"Public
-      Network on tf-acc-test-basic-aoa3htg7gjfe","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:91:6a:e4:4e:68","state":"attached","ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Ww63ztf7q4416rZ6","name":"Public
+      Network on tf-acc-test-basic-dwbb232cyc76","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -878,13 +837,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "544"
+      - "413"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:14 GMT
+      - Wed, 22 Mar 2023 17:39:52 GMT
       Etag:
-      - W/"6794c9ec9753f775512a8969749bda0b"
+      - W/"42c8a34960d8b4bb3ae0e0df6d38daa7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -892,9 +851,51 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "907"
+      - "843"
       X-Request-Id:
-      - 2a511f48-b915-46f8-9d01-9bc69b6d3587
+      - 506321c5-dceb-4fa9-85d4-1d113e3942e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Ww63ztf7q4416rZ6
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ww63ztf7q4416rZ6","virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76"},"name":"Public
+      Network on tf-acc-test-basic-dwbb232cyc76","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:10:7b:b2:0c:b5","state":"attached","ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "542"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:52 GMT
+      Etag:
+      - W/"8f54f082cf75d824ceedb036dcf3b6c8"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "842"
+      X-Request-Id:
+      - 8f21c6d6-cd6e-47af-a084-11e95d29777a
     status: 200 OK
     code: 200
     duration: ""
@@ -906,20 +907,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031226,"initial_root_password":"tS0FDrSXWFonWTBf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -928,13 +929,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3085"
+      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:14 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"540dd5b3e44bcbeb009963f896681b1b"
+      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -942,9 +943,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "906"
+      - "841"
       X-Request-Id:
-      - a89eeb04-0109-474c-ac3b-6f5d9037fc47
+      - 2e92d477-d6a4-466d-98c8-976ace7fb081
     status: 200 OK
     code: 200
     duration: ""
@@ -956,10 +957,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_zcwZDZQcTvxvVOsv
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_NTWwHydGbH8aVzTD
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -972,9 +973,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"725a1dd118c2e2780ca172dd675d906e"
+      - W/"9df7de160e7675268f7d4ae2f532447a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -982,9 +983,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "898"
+      - "838"
       X-Request-Id:
-      - 32a5e718-a8f0-4ae7-b486-05b2fad766e2
+      - e93fd55a-7603-4543-b953-fa6f7f99e222
     status: 200 OK
     code: 200
     duration: ""
@@ -996,12 +997,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1010,13 +1011,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "731"
+      - "729"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"e1fd17349fca528248632e74ebbc9d3c"
+      - W/"9e8f64afc5c83442a6eec7ced9e0af71"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1024,9 +1025,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "900"
+      - "839"
       X-Request-Id:
-      - 2387d809-4736-4b46-b24c-35831f3d5e47
+      - 1dc41275-c508-49ea-ba3e-bc94ad883198
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,12 +1039,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_5KQyws2YivDGFxbC
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1052,13 +1053,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "731"
+      - "729"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"ee8f8940e2cac6132a78ac27b79e6b85"
+      - W/"4f19845c87cb0d942fe48aada1f762d5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1066,9 +1067,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "900"
+      - "837"
       X-Request-Id:
-      - 892953ec-82ce-4f64-abec-8228bac0b818
+      - b07fb172-51f3-47ca-949d-ffa2e33a934e
     status: 200 OK
     code: 200
     duration: ""
@@ -1080,20 +1081,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031226,"initial_root_password":"tS0FDrSXWFonWTBf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1102,13 +1103,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3085"
+      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"540dd5b3e44bcbeb009963f896681b1b"
+      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1116,9 +1117,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "897"
+      - "836"
       X-Request-Id:
-      - 0b1df366-8b67-4d15-8033-a3a3778c65bc
+      - 992edc44-698b-469e-af62-b2338761dcfa
     status: 200 OK
     code: 200
     duration: ""
@@ -1130,12 +1131,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_ewbT3uKsI4VXxYfe","name":"Public
-      Network on tf-acc-test-basic-aoa3htg7gjfe","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Ww63ztf7q4416rZ6","name":"Public
+      Network on tf-acc-test-basic-dwbb232cyc76","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1144,13 +1145,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "415"
+      - "413"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"3ad572eb278699c9e51cacd6642227c7"
+      - W/"42c8a34960d8b4bb3ae0e0df6d38daa7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1158,9 +1159,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "896"
+      - "835"
       X-Request-Id:
-      - 51ae554e-9785-4db1-8070-ad5541196b4a
+      - d9053eab-d094-4dd7-b195-3eefdb7149f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,12 +1173,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_ewbT3uKsI4VXxYfe
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Ww63ztf7q4416rZ6
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_ewbT3uKsI4VXxYfe","virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe"},"name":"Public
-      Network on tf-acc-test-basic-aoa3htg7gjfe","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:91:6a:e4:4e:68","state":"attached","ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ww63ztf7q4416rZ6","virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76"},"name":"Public
+      Network on tf-acc-test-basic-dwbb232cyc76","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:10:7b:b2:0c:b5","state":"attached","ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1186,13 +1187,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "544"
+      - "542"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"6794c9ec9753f775512a8969749bda0b"
+      - W/"8f54f082cf75d824ceedb036dcf3b6c8"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1200,9 +1201,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "895"
+      - "834"
       X-Request-Id:
-      - 3277291f-49e7-4bbb-9e1a-80e0368c5bdf
+      - c7ef018e-be82-4bea-8fbc-8534c4500a4d
     status: 200 OK
     code: 200
     duration: ""
@@ -1214,20 +1215,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031226,"initial_root_password":"tS0FDrSXWFonWTBf","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1236,13 +1237,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3085"
+      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"540dd5b3e44bcbeb009963f896681b1b"
+      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1250,9 +1251,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "888"
+      - "832"
       X-Request-Id:
-      - a954d9e3-aa6d-40ab-bccb-38089c0daf9b
+      - d40bafb1-d265-46e5-94b4-7a45ecfb445e
     status: 200 OK
     code: 200
     duration: ""
@@ -1264,10 +1265,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: POST
   response:
-    body: '{"task":{"id":"task_tAfEmJvRgifY7RGl","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1280,9 +1281,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"fc85cbef2b807995b8db1e6c20093074"
+      - W/"3c067c66758732f4ed58004ec79b8d85"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1290,9 +1291,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "887"
+      - "831"
       X-Request-Id:
-      - 4e41470f-52ec-4d5f-a28a-bd8cd4611101
+      - aaae00dc-3625-461a-a247-107c49014b58
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,10 +1305,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_tAfEmJvRgifY7RGl
+    url: https://api.katapult.io/core/v1/tasks/task_5lugvJ92MCMW12ko
     method: GET
   response:
-    body: '{"task":{"id":"task_tAfEmJvRgifY7RGl","name":"Stop virtual machine","status":"pending","created_at":1676031255,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"pending","created_at":1679506793,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1320,9 +1321,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:16 GMT
+      - Wed, 22 Mar 2023 17:39:54 GMT
       Etag:
-      - W/"b47531f2318968a16c6cee9c079f0349"
+      - W/"043ad99b22fab762fb44588f64ba0b45"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1330,9 +1331,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "874"
+      - "830"
       X-Request-Id:
-      - 0f2b4863-ffe5-4a06-9f9f-7df3f13b9605
+      - d24c8f82-178c-4504-be02-69d527edaae2
     status: 200 OK
     code: 200
     duration: ""
@@ -1344,10 +1345,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_tAfEmJvRgifY7RGl
+    url: https://api.katapult.io/core/v1/tasks/task_5lugvJ92MCMW12ko
     method: GET
   response:
-    body: '{"task":{"id":"task_tAfEmJvRgifY7RGl","name":"Stop virtual machine","status":"pending","created_at":1676031255,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"pending","created_at":1679506793,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1360,9 +1361,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:21 GMT
+      - Wed, 22 Mar 2023 17:39:59 GMT
       Etag:
-      - W/"b47531f2318968a16c6cee9c079f0349"
+      - W/"043ad99b22fab762fb44588f64ba0b45"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1370,9 +1371,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "844"
+      - "823"
       X-Request-Id:
-      - d1994c75-3da8-450a-b8d3-b6ca7e9b65b2
+      - 0a0b43f3-d81d-4274-a671-4a0b5a97d8b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1384,10 +1385,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_tAfEmJvRgifY7RGl
+    url: https://api.katapult.io/core/v1/tasks/task_5lugvJ92MCMW12ko
     method: GET
   response:
-    body: '{"task":{"id":"task_tAfEmJvRgifY7RGl","name":"Stop virtual machine","status":"running","created_at":1676031255,"started_at":1676031270,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"running","created_at":1679506793,"started_at":1679506809,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1396,13 +1397,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:31 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"df579467cbb20929c26997b619b16bdd"
+      - W/"2a54a6d4b738631d0b6d0f3c46075e93"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1410,9 +1411,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "822"
+      - "962"
       X-Request-Id:
-      - 1f419d10-8829-45a2-83bb-0a794e9cee2b
+      - 08f5d12b-e655-41e8-96e9-7894b9dc4020
     status: 200 OK
     code: 200
     duration: ""
@@ -1424,10 +1425,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_tAfEmJvRgifY7RGl
+    url: https://api.katapult.io/core/v1/tasks/task_5lugvJ92MCMW12ko
     method: GET
   response:
-    body: '{"task":{"id":"task_tAfEmJvRgifY7RGl","name":"Stop virtual machine","status":"completed","created_at":1676031255,"started_at":1676031270,"finished_at":1676031273,"progress":100}}'
+    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"completed","created_at":1679506793,"started_at":1679506809,"finished_at":1679506812,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1440,9 +1441,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:41 GMT
+      - Wed, 22 Mar 2023 17:40:19 GMT
       Etag:
-      - W/"96954f36bdd6aff2bdaad795817928c8"
+      - W/"b842a152fe66662b0eb3a8f9acc845d5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1450,9 +1451,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "813"
+      - "941"
       X-Request-Id:
-      - c9067480-c0c5-466d-b658-5ddf3f54c7a9
+      - 28779b97-bbe4-46cb-a4bc-c83b49c4a894
     status: 200 OK
     code: 200
     duration: ""
@@ -1464,20 +1465,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_MNHApHwy3CIRq769","keep_until":1676204081,"object_id":"vm_0WSdVP3qqmC4xZ6g","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_0WSdVP3qqmC4xZ6g","name":"tf-acc-test-basic-aoa3htg7gjfe","hostname":"tf-acc-test-basic-aoa3htg7gjfe-host","fqdn":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031226,"initial_root_password":"tS0FDrSXWFonWTBf","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_rFTdQzRoqwm0WhuK","keep_until":1679679619,"object_id":"vm_ATtjVqrk15NLbjDY","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_5KQyws2YivDGFxbC","address":"185.199.222.100","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.100/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"},{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-basic-aoa3htg7gjfe-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_0WSdVP3qqmC4xZ6g","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1486,13 +1487,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3220"
+      - "3257"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:41 GMT
+      - Wed, 22 Mar 2023 17:40:19 GMT
       Etag:
-      - W/"a76fc1554e0cb3e33e5be37c70ca62a2"
+      - W/"7ee526c8c9c0c547a63ec48d9956617b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1500,9 +1501,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "812"
+      - "940"
       X-Request-Id:
-      - 7dcc3e46-0117-4342-a32c-4722ccd62c78
+      - 85fa28b8-74d1-4804-982d-d59c14bed643
     status: 200 OK
     code: 200
     duration: ""
@@ -1514,7 +1515,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
     method: POST
   response:
     body: '{}'
@@ -1530,7 +1531,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:42 GMT
+      - Wed, 22 Mar 2023 17:40:20 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1540,9 +1541,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "811"
+      - "939"
       X-Request-Id:
-      - bd48c76c-a812-4c71-94af-b2f132a922eb
+      - 68eedf55-bcea-4fcc-b59f-3110b3f96f08
     status: 200 OK
     code: 200
     duration: ""
@@ -1554,7 +1555,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_5KQyws2YivDGFxbC
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
     method: POST
   response:
     body: '{}'
@@ -1570,7 +1571,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:42 GMT
+      - Wed, 22 Mar 2023 17:40:20 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1580,9 +1581,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "809"
+      - "938"
       X-Request-Id:
-      - d4ad5e2c-69ec-4933-aeaf-8101ceccd24a
+      - 3a2fb3ed-46d3-4f4e-ae8e-fe1f2d92ad2a
     status: 200 OK
     code: 200
     duration: ""
@@ -1594,10 +1595,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_MNHApHwy3CIRq769
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_rFTdQzRoqwm0WhuK
     method: DELETE
   response:
-    body: '{"task":{"id":"task_RlQsPMDSe4gXA9gS","name":"Purge items from trash","status":"pending","created_at":1676031282,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_qDVg2nY2DhyDJEyb","name":"Purge items from trash","status":"pending","created_at":1679506820,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1610,9 +1611,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:42 GMT
+      - Wed, 22 Mar 2023 17:40:20 GMT
       Etag:
-      - W/"b726cb36d05e57f6edb0fd0e6ecc27ad"
+      - W/"abe3900e2ceb9a7ad6755261656d3375"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1620,9 +1621,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "808"
+      - "937"
       X-Request-Id:
-      - 391aef8c-05a8-4577-ae7c-c43342d58a7d
+      - 75a9c650-99b1-4a35-aebd-23f3a5339ee6
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,10 +1635,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_RlQsPMDSe4gXA9gS
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_rFTdQzRoqwm0WhuK
     method: GET
   response:
-    body: '{"task":{"id":"task_RlQsPMDSe4gXA9gS","name":"Purge items from trash","status":"pending","created_at":1676031282,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"trash_object":{"id":"trsh_rFTdQzRoqwm0WhuK","keep_until":1679679619,"object_id":"vm_ATtjVqrk15NLbjDY","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1646,13 +1647,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "164"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:43 GMT
+      - Wed, 22 Mar 2023 17:40:21 GMT
       Etag:
-      - W/"b726cb36d05e57f6edb0fd0e6ecc27ad"
+      - W/"66927e902dd8821b333954fcd2df5cd1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1660,9 +1661,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "807"
+      - "936"
       X-Request-Id:
-      - 07733c6b-ee0f-4a0a-b8a8-85a6770e40b7
+      - 28f95844-3140-4daf-ab8f-51e4f5525ad1
     status: 200 OK
     code: 200
     duration: ""
@@ -1674,37 +1675,38 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_RlQsPMDSe4gXA9gS
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_rFTdQzRoqwm0WhuK
     method: GET
   response:
-    body: '{"task":{"id":"task_RlQsPMDSe4gXA9gS","name":"Purge items from trash","status":"pending","created_at":1676031282,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "164"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:48 GMT
-      Etag:
-      - W/"b726cb36d05e57f6edb0fd0e6ecc27ad"
+      - Wed, 22 Mar 2023 17:40:26 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "804"
+      - "935"
       X-Request-Id:
-      - f2df5edc-9ebd-439b-ac6e-17a9dbfafecc
-    status: 200 OK
-    code: 200
+      - 12e6ae3c-c680-4dee-ae3c-a747dda000f7
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -1714,90 +1716,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_RlQsPMDSe4gXA9gS
-    method: GET
-  response:
-    body: '{"task":{"id":"task_RlQsPMDSe4gXA9gS","name":"Purge items from trash","status":"running","created_at":1676031282,"started_at":1676031298,"finished_at":null,"progress":5}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "170"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:58 GMT
-      Etag:
-      - W/"d5cf2a165c87caaf6e63ef1557d9061d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "748"
-      X-Request-Id:
-      - c264eb64-56e5-42c2-97df-1b20e6c03421
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_RlQsPMDSe4gXA9gS
-    method: GET
-  response:
-    body: '{"task":{"id":"task_RlQsPMDSe4gXA9gS","name":"Purge items from trash","status":"completed","created_at":1676031282,"started_at":1676031298,"finished_at":1676031301,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "180"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:15:08 GMT
-      Etag:
-      - W/"3d7e6717a01322cc6ad3243ac7045252"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "934"
-      X-Request-Id:
-      - 28314cab-193e-45cd-a104-b79543e9cefb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_zcwZDZQcTvxvVOsv
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_NTWwHydGbH8aVzTD
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_zcwZDZQcTvxvVOsv","name":"tf-acc-test-basic-aoa3htg7gjfe-group","segregate":true,"created_at":1676031224}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1810,49 +1732,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:08 GMT
+      - Wed, 22 Mar 2023 17:40:26 GMT
       Etag:
-      - W/"725a1dd118c2e2780ca172dd675d906e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "931"
-      X-Request-Id:
-      - 9c624752-7521-459d-960c-2558db7b7e5d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_5KQyws2YivDGFxbC
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:15:08 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
+      - W/"9df7de160e7675268f7d4ae2f532447a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1862,7 +1744,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "933"
       X-Request-Id:
-      - ae72345a-4bcb-43f5-bd7a-d200f5b94418
+      - 15286d41-e1a4-41dc-bb40-f632784b5237
     status: 200 OK
     code: 200
     duration: ""
@@ -1874,7 +1756,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
     method: DELETE
   response:
     body: '{}'
@@ -1890,7 +1772,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:08 GMT
+      - Wed, 22 Mar 2023 17:40:26 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1902,7 +1784,47 @@ interactions:
       X-Ratelimit-Remaining:
       - "932"
       X-Request-Id:
-      - 6b6a0d25-9a59-4492-bc6f-e5454d4bc261
+      - fcd80873-f1a4-461b-8a88-808e492dc876
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:26 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "932"
+      X-Request-Id:
+      - 90cbb36b-3f38-48f6-804a-ca8c037c757d
     status: 200 OK
     code: 200
     duration: ""
@@ -1914,7 +1836,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_0WSdVP3qqmC4xZ6g
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1931,7 +1853,48 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Wed, 22 Mar 2023 17:40:26 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "930"
+      X-Request-Id:
+      - 9cb54c11-3516-4cc8-9450-3ec4eb499ac9
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:26 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1943,7 +1906,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "929"
       X-Request-Id:
-      - 32098a0e-83d7-4871-aca6-277572d6313d
+      - 11f45494-be70-4b47-b4b4-ddb096073aa4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1955,7 +1918,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_5KQyws2YivDGFxbC
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -1972,7 +1935,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
+      - Wed, 22 Mar 2023 17:40:26 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1984,48 +1947,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "928"
       X-Request-Id:
-      - feee36be-a6cc-4a43-ad82-3f975c53d901
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
-    method: GET
-  response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
-      were found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "151"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:15:09 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "927"
-      X-Request-Id:
-      - 79d0d333-5403-4324-9b26-d7d67aa342cf
+      - 31661efc-d8fb-469f-bd0b-227934b2aa5f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_basic.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_basic.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:21 GMT
+      - Thu, 23 Mar 2023 10:55:41 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "912"
+      - "880"
       X-Request-Id:
-      - 668f1a66-a9e7-4371-ac92-2ac34506e7f6
+      - 6c235919-4dbc-4ea6-b335-f017270e46c3
     status: 200 OK
     code: 200
     duration: ""
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:21 GMT
+      - Thu, 23 Mar 2023 10:55:41 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -75,15 +75,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "911"
+      - "878"
       X-Request-Id:
-      - 8a03bcea-af81-4287-ac52-f9afd5656ee2
+      - 885d843b-a708-4e1c-86cd-a42898e068fb
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -95,7 +95,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -108,9 +108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:21 GMT
+      - Thu, 23 Mar 2023 10:55:41 GMT
       Etag:
-      - W/"9df7de160e7675268f7d4ae2f532447a"
+      - W/"8f21ff81beefbb7ab3cf33151b9d5fe1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "913"
+      - "879"
       X-Request-Id:
-      - bb17da91-0022-49ff-a5a4-102bd9f8aff7
+      - b46ccf83-1cb1-4090-a784-df3a4825e815
     status: 200 OK
     code: 200
     duration: ""
@@ -132,10 +132,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_NTWwHydGbH8aVzTD
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_OUFO8Ezy4bJziepF
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -148,9 +148,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:21 GMT
+      - Thu, 23 Mar 2023 10:55:41 GMT
       Etag:
-      - W/"9df7de160e7675268f7d4ae2f532447a"
+      - W/"8f21ff81beefbb7ab3cf33151b9d5fe1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "908"
+      - "875"
       X-Request-Id:
-      - 759f8bfc-6d8a-4b96-8d15-d6ba4dfb265f
+      - 7d9694e3-a1ec-4885-a56a-6fda9f5091d3
     status: 200 OK
     code: 200
     duration: ""
@@ -178,7 +178,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"185-199-222-61.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -189,13 +189,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "552"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:25 GMT
+      - Thu, 23 Mar 2023 10:55:48 GMT
       Etag:
-      - W/"04cb2602005af9ef28a94a2bae5c5eea"
+      - W/"3a687f736929f55327502ce877b5ad62"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -203,9 +203,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "910"
+      - "877"
       X-Request-Id:
-      - aa9f5fe7-39e3-4c52-bd10-156e5dda418e
+      - c02d1681-0e2e-4885-990a-6e9895478051
     status: 200 OK
     code: 200
     duration: ""
@@ -217,10 +217,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"185-199-222-61.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -231,13 +231,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:25 GMT
+      - Thu, 23 Mar 2023 10:55:48 GMT
       Etag:
-      - W/"12922e2443b262436d64329e7aa2a01a"
+      - W/"b5edb1f478fa37e762d80d507cfdce5d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -245,9 +245,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "907"
+      - "851"
       X-Request-Id:
-      - 7a456e66-97ec-4389-a181-98d7e4919e75
+      - ae08768e-f526-42b4-96ec-8d6222486566
     status: 200 OK
     code: 200
     duration: ""
@@ -265,7 +265,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"185-199-222-97.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"185-199-222-105.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -276,13 +276,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "552"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:28 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"e4c5c4245ffa90fccf4d87c5130d81f3"
+      - W/"449b67842eb5dd994990f08d170146e0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -290,9 +290,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "909"
+      - "876"
       X-Request-Id:
-      - 94b6c2ff-14b3-4a30-bf9d-df2b9b729b01
+      - 54898f5a-adb9-4465-a998-c28e334fbd48
     status: 200 OK
     code: 200
     duration: ""
@@ -304,10 +304,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_R1WNjalxn3P4MA3L
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"185-199-222-97.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"185-199-222-105.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -318,13 +318,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:28 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"4d887cde476eaedf3439c8af2b92d954"
+      - W/"f51cd0477255534ad80315f86dbcc7f6"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -332,9 +332,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "905"
+      - "846"
       X-Request-Id:
-      - c7ebaeab-9684-42fc-8e60-5d7503f7ed15
+      - 92b24799-48f8-4ce2-b0b0-7c28d57213b4
     status: 200 OK
     code: 200
     duration: ""
@@ -346,10 +346,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"185-199-222-61.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -360,13 +360,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:28 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"12922e2443b262436d64329e7aa2a01a"
+      - W/"b5edb1f478fa37e762d80d507cfdce5d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -374,9 +374,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "904"
+      - "845"
       X-Request-Id:
-      - 9617485a-1667-4274-ba15-a4630698746b
+      - 79b341be-eac1-428a-ac18-02c24da85704
     status: 200 OK
     code: 200
     duration: ""
@@ -388,10 +388,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_R1WNjalxn3P4MA3L
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"185-199-222-97.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"185-199-222-105.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -402,13 +402,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:28 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"4d887cde476eaedf3439c8af2b92d954"
+      - W/"f51cd0477255534ad80315f86dbcc7f6"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -416,15 +416,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "903"
+      - "844"
       X-Request-Id:
-      - 2c95551d-6a88-4002-b838-682ef210f054
+      - 9432abe4-a834-4de3-8c01-2e8c9c01f5ed
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_AuDgNPM5YokLXM3Q</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_wLnEBwjoU5QWfRrr</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-basic-dwbb232cyc76-host</Hostname></Hostname><Name>tf-acc-test-basic-dwbb232cyc76</Name><Description>A web server.</Description><Group>vmgrp_NTWwHydGbH8aVzTD</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_ThTjuc3gzLUgUUVg</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_R1WNjalxn3P4MA3L</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-basic-ns7mthflgzpf-host</Hostname></Hostname><Name>tf-acc-test-basic-ns7mthflgzpf</Name><Description>A web server.</Description><Group>vmgrp_OUFO8Ezy4bJziepF</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -436,7 +436,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_qVSkKv8yQH4pYPvF","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_GQikmVmANYGuwzVU","state":"pending"},"virtual_machine_build":{"id":"vmbuild_GQikmVmANYGuwzVU","state":"pending"},"hostname":"tf-acc-test-basic-dwbb232cyc76-host"}'
+    body: '{"task":{"id":"task_YETuX1dTJ6gHGLVp","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_IRySLhVDK7Sgxj6H","state":"pending"},"virtual_machine_build":{"id":"vmbuild_IRySLhVDK7Sgxj6H","state":"pending"},"hostname":"tf-acc-test-basic-ns7mthflgzpf-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -449,9 +449,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:28 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"1dc55b46ca78019e22a4e24102fc0f9d"
+      - W/"fbaacf342db84fbec4b4e59ee079f8e7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -459,9 +459,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "902"
+      - "843"
       X-Request-Id:
-      - 4f6edaec-1f35-4159-b856-1c8c48de6045
+      - d814454d-3e65-43b3-8a21-af66e2a8217d
     status: 201 Created
     code: 201
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GQikmVmANYGuwzVU
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_IRySLhVDK7Sgxj6H
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_GQikmVmANYGuwzVU","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_IRySLhVDK7Sgxj6H","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.97\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dwbb232cyc76-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dwbb232cyc76\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_NTWwHydGbH8aVzTD\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.105\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-ns7mthflgzpf-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-ns7mthflgzpf\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_OUFO8Ezy4bJziepF\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679506768}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679568952}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -494,13 +494,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1957"
+      - "1959"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:30 GMT
+      - Thu, 23 Mar 2023 10:55:54 GMT
       Etag:
-      - W/"174b882c3b61c2c1be7aa630b05ed8d4"
+      - W/"cc45f7dd5d818d89bf001b742a722b60"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -508,9 +508,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "899"
+      - "827"
       X-Request-Id:
-      - 0f5f1a79-7003-423b-9d6a-902bbf3e8c22
+      - dc9d3022-02d3-44ae-9b12-80943325ad61
     status: 200 OK
     code: 200
     duration: ""
@@ -522,19 +522,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GQikmVmANYGuwzVU
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_IRySLhVDK7Sgxj6H
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_GQikmVmANYGuwzVU","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_IRySLhVDK7Sgxj6H","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.97\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dwbb232cyc76-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dwbb232cyc76\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_NTWwHydGbH8aVzTD\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.105\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-ns7mthflgzpf-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-ns7mthflgzpf\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_OUFO8Ezy4bJziepF\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506768}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568952}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -543,13 +543,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2167"
+      - "2169"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:35 GMT
+      - Thu, 23 Mar 2023 10:55:59 GMT
       Etag:
-      - W/"50c9d43273522a49011872b160111b31"
+      - W/"c689560c7e23a509d2063f508ad92355"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -557,9 +557,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "881"
+      - "824"
       X-Request-Id:
-      - 19d412f2-e0ff-403b-aaac-92d7ea9e4a0b
+      - 8d520e17-48b6-4faf-93ad-0bb54e3f59fe
     status: 200 OK
     code: 200
     duration: ""
@@ -571,19 +571,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GQikmVmANYGuwzVU
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_IRySLhVDK7Sgxj6H
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_GQikmVmANYGuwzVU","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_IRySLhVDK7Sgxj6H","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.97\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-dwbb232cyc76-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-dwbb232cyc76\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_NTWwHydGbH8aVzTD\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.105\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-ns7mthflgzpf-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-ns7mthflgzpf\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_OUFO8Ezy4bJziepF\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679506768}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679568952}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -592,13 +592,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2168"
+      - "2170"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:45 GMT
+      - Thu, 23 Mar 2023 10:56:09 GMT
       Etag:
-      - W/"b0dd8843b294130b3abb9a2332f6d8d1"
+      - W/"31fec747a63a2d8bda20199bc6474d17"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -606,15 +606,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "858"
+      - "992"
       X-Request-Id:
-      - af292386-f926-46f3-b54e-0d4e5e3098c9
+      - 38ec8b98-1924-4de0-a6a5-a8f2609561c1
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -626,17 +626,17 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568953,"initial_root_password":"UikFtl9FspQHD3p7","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -645,13 +645,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3123"
+      - "3127"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:45 GMT
+      - Thu, 23 Mar 2023 10:56:09 GMT
       Etag:
-      - W/"3cf8878f41896945190debeef85240bc"
+      - W/"9b359dac78a21deb8edc14f3f246da32"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -659,9 +659,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "857"
+      - "991"
       X-Request-Id:
-      - 00f4e70b-d8c1-4d69-86eb-c1e3aaa706f1
+      - 98670af4-c0a1-4edb-8b93-306cca21285b
     status: 200 OK
     code: 200
     duration: ""
@@ -673,20 +673,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568953,"initial_root_password":"UikFtl9FspQHD3p7","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -695,13 +695,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3123"
+      - "3126"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:47 GMT
+      - Thu, 23 Mar 2023 10:56:11 GMT
       Etag:
-      - W/"3cf8878f41896945190debeef85240bc"
+      - W/"159d2249c80b74411ddc32f2455ee40f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -709,9 +709,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "848"
+      - "990"
       X-Request-Id:
-      - a00978db-a19f-48c0-854d-07439160bef8
+      - ae86753a-7e41-4ad4-bbb5-5780383ce218
     status: 200 OK
     code: 200
     duration: ""
@@ -723,20 +723,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568953,"initial_root_password":"UikFtl9FspQHD3p7","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -745,13 +745,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3122"
+      - "3126"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:52 GMT
+      - Thu, 23 Mar 2023 10:56:11 GMT
       Etag:
-      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
+      - W/"159d2249c80b74411ddc32f2455ee40f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -759,9 +759,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "845"
+      - "989"
       X-Request-Id:
-      - 9f75bb68-c4e9-4c60-a474-98f2bcbf1fb6
+      - 3e09d06e-9f33-41c6-9787-e9ae87a4ca22
     status: 200 OK
     code: 200
     duration: ""
@@ -773,20 +773,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_ezPYtPoJldeEFNkb","name":"Public
+      Network on tf-acc-test-basic-ns7mthflgzpf","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -795,13 +787,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3122"
+      - "415"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:52 GMT
+      - Thu, 23 Mar 2023 10:56:11 GMT
       Etag:
-      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
+      - W/"f592f638ccc43695eb9442f980678072"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -809,9 +801,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "844"
+      - "988"
       X-Request-Id:
-      - 87d0fe2e-85b9-4f30-9892-bd594f009272
+      - 356a6fd6-bf39-4d95-8206-a5c11ee50ffa
     status: 200 OK
     code: 200
     duration: ""
@@ -823,12 +815,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_ezPYtPoJldeEFNkb
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Ww63ztf7q4416rZ6","name":"Public
-      Network on tf-acc-test-basic-dwbb232cyc76","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_ezPYtPoJldeEFNkb","virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf"},"name":"Public
+      Network on tf-acc-test-basic-ns7mthflgzpf","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:26:61:78:8d","state":"detached","ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -837,13 +829,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "413"
+      - "544"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:52 GMT
+      - Thu, 23 Mar 2023 10:56:11 GMT
       Etag:
-      - W/"42c8a34960d8b4bb3ae0e0df6d38daa7"
+      - W/"b33353d1b2c1f8cc167f50a66b8f3d9d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -851,51 +843,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "843"
+      - "987"
       X-Request-Id:
-      - 506321c5-dceb-4fa9-85d4-1d113e3942e6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Ww63ztf7q4416rZ6
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ww63ztf7q4416rZ6","virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76"},"name":"Public
-      Network on tf-acc-test-basic-dwbb232cyc76","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:10:7b:b2:0c:b5","state":"attached","ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "542"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:52 GMT
-      Etag:
-      - W/"8f54f082cf75d824ceedb036dcf3b6c8"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "842"
-      X-Request-Id:
-      - 8f21c6d6-cd6e-47af-a084-11e95d29777a
+      - 4d06e750-f836-4afe-bba1-36722fa0af19
     status: 200 OK
     code: 200
     duration: ""
@@ -907,20 +857,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568953,"initial_root_password":"UikFtl9FspQHD3p7","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -929,13 +879,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3122"
+      - "3126"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:11 GMT
       Etag:
-      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
+      - W/"159d2249c80b74411ddc32f2455ee40f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -943,9 +893,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "841"
+      - "986"
       X-Request-Id:
-      - 2e92d477-d6a4-466d-98c8-976ace7fb081
+      - be77fa2e-b450-4afc-b550-c23e5f13cc86
     status: 200 OK
     code: 200
     duration: ""
@@ -957,10 +907,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_NTWwHydGbH8aVzTD
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_OUFO8Ezy4bJziepF
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -973,9 +923,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"9df7de160e7675268f7d4ae2f532447a"
+      - W/"8f21ff81beefbb7ab3cf33151b9d5fe1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -983,9 +933,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "838"
+      - "983"
       X-Request-Id:
-      - e93fd55a-7603-4543-b953-fa6f7f99e222
+      - 57d53a95-11cb-4c1c-a33e-5a3079abb50f
     status: 200 OK
     code: 200
     duration: ""
@@ -997,12 +947,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_R1WNjalxn3P4MA3L
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1011,13 +961,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "729"
+      - "731"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"9e8f64afc5c83442a6eec7ced9e0af71"
+      - W/"a99e106c8d2cbd4a00d78d70d4c6655e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1025,9 +975,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "839"
+      - "985"
       X-Request-Id:
-      - 1dc41275-c508-49ea-ba3e-bc94ad883198
+      - 5a7a84d0-ec61-4bbb-a973-233e5e107c82
     status: 200 OK
     code: 200
     duration: ""
@@ -1039,12 +989,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1053,13 +1003,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "729"
+      - "731"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"4f19845c87cb0d942fe48aada1f762d5"
+      - W/"70b70ebd1fec5565a98d3b9ac8b33ed1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1067,9 +1017,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "837"
+      - "984"
       X-Request-Id:
-      - b07fb172-51f3-47ca-949d-ffa2e33a934e
+      - f137b9eb-8435-4f47-b81a-a8399d390342
     status: 200 OK
     code: 200
     duration: ""
@@ -1081,20 +1031,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568953,"initial_root_password":"UikFtl9FspQHD3p7","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1103,13 +1053,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3122"
+      - "3126"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
+      - W/"159d2249c80b74411ddc32f2455ee40f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1117,9 +1067,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "836"
+      - "982"
       X-Request-Id:
-      - 992edc44-698b-469e-af62-b2338761dcfa
+      - 5ca6f913-82b1-4a0e-810f-89fb03d5fc25
     status: 200 OK
     code: 200
     duration: ""
@@ -1131,12 +1081,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Ww63ztf7q4416rZ6","name":"Public
-      Network on tf-acc-test-basic-dwbb232cyc76","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_ezPYtPoJldeEFNkb","name":"Public
+      Network on tf-acc-test-basic-ns7mthflgzpf","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1145,13 +1095,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "413"
+      - "415"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"42c8a34960d8b4bb3ae0e0df6d38daa7"
+      - W/"f592f638ccc43695eb9442f980678072"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1159,9 +1109,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "835"
+      - "981"
       X-Request-Id:
-      - d9053eab-d094-4dd7-b195-3eefdb7149f2
+      - 88168812-c1e8-4f29-a40a-046607329701
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,12 +1123,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Ww63ztf7q4416rZ6
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_ezPYtPoJldeEFNkb
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Ww63ztf7q4416rZ6","virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76"},"name":"Public
-      Network on tf-acc-test-basic-dwbb232cyc76","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:10:7b:b2:0c:b5","state":"attached","ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_ezPYtPoJldeEFNkb","virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf"},"name":"Public
+      Network on tf-acc-test-basic-ns7mthflgzpf","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:26:61:78:8d","state":"attached","ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1187,13 +1137,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "542"
+      - "544"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"8f54f082cf75d824ceedb036dcf3b6c8"
+      - W/"c06a7e2886d15e254652d523184066bc"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1201,9 +1151,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "834"
+      - "980"
       X-Request-Id:
-      - c7ef018e-be82-4bea-8fbc-8534c4500a4d
+      - 6edb4196-6337-40bd-bf35-34a69cf7faa0
     status: 200 OK
     code: 200
     duration: ""
@@ -1215,20 +1165,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568953,"initial_root_password":"UikFtl9FspQHD3p7","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1237,13 +1187,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3122"
+      - "3126"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"9ba16a1ddfde2199f3b49617eb0b2dc2"
+      - W/"159d2249c80b74411ddc32f2455ee40f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1251,9 +1201,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "832"
+      - "978"
       X-Request-Id:
-      - d40bafb1-d265-46e5-94b4-7a45ecfb445e
+      - 81aaa408-c84f-4f2b-90dc-822f356325ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1265,10 +1215,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: POST
   response:
-    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_PL2yJuVSYI4iD4Zz","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1281,9 +1231,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"3c067c66758732f4ed58004ec79b8d85"
+      - W/"edfbc0a8713f9b037fdd6ff1e894d1ac"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1291,9 +1241,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "831"
+      - "976"
       X-Request-Id:
-      - aaae00dc-3625-461a-a247-107c49014b58
+      - efdca020-feec-4d68-8b93-aa65b4d5c014
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,10 +1255,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_5lugvJ92MCMW12ko
+    url: https://api.katapult.io/core/v1/tasks/task_PL2yJuVSYI4iD4Zz
     method: GET
   response:
-    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"pending","created_at":1679506793,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_PL2yJuVSYI4iD4Zz","name":"Stop virtual machine","status":"pending","created_at":1679568972,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1321,9 +1271,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:54 GMT
+      - Thu, 23 Mar 2023 10:56:13 GMT
       Etag:
-      - W/"043ad99b22fab762fb44588f64ba0b45"
+      - W/"05d8da701e97089505b23f5a12c1377d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1331,9 +1281,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "830"
+      - "975"
       X-Request-Id:
-      - d24c8f82-178c-4504-be02-69d527edaae2
+      - 98a7c4be-0fd1-49f7-aa0d-42df5fa6dc46
     status: 200 OK
     code: 200
     duration: ""
@@ -1345,10 +1295,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_5lugvJ92MCMW12ko
+    url: https://api.katapult.io/core/v1/tasks/task_PL2yJuVSYI4iD4Zz
     method: GET
   response:
-    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"pending","created_at":1679506793,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_PL2yJuVSYI4iD4Zz","name":"Stop virtual machine","status":"pending","created_at":1679568972,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1361,9 +1311,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:59 GMT
+      - Thu, 23 Mar 2023 10:56:18 GMT
       Etag:
-      - W/"043ad99b22fab762fb44588f64ba0b45"
+      - W/"05d8da701e97089505b23f5a12c1377d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1371,9 +1321,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "823"
+      - "960"
       X-Request-Id:
-      - 0a0b43f3-d81d-4274-a671-4a0b5a97d8b9
+      - f123273e-6a47-45da-8ee6-d7cd32a4ac30
     status: 200 OK
     code: 200
     duration: ""
@@ -1385,10 +1335,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_5lugvJ92MCMW12ko
+    url: https://api.katapult.io/core/v1/tasks/task_PL2yJuVSYI4iD4Zz
     method: GET
   response:
-    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"running","created_at":1679506793,"started_at":1679506809,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_PL2yJuVSYI4iD4Zz","name":"Stop virtual machine","status":"running","created_at":1679568972,"started_at":1679568987,"finished_at":null,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1397,13 +1347,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "170"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:56:28 GMT
       Etag:
-      - W/"2a54a6d4b738631d0b6d0f3c46075e93"
+      - W/"cd0c792c88e9390b3e59e1e5323d1cb0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1411,9 +1361,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "953"
       X-Request-Id:
-      - 08f5d12b-e655-41e8-96e9-7894b9dc4020
+      - fa496b7f-6078-4f13-9c88-61618d9ed25f
     status: 200 OK
     code: 200
     duration: ""
@@ -1425,10 +1375,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_5lugvJ92MCMW12ko
+    url: https://api.katapult.io/core/v1/tasks/task_PL2yJuVSYI4iD4Zz
     method: GET
   response:
-    body: '{"task":{"id":"task_5lugvJ92MCMW12ko","name":"Stop virtual machine","status":"completed","created_at":1679506793,"started_at":1679506809,"finished_at":1679506812,"progress":100}}'
+    body: '{"task":{"id":"task_PL2yJuVSYI4iD4Zz","name":"Stop virtual machine","status":"completed","created_at":1679568972,"started_at":1679568987,"finished_at":1679568989,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1441,9 +1391,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:19 GMT
+      - Thu, 23 Mar 2023 10:56:38 GMT
       Etag:
-      - W/"b842a152fe66662b0eb3a8f9acc845d5"
+      - W/"0965d8044e32216cf2716239ea635312"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1451,9 +1401,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "951"
       X-Request-Id:
-      - 28779b97-bbe4-46cb-a4bc-c83b49c4a894
+      - a9b3d1ef-c345-4749-a31e-c62e021558d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,20 +1415,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_rFTdQzRoqwm0WhuK","keep_until":1679679619,"object_id":"vm_ATtjVqrk15NLbjDY","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_ATtjVqrk15NLbjDY","name":"tf-acc-test-basic-dwbb232cyc76","hostname":"tf-acc-test-basic-dwbb232cyc76-host","fqdn":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506770,"initial_root_password":"IFSddzYbPHB3xb4B","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_J90Oa3aiYFCI1z58","keep_until":1679741798,"object_id":"vm_65PEe6xFsJrCMUBp","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_65PEe6xFsJrCMUBp","name":"tf-acc-test-basic-ns7mthflgzpf","hostname":"tf-acc-test-basic-ns7mthflgzpf-host","fqdn":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568953,"initial_root_password":"UikFtl9FspQHD3p7","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_AuDgNPM5YokLXM3Q","address":"185.199.222.61","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.61/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_R1WNjalxn3P4MA3L","address":"185.199.222.105","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.105/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"},{"id":"ip_wLnEBwjoU5QWfRrr","address":"185.199.222.97","reverse_dns":"tf-acc-test-basic-dwbb232cyc76-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.97/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"},{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-basic-ns7mthflgzpf-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_ATtjVqrk15NLbjDY","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_65PEe6xFsJrCMUBp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1487,13 +1437,93 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3257"
+      - "3261"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:19 GMT
+      - Thu, 23 Mar 2023 10:56:38 GMT
       Etag:
-      - W/"7ee526c8c9c0c547a63ec48d9956617b"
+      - W/"d35a3ad18fe841dbffa7d6a6dbf535a6"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "950"
+      X-Request-Id:
+      - 5a879d94-1807-4a25-915b-3e793471e989
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:39 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - a512c736-6950-48f1-81f8-27dfe6861ee4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_R1WNjalxn3P4MA3L
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:39 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1503,7 +1533,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "940"
       X-Request-Id:
-      - 85fa28b8-74d1-4804-982d-d59c14bed643
+      - a251c119-7cd6-4ee6-8d2a-b75ff5fc087f
     status: 200 OK
     code: 200
     duration: ""
@@ -1515,90 +1545,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
-    method: POST
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:20 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "939"
-      X-Request-Id:
-      - 68eedf55-bcea-4fcc-b59f-3110b3f96f08
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
-    method: POST
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:20 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "938"
-      X-Request-Id:
-      - 3a2fb3ed-46d3-4f4e-ae8e-fe1f2d92ad2a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_rFTdQzRoqwm0WhuK
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_J90Oa3aiYFCI1z58
     method: DELETE
   response:
-    body: '{"task":{"id":"task_qDVg2nY2DhyDJEyb","name":"Purge items from trash","status":"pending","created_at":1679506820,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_4PvcCT7WNMTFEQzK","name":"Purge items from trash","status":"pending","created_at":1679568999,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1611,9 +1561,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:20 GMT
+      - Thu, 23 Mar 2023 10:56:39 GMT
       Etag:
-      - W/"abe3900e2ceb9a7ad6755261656d3375"
+      - W/"1afd1e051065c52d6233d7d042dc63ce"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1621,9 +1571,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "937"
+      - "939"
       X-Request-Id:
-      - 75a9c650-99b1-4a35-aebd-23f3a5339ee6
+      - aafdeaff-bc26-4fed-b8fb-9fdbaad10f29
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,10 +1585,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_rFTdQzRoqwm0WhuK
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_J90Oa3aiYFCI1z58
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_rFTdQzRoqwm0WhuK","keep_until":1679679619,"object_id":"vm_ATtjVqrk15NLbjDY","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_J90Oa3aiYFCI1z58","keep_until":1679741798,"object_id":"vm_65PEe6xFsJrCMUBp","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1651,9 +1601,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:21 GMT
+      - Thu, 23 Mar 2023 10:56:40 GMT
       Etag:
-      - W/"66927e902dd8821b333954fcd2df5cd1"
+      - W/"17834ed3b1d0adced950fbd63a65388e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1661,9 +1611,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "936"
+      - "938"
       X-Request-Id:
-      - 28f95844-3140-4daf-ab8f-51e4f5525ad1
+      - a8cc7b53-b546-4bb2-986c-fa5afab90bbf
     status: 200 OK
     code: 200
     duration: ""
@@ -1675,7 +1625,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_rFTdQzRoqwm0WhuK
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_J90Oa3aiYFCI1z58
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -1692,7 +1642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:26 GMT
+      - Thu, 23 Mar 2023 10:56:45 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1702,9 +1652,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "935"
+      - "937"
       X-Request-Id:
-      - 12e6ae3c-c680-4dee-ae3c-a747dda000f7
+      - b0b18371-dcae-409b-8d8d-4887b374b511
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1716,10 +1666,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_NTWwHydGbH8aVzTD
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_OUFO8Ezy4bJziepF
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_NTWwHydGbH8aVzTD","name":"tf-acc-test-basic-dwbb232cyc76-group","segregate":true,"created_at":1679506761}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_OUFO8Ezy4bJziepF","name":"tf-acc-test-basic-ns7mthflgzpf-group","segregate":true,"created_at":1679568941}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1732,9 +1682,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:26 GMT
+      - Thu, 23 Mar 2023 10:56:45 GMT
       Etag:
-      - W/"9df7de160e7675268f7d4ae2f532447a"
+      - W/"8f21ff81beefbb7ab3cf33151b9d5fe1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1742,9 +1692,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "933"
+      - "934"
       X-Request-Id:
-      - 15286d41-e1a4-41dc-bb40-f632784b5237
+      - e2ed560c-d317-4b64-97bd-dc2d70e29744
     status: 200 OK
     code: 200
     duration: ""
@@ -1756,7 +1706,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_R1WNjalxn3P4MA3L
     method: DELETE
   response:
     body: '{}'
@@ -1772,7 +1722,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:26 GMT
+      - Thu, 23 Mar 2023 10:56:45 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1782,9 +1732,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "932"
+      - "936"
       X-Request-Id:
-      - fcd80873-f1a4-461b-8a88-808e492dc876
+      - add66410-3baa-45f4-8dfd-2e7d6e713de1
     status: 200 OK
     code: 200
     duration: ""
@@ -1796,7 +1746,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: DELETE
   response:
     body: '{}'
@@ -1812,7 +1762,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:26 GMT
+      - Thu, 23 Mar 2023 10:56:47 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1822,9 +1772,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "932"
+      - "936"
       X-Request-Id:
-      - 90cbb36b-3f38-48f6-804a-ca8c037c757d
+      - 4ab7eeb4-ef9c-436f-b906-1cef5f0f2984
     status: 200 OK
     code: 200
     duration: ""
@@ -1836,7 +1786,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_ATtjVqrk15NLbjDY
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_65PEe6xFsJrCMUBp
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1853,7 +1803,130 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:26 GMT
+      - Thu, 23 Mar 2023 10:56:47 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "933"
+      X-Request-Id:
+      - aefb893a-7289-4117-bd71-35481f342f34
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_65PEe6xFsJrCMUBp
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:47 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "932"
+      X-Request-Id:
+      - c91ad0c8-837c-44ee-b6e9-f09fe22fe025
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:47 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "931"
+      X-Request-Id:
+      - 2848e49c-b13a-4de2-a629-60c4932687ab
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_R1WNjalxn3P4MA3L
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:47 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1865,89 +1938,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "930"
       X-Request-Id:
-      - 9cb54c11-3516-4cc8-9450-3ec4eb499ac9
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_wLnEBwjoU5QWfRrr
-    method: GET
-  response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
-      were found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "151"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:26 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "929"
-      X-Request-Id:
-      - 11f45494-be70-4b47-b4b4-ddb096073aa4
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_AuDgNPM5YokLXM3Q
-    method: GET
-  response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
-      were found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "151"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:26 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "928"
-      X-Request-Id:
-      - 31661efc-d8fb-469f-bd0b-227934b2aa5f
+      - 9d38a2e0-a595-415c-a093-5f1b5f0189a3
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_custom_disks.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_custom_disks.cassette.rand_id
@@ -1,1 +1,1 @@
-m0munbbpkm3n
+ft3k6tpxc7yi

--- a/internal/provider/testdata/VirtualMachine_custom_disks.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_custom_disks.cassette.rand_id
@@ -1,1 +1,1 @@
-j7bvkhzeb9fz
+m0munbbpkm3n

--- a/internal/provider/testdata/VirtualMachine_custom_disks.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_custom_disks.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
+      - Wed, 22 Mar 2023 17:38:10 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "980"
+      - "996"
       X-Request-Id:
-      - 12c5d523-2bdd-4edf-9cfa-6f5e9e6bf1ae
+      - 8c288043-8b92-42af-9b06-dfb3e509ee8c
     status: 200 OK
     code: 200
     duration: ""
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
+      - Wed, 22 Mar 2023 17:38:10 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -75,15 +75,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "978"
+      - "993"
       X-Request-Id:
-      - 7eaeb625-263c-487e-8ea3-4a8cd389b02a
+      - 9ece52de-0567-4606-90f5-ebd70e68e01d
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -95,7 +95,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -108,9 +108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
+      - Wed, 22 Mar 2023 17:38:10 GMT
       Etag:
-      - W/"b31a71edc87a56c170f0dfeba61c5dd5"
+      - W/"f3fe1799a09f12d5e27233bc5b0f94ae"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "980"
+      - "996"
       X-Request-Id:
-      - a62f81f8-61a7-40fc-ae67-7669b9e08948
+      - 45fa9ba3-333f-403e-b95b-eb6510ac4a3d
     status: 200 OK
     code: 200
     duration: ""
@@ -132,10 +132,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_EiJha1G2P7iivL1X
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_L80o7ZCG8Dlzn0IP
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -148,9 +148,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
+      - Wed, 22 Mar 2023 17:38:10 GMT
       Etag:
-      - W/"b31a71edc87a56c170f0dfeba61c5dd5"
+      - W/"f3fe1799a09f12d5e27233bc5b0f94ae"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "991"
       X-Request-Id:
-      - bfcbce2e-92c1-4d5f-bf9b-a0969a398101
+      - c7756e02-c855-4b42-ab0e-7c71994cd994
     status: 200 OK
     code: 200
     duration: ""
@@ -178,52 +178,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"185-199-222-110.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "552"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
-      Etag:
-      - W/"cd27f55240c181e782511ea3cbbac6e5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - 6c76b8fb-7a5a-47f6-9cb8-9811f45cb2ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
-    method: POST
-  response:
-    body: '{"ip_address":{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"185-199-222-59.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -238,9 +193,138 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
+      - Wed, 22 Mar 2023 17:38:24 GMT
       Etag:
-      - W/"ba45593313d2eaa9119ef9c2bdb175a9"
+      - W/"02acb1d6e39d2dd3d1fdd50d084a43c8"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 57fdf298-7871-4365-8b70-b875a9e276a2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "567"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:24 GMT
+      Etag:
+      - W/"302278f172a97bb1f106ca9e8f0749c2"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - fe1a9ee2-c7e4-4c7d-8500-3da91b8a3746
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"185-199-222-213.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "552"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:29 GMT
+      Etag:
+      - W/"4f3cd47e2ee7c0f358ef4337e48e28a3"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - df6c9157-fc8b-4e83-8c97-427e2c28cb51
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"185-199-222-213.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:29 GMT
+      Etag:
+      - W/"0c38e0e15be1e3e90ede6c372c94687d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -250,7 +334,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - bcf019d5-d4ad-4299-95f7-bcb359648c10
+      - 253dc095-ca22-470c-b2b5-8ce52609257e
     status: 200 OK
     code: 200
     duration: ""
@@ -262,10 +346,52 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"185-199-222-110.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "567"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:29 GMT
+      Etag:
+      - W/"302278f172a97bb1f106ca9e8f0749c2"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 09c500d0-04c2-486d-9d6b-038c3c0c6e98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"185-199-222-213.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -280,9 +406,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
+      - Wed, 22 Mar 2023 17:38:29 GMT
       Etag:
-      - W/"988b8e487f5a90073bdfc45e4a28611c"
+      - W/"0c38e0e15be1e3e90ede6c372c94687d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -292,139 +418,13 @@ interactions:
       X-Ratelimit-Remaining:
       - "974"
       X-Request-Id:
-      - 80d23d38-3520-42c9-aca9-8fac4282e87d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_IfpYnsZOYg3w24re
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"185-199-222-59.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
-      Etag:
-      - W/"701dbca2c2df4dc229a9a7e310e47ec8"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "973"
-      X-Request-Id:
-      - 68d4cc66-b83e-48a5-a297-75d7d4faa749
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_IfpYnsZOYg3w24re
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"185-199-222-59.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
-      Etag:
-      - W/"701dbca2c2df4dc229a9a7e310e47ec8"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "972"
-      X-Request-Id:
-      - 79a66343-3877-4304-bb6d-66c3158afc17
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"185-199-222-110.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "570"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
-      Etag:
-      - W/"988b8e487f5a90073bdfc45e4a28611c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - b5f5e522-b0c7-47ab-a053-7f97029044bc
+      - 47ea7aae-1b3a-4b29-8e72-9eddfd7a17c6
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><SystemDisks><Disk><Name>System</Name><Size>20</Size></Disk><Disk><Name>Data</Name><Size>10</Size></Disk><Disk><Name>Disk #3</Name><Size>10</Size></Disk></SystemDisks><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_IfpYnsZOYg3w24re</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_Gl63yHUEkeELpdGm</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-custom-disks-j7bvkhzeb9fz-host</Hostname></Hostname><Name>tf-acc-test-custom-disks-j7bvkhzeb9fz</Name><Description>A web server.</Description><Group>vmgrp_EiJha1G2P7iivL1X</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><SystemDisks><Disk><Name>System</Name><Size>20</Size></Disk><Disk><Name>Data</Name><Size>10</Size></Disk><Disk><Name>Disk #3</Name><Size>10</Size></Disk></SystemDisks><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_KbfXZm6mJYp6AdZf</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_T4SGxVKBxX6tyqWy</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-custom-disks-m0munbbpkm3n-host</Hostname></Hostname><Name>tf-acc-test-custom-disks-m0munbbpkm3n</Name><Description>A web server.</Description><Group>vmgrp_L80o7ZCG8Dlzn0IP</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -436,7 +436,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_NJQqXNwiqDZteV8M","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_7YHMr4QhnEDdYpos","state":"pending"},"virtual_machine_build":{"id":"vmbuild_7YHMr4QhnEDdYpos","state":"pending"},"hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host"}'
+    body: '{"task":{"id":"task_T6mCXG9jsYOHV5iq","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","state":"pending"},"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","state":"pending"},"hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -449,9 +449,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:23 GMT
+      - Wed, 22 Mar 2023 17:38:29 GMT
       Etag:
-      - W/"2dd2b3c63c34e3dbeca0c9e18187fb66"
+      - W/"5f7ccbedd41ea567886d8b590f361d88"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -459,9 +459,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "970"
+      - "973"
       X-Request-Id:
-      - c15c2827-3b8b-4346-b8a9-a671d252c374
+      - 4f0b88a7-273c-4063-a610-b95f61ef724c
     status: 201 Created
     code: 201
     duration: ""
@@ -473,20 +473,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_7YHMr4QhnEDdYpos
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_heCkDlWXL6uJ0WXT
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_7YHMr4QhnEDdYpos","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.59\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.110\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-j7bvkhzeb9fz-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-j7bvkhzeb9fz\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_EiJha1G2P7iivL1X\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.213\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-m0munbbpkm3n-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-m0munbbpkm3n\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_L80o7ZCG8Dlzn0IP\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031683}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506709}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -499,9 +499,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:25 GMT
+      - Wed, 22 Mar 2023 17:38:31 GMT
       Etag:
-      - W/"298fbadd78b536c596ddc75011a6448a"
+      - W/"93c5228e11863cd99c63c32ffa99a68a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -509,9 +509,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "969"
+      - "972"
       X-Request-Id:
-      - 09fa6981-d205-456a-b9d0-31383f87aed6
+      - a1fec605-8052-4845-86bd-b7efcc2bcb4e
     status: 200 OK
     code: 200
     duration: ""
@@ -523,20 +523,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_7YHMr4QhnEDdYpos
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_heCkDlWXL6uJ0WXT
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_7YHMr4QhnEDdYpos","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.59\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.110\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-j7bvkhzeb9fz-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-j7bvkhzeb9fz\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_EiJha1G2P7iivL1X\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.213\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-m0munbbpkm3n-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-m0munbbpkm3n\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_L80o7ZCG8Dlzn0IP\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031683}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506709}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -549,9 +549,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:30 GMT
+      - Wed, 22 Mar 2023 17:38:36 GMT
       Etag:
-      - W/"298fbadd78b536c596ddc75011a6448a"
+      - W/"93c5228e11863cd99c63c32ffa99a68a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -559,9 +559,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "968"
+      - "955"
       X-Request-Id:
-      - b121d78f-9469-4ba2-844a-ac4cab41568e
+      - 64ae0d09-c758-4717-b0f4-05527ed4ddaf
     status: 200 OK
     code: 200
     duration: ""
@@ -573,20 +573,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_7YHMr4QhnEDdYpos
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_heCkDlWXL6uJ0WXT
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_7YHMr4QhnEDdYpos","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.59\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.110\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-j7bvkhzeb9fz-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-j7bvkhzeb9fz\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_EiJha1G2P7iivL1X\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.213\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-m0munbbpkm3n-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-m0munbbpkm3n\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_L80o7ZCG8Dlzn0IP\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1676031683}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506709}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -595,13 +595,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2663"
+      - "2662"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:40 GMT
+      - Wed, 22 Mar 2023 17:38:46 GMT
       Etag:
-      - W/"7067165c2db00f971d8714a0a121895e"
+      - W/"93c5228e11863cd99c63c32ffa99a68a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -609,15 +609,65 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "925"
       X-Request-Id:
-      - 4a506800-095b-4749-bab3-128370d99846
+      - 3f2f5ece-99c1-495b-b387-2abdfa67265f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_heCkDlWXL6uJ0WXT
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
+      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.213\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-m0munbbpkm3n-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-m0munbbpkm3n\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_L80o7ZCG8Dlzn0IP\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679506709}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2662"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:56 GMT
+      Etag:
+      - W/"cce2a8ff846c54dec4deba6e53039bd0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "907"
+      X-Request-Id:
+      - 7925ce99-0e6d-4974-9a65-a635c3df56ba
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -629,17 +679,17 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031684,"initial_root_password":"Bkot91f6plL36xFS","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -648,13 +698,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3126"
+      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:40 GMT
+      - Wed, 22 Mar 2023 17:38:56 GMT
       Etag:
-      - W/"0a2814bf9c861340f5f656170cb28422"
+      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -662,9 +712,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "906"
       X-Request-Id:
-      - 472f4bca-a421-4a3f-b6e2-4ada3a65fccc
+      - c9d6ab25-56d0-493d-83db-a9259b610345
     status: 200 OK
     code: 200
     duration: ""
@@ -676,20 +726,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031684,"initial_root_password":"Bkot91f6plL36xFS","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -698,13 +748,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3126"
+      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:43 GMT
+      - Wed, 22 Mar 2023 17:38:58 GMT
       Etag:
-      - W/"0a2814bf9c861340f5f656170cb28422"
+      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -712,9 +762,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "905"
       X-Request-Id:
-      - bb4439dc-4ed7-4058-a214-24fe6fcb288b
+      - e93eaab4-2ee3-4a18-b4b5-df70c9ccc25e
     status: 200 OK
     code: 200
     duration: ""
@@ -726,20 +776,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031684,"initial_root_password":"Bkot91f6plL36xFS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -748,13 +798,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3125"
+      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:58 GMT
       Etag:
-      - W/"b571506ba35a9b93a9009fdfd1d77692"
+      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -762,9 +812,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "904"
       X-Request-Id:
-      - 0a9d8992-1603-45ec-a447-b4dcdac0e5bc
+      - 29c4e0c7-ad47-47b6-8713-e2af00a95312
     status: 200 OK
     code: 200
     duration: ""
@@ -776,62 +826,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031684,"initial_root_password":"Bkot91f6plL36xFS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3125"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
-      Etag:
-      - W/"b571506ba35a9b93a9009fdfd1d77692"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "963"
-      X-Request-Id:
-      - 4542da55-6764-4af4-b04c-d678c3c8a63b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_fLYXAdq9ZGA4VHER","name":"Public
-      Network on tf-acc-test-custom-disks-j7bvkhzeb9fz","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_M41UxXCoKdXpRRLs","name":"Public
+      Network on tf-acc-test-custom-disks-m0munbbpkm3n","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -844,9 +844,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:58 GMT
       Etag:
-      - W/"ba5efb8550e2c8152c4e83852c1b4b75"
+      - W/"99efe87d258ab3a314963d1582f6c094"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -854,9 +854,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "903"
       X-Request-Id:
-      - 9f94ae9f-ce72-42c2-8aca-9af460db56a6
+      - 56c19a61-292c-48cb-abbd-df660b675040
     status: 200 OK
     code: 200
     duration: ""
@@ -868,12 +868,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_fLYXAdq9ZGA4VHER
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_M41UxXCoKdXpRRLs
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_fLYXAdq9ZGA4VHER","virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz"},"name":"Public
-      Network on tf-acc-test-custom-disks-j7bvkhzeb9fz","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:b9:e7:39:25:cc","state":"attached","ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_M41UxXCoKdXpRRLs","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n"},"name":"Public
+      Network on tf-acc-test-custom-disks-m0munbbpkm3n","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:a9:92:74:fe:b6","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -886,9 +886,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:58 GMT
       Etag:
-      - W/"d0e5270f6a73dd41d68afce37bdac258"
+      - W/"94c5f8e85849613e0d2a7ee6483770d3"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -896,9 +896,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "902"
       X-Request-Id:
-      - 87e166d2-fdac-4d61-84f2-cc3078653039
+      - 08132cec-4177-4f58-9eb2-cdc2732bcb84
     status: 200 OK
     code: 200
     duration: ""
@@ -910,20 +910,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031684,"initial_root_password":"Bkot91f6plL36xFS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -932,13 +932,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3125"
+      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"b571506ba35a9b93a9009fdfd1d77692"
+      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -946,9 +946,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "901"
       X-Request-Id:
-      - fc2bb5eb-ba26-4438-a3c7-65d44da5efcd
+      - a0d72309-9503-405b-b0c3-83a60bd418c4
     status: 200 OK
     code: 200
     duration: ""
@@ -960,10 +960,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_EiJha1G2P7iivL1X
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_L80o7ZCG8Dlzn0IP
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -976,9 +976,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"b31a71edc87a56c170f0dfeba61c5dd5"
+      - W/"f3fe1799a09f12d5e27233bc5b0f94ae"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -986,9 +986,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "899"
       X-Request-Id:
-      - 418ab65b-4f62-4dab-a512-6c74d890e65d
+      - d250b902-7d4b-4e3b-bd26-2b82b2ae7a3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1000,12 +1000,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1018,9 +1018,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"9013ec9ffa68cb2963dde0ede6cbf1b8"
+      - W/"b5703203731acdf8567b57b7b8c11de9"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1028,9 +1028,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "900"
       X-Request-Id:
-      - 247429e9-46df-47d3-a1af-a74cbddbd3f3
+      - ee2b52ca-0bac-4fa2-be19-eb14e62a6fc8
     status: 200 OK
     code: 200
     duration: ""
@@ -1042,12 +1042,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_IfpYnsZOYg3w24re
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1060,9 +1060,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"4ca5f94180d3825826f9f4f65babd818"
+      - W/"17b5003beefb111291c184249b8e2175"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1070,9 +1070,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "898"
       X-Request-Id:
-      - a965c834-b6f0-4bd0-a589-1e9a6d15e490
+      - 22bb83ec-4c76-4e68-b180-49b932dac348
     status: 200 OK
     code: 200
     duration: ""
@@ -1084,20 +1084,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031684,"initial_root_password":"Bkot91f6plL36xFS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1106,13 +1106,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3125"
+      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"b571506ba35a9b93a9009fdfd1d77692"
+      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1120,9 +1120,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "897"
       X-Request-Id:
-      - e8f619b9-1f60-459e-8859-b8bf3a2088fc
+      - 5120b4a4-c535-4546-ae85-d4f200b3d7f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1134,12 +1134,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_fLYXAdq9ZGA4VHER","name":"Public
-      Network on tf-acc-test-custom-disks-j7bvkhzeb9fz","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_M41UxXCoKdXpRRLs","name":"Public
+      Network on tf-acc-test-custom-disks-m0munbbpkm3n","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1152,9 +1152,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"ba5efb8550e2c8152c4e83852c1b4b75"
+      - W/"99efe87d258ab3a314963d1582f6c094"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1162,9 +1162,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "896"
       X-Request-Id:
-      - 92e597b2-25c0-4014-9957-b4cce82582da
+      - ef607239-711a-4022-b5b1-ae7e5583b213
     status: 200 OK
     code: 200
     duration: ""
@@ -1176,12 +1176,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_fLYXAdq9ZGA4VHER
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_M41UxXCoKdXpRRLs
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_fLYXAdq9ZGA4VHER","virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz"},"name":"Public
-      Network on tf-acc-test-custom-disks-j7bvkhzeb9fz","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:b9:e7:39:25:cc","state":"attached","ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_M41UxXCoKdXpRRLs","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n"},"name":"Public
+      Network on tf-acc-test-custom-disks-m0munbbpkm3n","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:a9:92:74:fe:b6","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1194,9 +1194,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"d0e5270f6a73dd41d68afce37bdac258"
+      - W/"94c5f8e85849613e0d2a7ee6483770d3"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1204,9 +1204,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "895"
       X-Request-Id:
-      - 673d2de1-b126-42f0-8029-66688c2e8c2e
+      - 58716ce5-d797-4e16-b046-38b00207cdcb
     status: 200 OK
     code: 200
     duration: ""
@@ -1218,20 +1218,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031684,"initial_root_password":"Bkot91f6plL36xFS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1240,13 +1240,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3125"
+      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:48 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"b571506ba35a9b93a9009fdfd1d77692"
+      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1254,9 +1254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "894"
       X-Request-Id:
-      - 2c1dbba2-4b0d-4b98-83af-c3481cc187a7
+      - fcf5d4e4-b083-4666-b976-4cb3f27401d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1268,10 +1268,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: POST
   response:
-    body: '{"task":{"id":"task_7uAiEUS8aN4CHA3k","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1284,9 +1284,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:49 GMT
+      - Wed, 22 Mar 2023 17:38:59 GMT
       Etag:
-      - W/"02b74d0b2eb903deb8de3db3a2e53b29"
+      - W/"9d17050e32a0cf69806a3303f83496bf"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1294,9 +1294,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "952"
+      - "893"
       X-Request-Id:
-      - cefe1c09-a733-4966-b097-d7ee10338fc7
+      - de915b61-419a-44db-912a-05cb612ccd51
     status: 200 OK
     code: 200
     duration: ""
@@ -1308,10 +1308,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7uAiEUS8aN4CHA3k
+    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
     method: GET
   response:
-    body: '{"task":{"id":"task_7uAiEUS8aN4CHA3k","name":"Stop virtual machine","status":"pending","created_at":1676031708,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1324,9 +1324,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:50 GMT
+      - Wed, 22 Mar 2023 17:39:00 GMT
       Etag:
-      - W/"651039fd4f7e1e3a5fbc30698c13504b"
+      - W/"2a69e33fc2eae11f9ca44a43d755f566"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1334,9 +1334,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "951"
+      - "990"
       X-Request-Id:
-      - e571d4d8-3dda-45e6-b02d-7f7ab66c6a87
+      - 2bb9a76e-a462-4b2d-b5ef-3e8fa2af1005
     status: 200 OK
     code: 200
     duration: ""
@@ -1348,10 +1348,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7uAiEUS8aN4CHA3k
+    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
     method: GET
   response:
-    body: '{"task":{"id":"task_7uAiEUS8aN4CHA3k","name":"Stop virtual machine","status":"pending","created_at":1676031708,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1364,9 +1364,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:21:55 GMT
+      - Wed, 22 Mar 2023 17:39:05 GMT
       Etag:
-      - W/"651039fd4f7e1e3a5fbc30698c13504b"
+      - W/"2a69e33fc2eae11f9ca44a43d755f566"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1374,9 +1374,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "950"
+      - "967"
       X-Request-Id:
-      - f21d919c-7d44-45c9-8e63-ba5ba673ee70
+      - 8460569e-f38d-4aa9-8a2a-7b275648cdcb
     status: 200 OK
     code: 200
     duration: ""
@@ -1388,10 +1388,130 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7uAiEUS8aN4CHA3k
+    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
     method: GET
   response:
-    body: '{"task":{"id":"task_7uAiEUS8aN4CHA3k","name":"Stop virtual machine","status":"running","created_at":1676031708,"started_at":1676031724,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:15 GMT
+      Etag:
+      - W/"2a69e33fc2eae11f9ca44a43d755f566"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "922"
+      X-Request-Id:
+      - 15e207e8-dde2-4b19-b97b-c6912b488a12
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
+    method: GET
+  response:
+    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:26 GMT
+      Etag:
+      - W/"2a69e33fc2eae11f9ca44a43d755f566"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "906"
+      X-Request-Id:
+      - c2a21916-644e-461c-a5f9-31f3ef5e0ce3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
+    method: GET
+  response:
+    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:36 GMT
+      Etag:
+      - W/"2a69e33fc2eae11f9ca44a43d755f566"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "880"
+      X-Request-Id:
+      - 6a302008-0e43-4d03-9034-513bafba1d22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
+    method: GET
+  response:
+    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"running","created_at":1679506739,"started_at":1679506785,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1404,9 +1524,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:05 GMT
+      - Wed, 22 Mar 2023 17:39:46 GMT
       Etag:
-      - W/"5cfb8f740ffeda1ed78ec6ce6e6ebdb0"
+      - W/"0604c38243d1de6cb84397f7ada2276d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1414,9 +1534,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "856"
       X-Request-Id:
-      - 3eb9e326-627d-47d7-a57d-343da9e6a9c6
+      - 9425b260-2e85-436a-8bcc-97da4ad7384b
     status: 200 OK
     code: 200
     duration: ""
@@ -1428,10 +1548,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7uAiEUS8aN4CHA3k
+    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
     method: GET
   response:
-    body: '{"task":{"id":"task_7uAiEUS8aN4CHA3k","name":"Stop virtual machine","status":"completed","created_at":1676031708,"started_at":1676031724,"finished_at":1676031726,"progress":100}}'
+    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"completed","created_at":1679506739,"started_at":1679506785,"finished_at":1679506788,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1444,9 +1564,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:15 GMT
+      - Wed, 22 Mar 2023 17:39:56 GMT
       Etag:
-      - W/"4cff817a1dbe2d39e75704b6aa6f0890"
+      - W/"c23fbbe8737100ba0e413afcc5e58cf3"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1454,9 +1574,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "829"
       X-Request-Id:
-      - 1f21e262-f349-4e49-90cf-3ee141eddaf4
+      - 4127f527-b3fd-41a5-8d2e-9efe1afe444c
     status: 200 OK
     code: 200
     duration: ""
@@ -1468,20 +1588,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_1oiYUeL04U55SeMC","keep_until":1676204535,"object_id":"vm_5xtZxmLwOERVGJaW","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_5xtZxmLwOERVGJaW","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz","hostname":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host","fqdn":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031684,"initial_root_password":"Bkot91f6plL36xFS","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_0kmXXLKKrAEogNnG","keep_until":1679679596,"object_id":"vm_p8kEPh4E7Hq9TrKL","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_IfpYnsZOYg3w24re","address":"185.199.222.59","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.59/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-j7bvkhzeb9fz-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5xtZxmLwOERVGJaW","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1490,13 +1610,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3260"
+      - "3301"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:15 GMT
+      - Wed, 22 Mar 2023 17:39:56 GMT
       Etag:
-      - W/"48e20313f585536e104e6abab5517213"
+      - W/"8558eae77e5dbc2784cd042928a3764d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1504,9 +1624,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "828"
       X-Request-Id:
-      - 0c8d0908-6fac-468c-907f-64728eb0218b
+      - ae5c1d51-1921-4e39-a5ae-c1864fd49f96
     status: 200 OK
     code: 200
     duration: ""
@@ -1518,7 +1638,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_IfpYnsZOYg3w24re
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
     method: POST
   response:
     body: '{}'
@@ -1534,7 +1654,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:15 GMT
+      - Wed, 22 Mar 2023 17:39:56 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1544,9 +1664,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "827"
       X-Request-Id:
-      - 2a20e64c-ddb8-45fc-a96e-aeeba14a7812
+      - 44b76409-2c06-42fc-abcd-06cf23904898
     status: 200 OK
     code: 200
     duration: ""
@@ -1558,7 +1678,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
     method: POST
   response:
     body: '{}'
@@ -1574,7 +1694,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:15 GMT
+      - Wed, 22 Mar 2023 17:39:56 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1584,9 +1704,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "826"
       X-Request-Id:
-      - a7c8de35-b1cc-413c-b7bf-59c6f10226f9
+      - 5311b219-22a2-4c9b-b92c-acd942735cef
     status: 200 OK
     code: 200
     duration: ""
@@ -1598,10 +1718,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_1oiYUeL04U55SeMC
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0kmXXLKKrAEogNnG
     method: DELETE
   response:
-    body: '{"task":{"id":"task_ocKO8ysS3KiPtQPe","name":"Purge items from trash","status":"pending","created_at":1676031736,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_086iqQLwYXKXyEzS","name":"Purge items from trash","status":"pending","created_at":1679506796,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1614,9 +1734,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:16 GMT
+      - Wed, 22 Mar 2023 17:39:56 GMT
       Etag:
-      - W/"bc1ff7236029de6aa55f032aa785035b"
+      - W/"1d74ac9c5a497cb308b2f47ce48416da"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1624,9 +1744,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "825"
       X-Request-Id:
-      - d2ecaeed-171e-48a6-9ed0-f5fb39087c1a
+      - 51613baf-bfcd-4ee3-9be5-b81aface5957
     status: 200 OK
     code: 200
     duration: ""
@@ -1638,10 +1758,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_ocKO8ysS3KiPtQPe
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0kmXXLKKrAEogNnG
     method: GET
   response:
-    body: '{"task":{"id":"task_ocKO8ysS3KiPtQPe","name":"Purge items from trash","status":"running","created_at":1676031736,"started_at":1676031736,"finished_at":null,"progress":5}}'
+    body: '{"trash_object":{"id":"trsh_0kmXXLKKrAEogNnG","keep_until":1679679596,"object_id":"vm_p8kEPh4E7Hq9TrKL","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1650,13 +1770,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:17 GMT
+      - Wed, 22 Mar 2023 17:39:57 GMT
       Etag:
-      - W/"0a59bd898d39358730031d0240a27979"
+      - W/"cf03447afd350abbe6d885ac91b21a75"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1664,9 +1784,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "824"
       X-Request-Id:
-      - c9b8bffa-fe1e-4a40-b442-6a62db68cdb3
+      - e5308fe6-5d5b-42fa-8cb0-91be6a368553
     status: 200 OK
     code: 200
     duration: ""
@@ -1678,10 +1798,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_ocKO8ysS3KiPtQPe
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0kmXXLKKrAEogNnG
     method: GET
   response:
-    body: '{"task":{"id":"task_ocKO8ysS3KiPtQPe","name":"Purge items from trash","status":"running","created_at":1676031736,"started_at":1676031736,"finished_at":null,"progress":5}}'
+    body: '{"trash_object":{"id":"trsh_0kmXXLKKrAEogNnG","keep_until":1679679596,"object_id":"vm_p8kEPh4E7Hq9TrKL","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1690,13 +1810,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:22 GMT
+      - Wed, 22 Mar 2023 17:40:02 GMT
       Etag:
-      - W/"0a59bd898d39358730031d0240a27979"
+      - W/"cf03447afd350abbe6d885ac91b21a75"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1704,9 +1824,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "999"
       X-Request-Id:
-      - 1d3c0f71-6b33-4456-ae6f-dee777b9d28b
+      - f4a0db2a-dc77-45b4-a533-88e4debf1a5a
     status: 200 OK
     code: 200
     duration: ""
@@ -1718,37 +1838,38 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_ocKO8ysS3KiPtQPe
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0kmXXLKKrAEogNnG
     method: GET
   response:
-    body: '{"task":{"id":"task_ocKO8ysS3KiPtQPe","name":"Purge items from trash","status":"completed","created_at":1676031736,"started_at":1676031736,"finished_at":1676031742,"progress":100}}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "180"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:32 GMT
-      Etag:
-      - W/"1c6c51e4027fe7e984751e3db3e14b31"
+      - Wed, 22 Mar 2023 17:40:12 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "949"
       X-Request-Id:
-      - 4501313e-de2d-4cdf-8ff2-ea3d3ba28c1a
-    status: 200 OK
-    code: 200
+      - 55885d0e-a105-4b4e-949d-b626ca761223
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -1758,50 +1879,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_L80o7ZCG8Dlzn0IP
     method: DELETE
   response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:22:32 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - 0d1d284b-0c4e-4d88-9b5f-ea34da94012d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_EiJha1G2P7iivL1X
-    method: DELETE
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_EiJha1G2P7iivL1X","name":"tf-acc-test-custom-disks-j7bvkhzeb9fz-group","segregate":true,"created_at":1676031683}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1814,9 +1895,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:32 GMT
+      - Wed, 22 Mar 2023 17:40:12 GMT
       Etag:
-      - W/"b31a71edc87a56c170f0dfeba61c5dd5"
+      - W/"f3fe1799a09f12d5e27233bc5b0f94ae"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1824,9 +1905,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "947"
       X-Request-Id:
-      - 0ef38adb-3c8c-4e56-8313-896b14fbfd12
+      - bf1e35e8-a091-47c6-b863-d8195e24e7b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1838,7 +1919,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_IfpYnsZOYg3w24re
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
     method: DELETE
   response:
     body: '{}'
@@ -1854,7 +1935,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:33 GMT
+      - Wed, 22 Mar 2023 17:40:13 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1864,9 +1945,49 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "948"
       X-Request-Id:
-      - 8edaab7b-3919-44cc-9623-49bd51cdb36d
+      - 18e916d9-ad4c-4a91-948b-d75271f3ee2d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:13 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - a4d5606a-de2f-4a69-bcbc-d6f9f46f8ac4
     status: 200 OK
     code: 200
     duration: ""
@@ -1878,7 +1999,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5xtZxmLwOERVGJaW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1895,7 +2016,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:33 GMT
+      - Wed, 22 Mar 2023 17:40:13 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1905,9 +2026,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "945"
       X-Request-Id:
-      - 0502092b-abd1-42f3-bd05-d2666be1156c
+      - eaec84fc-1f0d-4f92-9593-8ab0c52a74a8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1919,7 +2040,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -1936,7 +2057,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:33 GMT
+      - Wed, 22 Mar 2023 17:40:13 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1946,9 +2067,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "944"
       X-Request-Id:
-      - eed9bd5b-2f52-428e-ad77-823bc2df5af7
+      - 4deddbaa-fe7a-4786-bd5d-f3d24cca2ac4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1960,7 +2081,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_IfpYnsZOYg3w24re
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -1977,7 +2098,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:22:33 GMT
+      - Wed, 22 Mar 2023 17:40:13 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1987,9 +2108,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "943"
       X-Request-Id:
-      - 6b9836fb-19c0-4898-a58b-ca7c4da5c939
+      - 1e93b983-96ba-4d0e-ad09-6440f0392ae0
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_custom_disks.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_custom_disks.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:10 GMT
+      - Thu, 23 Mar 2023 10:55:37 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "893"
       X-Request-Id:
-      - 8c288043-8b92-42af-9b06-dfb3e509ee8c
+      - 7dc64d08-5d20-4f72-9f85-78d01e8fcac4
     status: 200 OK
     code: 200
     duration: ""
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:10 GMT
+      - Thu, 23 Mar 2023 10:55:37 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -75,15 +75,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "892"
       X-Request-Id:
-      - 9ece52de-0567-4606-90f5-ebd70e68e01d
+      - fb9356ea-0159-44df-a724-184ed135f6b9
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -95,7 +95,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -108,9 +108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:10 GMT
+      - Thu, 23 Mar 2023 10:55:37 GMT
       Etag:
-      - W/"f3fe1799a09f12d5e27233bc5b0f94ae"
+      - W/"ec3fe221b455c36c89ae23c039be8957"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "892"
       X-Request-Id:
-      - 45fa9ba3-333f-403e-b95b-eb6510ac4a3d
+      - ef21c04f-5d6f-426a-b64e-2a428d160a11
     status: 200 OK
     code: 200
     duration: ""
@@ -132,10 +132,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_L80o7ZCG8Dlzn0IP
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_T2XflYxrpxLLtTCl
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -148,9 +148,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:10 GMT
+      - Thu, 23 Mar 2023 10:55:37 GMT
       Etag:
-      - W/"f3fe1799a09f12d5e27233bc5b0f94ae"
+      - W/"ec3fe221b455c36c89ae23c039be8957"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "888"
       X-Request-Id:
-      - c7756e02-c855-4b42-ab0e-7c71994cd994
+      - c4427c8a-0598-40d4-9113-2ad3c1a253ee
     status: 200 OK
     code: 200
     duration: ""
@@ -178,7 +178,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -193,9 +193,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:24 GMT
+      - Thu, 23 Mar 2023 10:55:41 GMT
       Etag:
-      - W/"02acb1d6e39d2dd3d1fdd50d084a43c8"
+      - W/"bca869113d81fc0901f92a0d7516e299"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -203,9 +203,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "890"
       X-Request-Id:
-      - 57fdf298-7871-4365-8b70-b875a9e276a2
+      - 8b634414-3b46-4bc9-bff7-6f2459696648
     status: 200 OK
     code: 200
     duration: ""
@@ -217,10 +217,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -235,9 +235,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:24 GMT
+      - Thu, 23 Mar 2023 10:55:41 GMT
       Etag:
-      - W/"302278f172a97bb1f106ca9e8f0749c2"
+      - W/"e885820193fa788a5a81f9194c9217d1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -245,9 +245,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "978"
+      - "881"
       X-Request-Id:
-      - fe1a9ee2-c7e4-4c7d-8500-3da91b8a3746
+      - 2298524d-ed80-4233-b29a-f5046aa92e5e
     status: 200 OK
     code: 200
     duration: ""
@@ -265,7 +265,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"185-199-222-213.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"185-199-222-110.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -280,9 +280,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:29 GMT
+      - Thu, 23 Mar 2023 10:55:45 GMT
       Etag:
-      - W/"4f3cd47e2ee7c0f358ef4337e48e28a3"
+      - W/"cd27f55240c181e782511ea3cbbac6e5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -290,9 +290,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "889"
       X-Request-Id:
-      - df6c9157-fc8b-4e83-8c97-427e2c28cb51
+      - 71efce09-f467-4e37-9447-7eb2bd3f4e89
     status: 200 OK
     code: 200
     duration: ""
@@ -304,10 +304,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"185-199-222-213.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"185-199-222-110.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -322,9 +322,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:29 GMT
+      - Thu, 23 Mar 2023 10:55:45 GMT
       Etag:
-      - W/"0c38e0e15be1e3e90ede6c372c94687d"
+      - W/"988b8e487f5a90073bdfc45e4a28611c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -332,9 +332,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "976"
+      - "859"
       X-Request-Id:
-      - 253dc095-ca22-470c-b2b5-8ce52609257e
+      - 971c292e-7875-4ed7-9bce-aa5d20bba272
     status: 200 OK
     code: 200
     duration: ""
@@ -346,10 +346,52 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"185-199-222-110.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:45 GMT
+      Etag:
+      - W/"988b8e487f5a90073bdfc45e4a28611c"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "858"
+      X-Request-Id:
+      - e12b2737-eaf7-49ab-a765-c3f74ad128a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -364,9 +406,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:29 GMT
+      - Thu, 23 Mar 2023 10:55:45 GMT
       Etag:
-      - W/"302278f172a97bb1f106ca9e8f0749c2"
+      - W/"e885820193fa788a5a81f9194c9217d1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -374,57 +416,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "857"
       X-Request-Id:
-      - 09c500d0-04c2-486d-9d6b-038c3c0c6e98
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"185-199-222-213.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "570"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:29 GMT
-      Etag:
-      - W/"0c38e0e15be1e3e90ede6c372c94687d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - 47ea7aae-1b3a-4b29-8e72-9eddfd7a17c6
+      - 7e53553a-ded7-47ac-be10-88ac05d8214f
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><SystemDisks><Disk><Name>System</Name><Size>20</Size></Disk><Disk><Name>Data</Name><Size>10</Size></Disk><Disk><Name>Disk #3</Name><Size>10</Size></Disk></SystemDisks><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_KbfXZm6mJYp6AdZf</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_T4SGxVKBxX6tyqWy</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-custom-disks-m0munbbpkm3n-host</Hostname></Hostname><Name>tf-acc-test-custom-disks-m0munbbpkm3n</Name><Description>A web server.</Description><Group>vmgrp_L80o7ZCG8Dlzn0IP</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><SystemDisks><Disk><Name>System</Name><Size>20</Size></Disk><Disk><Name>Data</Name><Size>10</Size></Disk><Disk><Name>Disk #3</Name><Size>10</Size></Disk></SystemDisks><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_Gl63yHUEkeELpdGm</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_Ntu5DTZickqN6c9T</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-custom-disks-ft3k6tpxc7yi-host</Hostname></Hostname><Name>tf-acc-test-custom-disks-ft3k6tpxc7yi</Name><Description>A web server.</Description><Group>vmgrp_T2XflYxrpxLLtTCl</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -436,7 +436,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_T6mCXG9jsYOHV5iq","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","state":"pending"},"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","state":"pending"},"hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host"}'
+    body: '{"task":{"id":"task_TlMJOd8kO9D7T5R7","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_OdF7pOcyqAxes1ig","state":"pending"},"virtual_machine_build":{"id":"vmbuild_OdF7pOcyqAxes1ig","state":"pending"},"hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -449,9 +449,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:29 GMT
+      - Thu, 23 Mar 2023 10:55:45 GMT
       Etag:
-      - W/"5f7ccbedd41ea567886d8b590f361d88"
+      - W/"c9199cb92f0762bfb34939ed1638594e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -459,9 +459,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "973"
+      - "856"
       X-Request-Id:
-      - 4f0b88a7-273c-4063-a610-b95f61ef724c
+      - 2ac2b0b3-b242-459c-a573-774fb9e99133
     status: 201 Created
     code: 201
     duration: ""
@@ -473,20 +473,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_heCkDlWXL6uJ0WXT
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OdF7pOcyqAxes1ig
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_OdF7pOcyqAxes1ig","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.213\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-m0munbbpkm3n-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-m0munbbpkm3n\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_L80o7ZCG8Dlzn0IP\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.110\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-ft3k6tpxc7yi-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-ft3k6tpxc7yi\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_T2XflYxrpxLLtTCl\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506709}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679568945}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -495,13 +495,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2662"
+      - "2431"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:31 GMT
+      - Thu, 23 Mar 2023 10:55:47 GMT
       Etag:
-      - W/"93c5228e11863cd99c63c32ffa99a68a"
+      - W/"1f131a7e19d2a034256119f66a92bf01"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -509,9 +509,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "972"
+      - "852"
       X-Request-Id:
-      - a1fec605-8052-4845-86bd-b7efcc2bcb4e
+      - a4b5fb95-9dd5-44bd-b513-d3202331e7fb
     status: 200 OK
     code: 200
     duration: ""
@@ -523,20 +523,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_heCkDlWXL6uJ0WXT
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OdF7pOcyqAxes1ig
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_OdF7pOcyqAxes1ig","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.213\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-m0munbbpkm3n-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-m0munbbpkm3n\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_L80o7ZCG8Dlzn0IP\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.110\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-ft3k6tpxc7yi-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-ft3k6tpxc7yi\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_T2XflYxrpxLLtTCl\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506709}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568945}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -549,9 +549,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:36 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"93c5228e11863cd99c63c32ffa99a68a"
+      - W/"05e4013b8bd5ea3d15b5e51c8b0e6b0d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -559,9 +559,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "841"
       X-Request-Id:
-      - 64ae0d09-c758-4717-b0f4-05527ed4ddaf
+      - 3fb8cb96-9f04-47e6-9cf3-b5bbd551b9ec
     status: 200 OK
     code: 200
     duration: ""
@@ -573,20 +573,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_heCkDlWXL6uJ0WXT
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OdF7pOcyqAxes1ig
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_OdF7pOcyqAxes1ig","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.213\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-m0munbbpkm3n-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-m0munbbpkm3n\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_L80o7ZCG8Dlzn0IP\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.110\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-ft3k6tpxc7yi-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-ft3k6tpxc7yi\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_T2XflYxrpxLLtTCl\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506709}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568945}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -599,9 +599,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:46 GMT
+      - Thu, 23 Mar 2023 10:56:02 GMT
       Etag:
-      - W/"93c5228e11863cd99c63c32ffa99a68a"
+      - W/"05e4013b8bd5ea3d15b5e51c8b0e6b0d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -609,9 +609,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "925"
+      - "998"
       X-Request-Id:
-      - 3f2f5ece-99c1-495b-b387-2abdfa67265f
+      - 4b2ed05e-61ea-45bd-9b4a-5e1d2b8da262
     status: 200 OK
     code: 200
     duration: ""
@@ -623,20 +623,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_heCkDlWXL6uJ0WXT
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OdF7pOcyqAxes1ig
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_heCkDlWXL6uJ0WXT","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_OdF7pOcyqAxes1ig","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.213\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-m0munbbpkm3n-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-m0munbbpkm3n\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_L80o7ZCG8Dlzn0IP\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.110\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-ft3k6tpxc7yi-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-ft3k6tpxc7yi\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_T2XflYxrpxLLtTCl\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679506709}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679568945}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -649,9 +649,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:56 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"cce2a8ff846c54dec4deba6e53039bd0"
+      - W/"55df3c4e3b5e3d0f434333f0a6c59e6c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -659,15 +659,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "907"
+      - "979"
       X-Request-Id:
-      - 7925ce99-0e6d-4974-9a65-a635c3df56ba
+      - f8e01af3-6f84-455a-b76d-06ba7758b425
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -679,17 +679,17 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568946,"initial_root_password":"3FAaRl9n20YzGduS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -702,9 +702,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:56 GMT
+      - Thu, 23 Mar 2023 10:56:12 GMT
       Etag:
-      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
+      - W/"e8cbc17b34201f719c0e7ccd64352869"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -712,9 +712,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "906"
+      - "977"
       X-Request-Id:
-      - c9d6ab25-56d0-493d-83db-a9259b610345
+      - 7089d487-2fe5-41b8-85ca-76f1e447fcbd
     status: 200 OK
     code: 200
     duration: ""
@@ -726,20 +726,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568946,"initial_root_password":"3FAaRl9n20YzGduS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -752,9 +752,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:58 GMT
+      - Thu, 23 Mar 2023 10:56:14 GMT
       Etag:
-      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
+      - W/"e8cbc17b34201f719c0e7ccd64352869"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -762,9 +762,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "905"
+      - "974"
       X-Request-Id:
-      - e93eaab4-2ee3-4a18-b4b5-df70c9ccc25e
+      - ecad70e7-8cf2-4c49-88a3-631e7679c59f
     status: 200 OK
     code: 200
     duration: ""
@@ -776,20 +776,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568946,"initial_root_password":"3FAaRl9n20YzGduS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -802,9 +802,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:58 GMT
+      - Thu, 23 Mar 2023 10:56:14 GMT
       Etag:
-      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
+      - W/"e8cbc17b34201f719c0e7ccd64352869"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -812,9 +812,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "904"
+      - "973"
       X-Request-Id:
-      - 29c4e0c7-ad47-47b6-8713-e2af00a95312
+      - 4f48a1ef-fb7f-4970-b5bc-0b5cc06d7f92
     status: 200 OK
     code: 200
     duration: ""
@@ -826,12 +826,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_M41UxXCoKdXpRRLs","name":"Public
-      Network on tf-acc-test-custom-disks-m0munbbpkm3n","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Tp32Ezz1qAMBOO6P","name":"Public
+      Network on tf-acc-test-custom-disks-ft3k6tpxc7yi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -844,9 +844,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:58 GMT
+      - Thu, 23 Mar 2023 10:56:14 GMT
       Etag:
-      - W/"99efe87d258ab3a314963d1582f6c094"
+      - W/"c5e13592804f83d59b89f0e4d3ca175e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -854,9 +854,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "903"
+      - "972"
       X-Request-Id:
-      - 56c19a61-292c-48cb-abbd-df660b675040
+      - 2ccdfebd-0a39-4e6c-b5d8-1bca2f90fb2c
     status: 200 OK
     code: 200
     duration: ""
@@ -868,12 +868,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_M41UxXCoKdXpRRLs
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Tp32Ezz1qAMBOO6P
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_M41UxXCoKdXpRRLs","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n"},"name":"Public
-      Network on tf-acc-test-custom-disks-m0munbbpkm3n","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a9:92:74:fe:b6","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Tp32Ezz1qAMBOO6P","virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi"},"name":"Public
+      Network on tf-acc-test-custom-disks-ft3k6tpxc7yi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:37:9d:e1:37:ec","state":"attached","ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -886,9 +886,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:58 GMT
+      - Thu, 23 Mar 2023 10:56:14 GMT
       Etag:
-      - W/"94c5f8e85849613e0d2a7ee6483770d3"
+      - W/"1c3cf5730d436f89a2ac2718124e3361"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -896,9 +896,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "902"
+      - "971"
       X-Request-Id:
-      - 08132cec-4177-4f58-9eb2-cdc2732bcb84
+      - db9431df-8a10-43ec-b456-f8f456b59bcc
     status: 200 OK
     code: 200
     duration: ""
@@ -910,20 +910,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568946,"initial_root_password":"3FAaRl9n20YzGduS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -936,9 +936,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
+      - Thu, 23 Mar 2023 10:56:14 GMT
       Etag:
-      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
+      - W/"e8cbc17b34201f719c0e7ccd64352869"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -946,9 +946,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "901"
+      - "970"
       X-Request-Id:
-      - a0d72309-9503-405b-b0c3-83a60bd418c4
+      - 8dc0a1b2-2829-4bcc-b381-06c8ac78acbb
     status: 200 OK
     code: 200
     duration: ""
@@ -960,10 +960,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_L80o7ZCG8Dlzn0IP
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_T2XflYxrpxLLtTCl
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -976,9 +976,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
+      - Thu, 23 Mar 2023 10:56:15 GMT
       Etag:
-      - W/"f3fe1799a09f12d5e27233bc5b0f94ae"
+      - W/"ec3fe221b455c36c89ae23c039be8957"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -986,9 +986,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "899"
+      - "969"
       X-Request-Id:
-      - d250b902-7d4b-4e3b-bd26-2b82b2ae7a3e
+      - e85f2d33-f638-406d-8375-9c35fdd7a554
     status: 200 OK
     code: 200
     duration: ""
@@ -1000,54 +1000,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "745"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
-      Etag:
-      - W/"b5703203731acdf8567b57b7b8c11de9"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "900"
-      X-Request-Id:
-      - ee2b52ca-0bac-4fa2-be19-eb14e62a6fc8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1060,9 +1018,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
+      - Thu, 23 Mar 2023 10:56:15 GMT
       Etag:
-      - W/"17b5003beefb111291c184249b8e2175"
+      - W/"4c3ddf8b387b00047122f7b7bfa45afd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1070,9 +1028,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "898"
+      - "968"
       X-Request-Id:
-      - 22bb83ec-4c76-4e68-b180-49b932dac348
+      - 5a394117-d154-4ead-85a1-3afe898de2ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1084,20 +1042,62 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "745"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:15 GMT
+      Etag:
+      - W/"83f1d9d0e3c9b7381269b4e58819da68"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - b54a8b3b-8d89-42c8-85f0-b5ff2f6f41d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568946,"initial_root_password":"3FAaRl9n20YzGduS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1110,9 +1110,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
+      - Thu, 23 Mar 2023 10:56:15 GMT
       Etag:
-      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
+      - W/"e8cbc17b34201f719c0e7ccd64352869"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1120,9 +1120,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "897"
+      - "966"
       X-Request-Id:
-      - 5120b4a4-c535-4546-ae85-d4f200b3d7f5
+      - 744a08aa-5517-4095-997a-062b463ff095
     status: 200 OK
     code: 200
     duration: ""
@@ -1134,12 +1134,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_M41UxXCoKdXpRRLs","name":"Public
-      Network on tf-acc-test-custom-disks-m0munbbpkm3n","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Tp32Ezz1qAMBOO6P","name":"Public
+      Network on tf-acc-test-custom-disks-ft3k6tpxc7yi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1152,9 +1152,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
+      - Thu, 23 Mar 2023 10:56:15 GMT
       Etag:
-      - W/"99efe87d258ab3a314963d1582f6c094"
+      - W/"c5e13592804f83d59b89f0e4d3ca175e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1162,9 +1162,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "896"
+      - "965"
       X-Request-Id:
-      - ef607239-711a-4022-b5b1-ae7e5583b213
+      - deee60be-43e0-4da8-8e8e-926c722a886e
     status: 200 OK
     code: 200
     duration: ""
@@ -1176,12 +1176,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_M41UxXCoKdXpRRLs
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Tp32Ezz1qAMBOO6P
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_M41UxXCoKdXpRRLs","virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n"},"name":"Public
-      Network on tf-acc-test-custom-disks-m0munbbpkm3n","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:a9:92:74:fe:b6","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Tp32Ezz1qAMBOO6P","virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi"},"name":"Public
+      Network on tf-acc-test-custom-disks-ft3k6tpxc7yi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:37:9d:e1:37:ec","state":"attached","ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1194,9 +1194,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
+      - Thu, 23 Mar 2023 10:56:15 GMT
       Etag:
-      - W/"94c5f8e85849613e0d2a7ee6483770d3"
+      - W/"1c3cf5730d436f89a2ac2718124e3361"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1204,9 +1204,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "895"
+      - "964"
       X-Request-Id:
-      - 58716ce5-d797-4e16-b046-38b00207cdcb
+      - 89c214c7-a191-4f07-8ba5-50f3ae99ec40
     status: 200 OK
     code: 200
     duration: ""
@@ -1218,20 +1218,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568946,"initial_root_password":"3FAaRl9n20YzGduS","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1244,9 +1244,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
+      - Thu, 23 Mar 2023 10:56:15 GMT
       Etag:
-      - W/"1da122ee1a6c907e30ae0b5a74f2d9ed"
+      - W/"e8cbc17b34201f719c0e7ccd64352869"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1254,9 +1254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "894"
+      - "963"
       X-Request-Id:
-      - fcf5d4e4-b083-4666-b976-4cb3f27401d2
+      - 5136255b-b191-4043-b5f5-fc79e0b4a355
     status: 200 OK
     code: 200
     duration: ""
@@ -1268,10 +1268,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: POST
   response:
-    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_0l9kHn2AhAhw7mL2","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1284,9 +1284,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:59 GMT
+      - Thu, 23 Mar 2023 10:56:15 GMT
       Etag:
-      - W/"9d17050e32a0cf69806a3303f83496bf"
+      - W/"0213d44d8c582ca89cb586f257e23978"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1294,9 +1294,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "893"
+      - "962"
       X-Request-Id:
-      - de915b61-419a-44db-912a-05cb612ccd51
+      - c64d942d-f8d8-4c24-9a1f-d22452bedabb
     status: 200 OK
     code: 200
     duration: ""
@@ -1308,210 +1308,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
+    url: https://api.katapult.io/core/v1/tasks/task_0l9kHn2AhAhw7mL2
     method: GET
   response:
-    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:00 GMT
-      Etag:
-      - W/"2a69e33fc2eae11f9ca44a43d755f566"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - 2bb9a76e-a462-4b2d-b5ef-3e8fa2af1005
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
-    method: GET
-  response:
-    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:05 GMT
-      Etag:
-      - W/"2a69e33fc2eae11f9ca44a43d755f566"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "967"
-      X-Request-Id:
-      - 8460569e-f38d-4aa9-8a2a-7b275648cdcb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
-    method: GET
-  response:
-    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:15 GMT
-      Etag:
-      - W/"2a69e33fc2eae11f9ca44a43d755f566"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "922"
-      X-Request-Id:
-      - 15e207e8-dde2-4b19-b97b-c6912b488a12
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
-    method: GET
-  response:
-    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:26 GMT
-      Etag:
-      - W/"2a69e33fc2eae11f9ca44a43d755f566"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "906"
-      X-Request-Id:
-      - c2a21916-644e-461c-a5f9-31f3ef5e0ce3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
-    method: GET
-  response:
-    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"pending","created_at":1679506739,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:36 GMT
-      Etag:
-      - W/"2a69e33fc2eae11f9ca44a43d755f566"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "880"
-      X-Request-Id:
-      - 6a302008-0e43-4d03-9034-513bafba1d22
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
-    method: GET
-  response:
-    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"running","created_at":1679506739,"started_at":1679506785,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_0l9kHn2AhAhw7mL2","name":"Stop virtual machine","status":"running","created_at":1679568975,"started_at":1679568976,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1524,9 +1324,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:46 GMT
+      - Thu, 23 Mar 2023 10:56:16 GMT
       Etag:
-      - W/"0604c38243d1de6cb84397f7ada2276d"
+      - W/"cff2c012cc536e7f1fad991ec7e80d4c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1534,9 +1334,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "856"
+      - "961"
       X-Request-Id:
-      - 9425b260-2e85-436a-8bcc-97da4ad7384b
+      - abdc13e4-2934-4894-892b-c4989c26d1d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1548,10 +1348,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FBugPjlq4lvDM6Gz
+    url: https://api.katapult.io/core/v1/tasks/task_0l9kHn2AhAhw7mL2
     method: GET
   response:
-    body: '{"task":{"id":"task_FBugPjlq4lvDM6Gz","name":"Stop virtual machine","status":"completed","created_at":1679506739,"started_at":1679506785,"finished_at":1679506788,"progress":100}}'
+    body: '{"task":{"id":"task_0l9kHn2AhAhw7mL2","name":"Stop virtual machine","status":"completed","created_at":1679568975,"started_at":1679568976,"finished_at":1679568978,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1564,9 +1364,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:56 GMT
+      - Thu, 23 Mar 2023 10:56:21 GMT
       Etag:
-      - W/"c23fbbe8737100ba0e413afcc5e58cf3"
+      - W/"b20fd5de5875042dbda69dfc4ec20400"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1574,9 +1374,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "829"
+      - "959"
       X-Request-Id:
-      - 4127f527-b3fd-41a5-8d2e-9efe1afe444c
+      - c941b134-fa45-47ab-a5ef-9f15afbe2b91
     status: 200 OK
     code: 200
     duration: ""
@@ -1588,20 +1388,20 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_0kmXXLKKrAEogNnG","keep_until":1679679596,"object_id":"vm_p8kEPh4E7Hq9TrKL","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_p8kEPh4E7Hq9TrKL","name":"tf-acc-test-custom-disks-m0munbbpkm3n","hostname":"tf-acc-test-custom-disks-m0munbbpkm3n-host","fqdn":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506710,"initial_root_password":"l7X8ve3uXpqhISGv","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_4O1NsFh7381ilC2s","keep_until":1679741781,"object_id":"vm_pK9qsZGVIpeAZxVT","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_pK9qsZGVIpeAZxVT","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi","hostname":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host","fqdn":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568946,"initial_root_password":"3FAaRl9n20YzGduS","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"},{"id":"ip_T4SGxVKBxX6tyqWy","address":"185.199.222.213","reverse_dns":"tf-acc-test-custom-disks-m0munbbpkm3n-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.213/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"},{"id":"ip_Gl63yHUEkeELpdGm","address":"185.199.222.110","reverse_dns":"tf-acc-test-custom-disks-ft3k6tpxc7yi-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.110/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_p8kEPh4E7Hq9TrKL","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_pK9qsZGVIpeAZxVT","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1614,9 +1414,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:56 GMT
+      - Thu, 23 Mar 2023 10:56:21 GMT
       Etag:
-      - W/"8558eae77e5dbc2784cd042928a3764d"
+      - W/"07e53868f12fc5025477f85a01452c2f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1624,9 +1424,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "828"
+      - "958"
       X-Request-Id:
-      - ae5c1d51-1921-4e39-a5ae-c1864fd49f96
+      - ade95fff-3eb3-467c-8249-ded9ce0d7880
     status: 200 OK
     code: 200
     duration: ""
@@ -1638,7 +1438,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
     method: POST
   response:
     body: '{}'
@@ -1654,7 +1454,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:56 GMT
+      - Thu, 23 Mar 2023 10:56:22 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1664,9 +1464,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "827"
+      - "957"
       X-Request-Id:
-      - 44b76409-2c06-42fc-abcd-06cf23904898
+      - 734d074c-a323-4df3-9230-3aa59dd9fb21
     status: 200 OK
     code: 200
     duration: ""
@@ -1678,7 +1478,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
     method: POST
   response:
     body: '{}'
@@ -1694,7 +1494,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:56 GMT
+      - Thu, 23 Mar 2023 10:56:22 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1704,9 +1504,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "826"
+      - "956"
       X-Request-Id:
-      - 5311b219-22a2-4c9b-b92c-acd942735cef
+      - d95d438b-e086-4d37-88ac-b08fe4c97598
     status: 200 OK
     code: 200
     duration: ""
@@ -1718,10 +1518,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0kmXXLKKrAEogNnG
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_4O1NsFh7381ilC2s
     method: DELETE
   response:
-    body: '{"task":{"id":"task_086iqQLwYXKXyEzS","name":"Purge items from trash","status":"pending","created_at":1679506796,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_5tNf7BeEyKa1BZdE","name":"Purge items from trash","status":"pending","created_at":1679568982,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1734,9 +1534,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:56 GMT
+      - Thu, 23 Mar 2023 10:56:22 GMT
       Etag:
-      - W/"1d74ac9c5a497cb308b2f47ce48416da"
+      - W/"71f423e01556f91cc9eaa6178d08069c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1744,9 +1544,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "825"
+      - "955"
       X-Request-Id:
-      - 51613baf-bfcd-4ee3-9be5-b81aface5957
+      - 8c4f0ff4-f581-4da6-893d-f75682fce4ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1758,10 +1558,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0kmXXLKKrAEogNnG
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_4O1NsFh7381ilC2s
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_0kmXXLKKrAEogNnG","keep_until":1679679596,"object_id":"vm_p8kEPh4E7Hq9TrKL","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_4O1NsFh7381ilC2s","keep_until":1679741781,"object_id":"vm_pK9qsZGVIpeAZxVT","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1774,9 +1574,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:57 GMT
+      - Thu, 23 Mar 2023 10:56:23 GMT
       Etag:
-      - W/"cf03447afd350abbe6d885ac91b21a75"
+      - W/"0669d1d2e1b0891ca269f9c23d4b98e7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1784,9 +1584,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "824"
+      - "954"
       X-Request-Id:
-      - e5308fe6-5d5b-42fa-8cb0-91be6a368553
+      - 95f393e8-7218-421f-8c69-96b93b971d0e
     status: 200 OK
     code: 200
     duration: ""
@@ -1798,10 +1598,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0kmXXLKKrAEogNnG
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_4O1NsFh7381ilC2s
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_0kmXXLKKrAEogNnG","keep_until":1679679596,"object_id":"vm_p8kEPh4E7Hq9TrKL","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_4O1NsFh7381ilC2s","keep_until":1679741781,"object_id":"vm_pK9qsZGVIpeAZxVT","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1814,9 +1614,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:02 GMT
+      - Thu, 23 Mar 2023 10:56:28 GMT
       Etag:
-      - W/"cf03447afd350abbe6d885ac91b21a75"
+      - W/"0669d1d2e1b0891ca269f9c23d4b98e7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1824,9 +1624,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "952"
       X-Request-Id:
-      - f4a0db2a-dc77-45b4-a533-88e4debf1a5a
+      - 1319bc14-e9ed-4fa5-81f5-953b87438b52
     status: 200 OK
     code: 200
     duration: ""
@@ -1838,7 +1638,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_0kmXXLKKrAEogNnG
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_4O1NsFh7381ilC2s
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -1855,7 +1655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:12 GMT
+      - Thu, 23 Mar 2023 10:56:38 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1867,7 +1667,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "949"
       X-Request-Id:
-      - 55885d0e-a105-4b4e-949d-b626ca761223
+      - 3edbd508-0f38-4b58-88a4-32388a85f055
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1879,10 +1679,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_L80o7ZCG8Dlzn0IP
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_T2XflYxrpxLLtTCl
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_L80o7ZCG8Dlzn0IP","name":"tf-acc-test-custom-disks-m0munbbpkm3n-group","segregate":true,"created_at":1679506690}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_T2XflYxrpxLLtTCl","name":"tf-acc-test-custom-disks-ft3k6tpxc7yi-group","segregate":true,"created_at":1679568937}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1895,9 +1695,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:12 GMT
+      - Thu, 23 Mar 2023 10:56:38 GMT
       Etag:
-      - W/"f3fe1799a09f12d5e27233bc5b0f94ae"
+      - W/"ec3fe221b455c36c89ae23c039be8957"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1907,7 +1707,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "947"
       X-Request-Id:
-      - bf1e35e8-a091-47c6-b863-d8195e24e7b0
+      - ee910249-c3ab-4028-bdf9-85f8d16f566b
     status: 200 OK
     code: 200
     duration: ""
@@ -1919,7 +1719,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
     method: DELETE
   response:
     body: '{}'
@@ -1935,7 +1735,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:13 GMT
+      - Thu, 23 Mar 2023 10:56:38 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1945,9 +1745,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "947"
       X-Request-Id:
-      - 18e916d9-ad4c-4a91-948b-d75271f3ee2d
+      - d8ab86a8-f955-454e-8270-b781f033c15c
     status: 200 OK
     code: 200
     duration: ""
@@ -1959,7 +1759,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
     method: DELETE
   response:
     body: '{}'
@@ -1975,7 +1775,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:13 GMT
+      - Thu, 23 Mar 2023 10:56:38 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1985,9 +1785,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "946"
+      - "945"
       X-Request-Id:
-      - a4d5606a-de2f-4a69-bcbc-d6f9f46f8ac4
+      - 1381f515-7c23-44e9-aefa-24a3de2a8fe9
     status: 200 OK
     code: 200
     duration: ""
@@ -1999,7 +1799,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_p8kEPh4E7Hq9TrKL
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_pK9qsZGVIpeAZxVT
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2016,48 +1816,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:13 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "945"
-      X-Request-Id:
-      - eaec84fc-1f0d-4f92-9593-8ab0c52a74a8
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
-    method: GET
-  response:
-    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
-      were found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "151"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:13 GMT
+      - Thu, 23 Mar 2023 10:56:38 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2069,7 +1828,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "944"
       X-Request-Id:
-      - 4deddbaa-fe7a-4786-bd5d-f3d24cca2ac4
+      - 854315e7-0925-460f-80ce-d5318fddd8e0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2081,7 +1840,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T4SGxVKBxX6tyqWy
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_pK9qsZGVIpeAZxVT
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:38 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - f35f15ad-61cd-402d-b467-94b23fbec359
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2098,7 +1898,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:13 GMT
+      - Thu, 23 Mar 2023 10:56:38 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2108,9 +1908,50 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "943"
+      - "942"
       X-Request-Id:
-      - 1e93b983-96ba-4d0e-ad09-6440f0392ae0
+      - b5b59a1e-9cfe-4a2f-bf57-b899cc23a5e3
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Gl63yHUEkeELpdGm
+    method: GET
+  response:
+    body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
+      were found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "151"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:38 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "941"
+      X-Request-Id:
+      - 40460f52-92bc-4712-bfbc-32a7ecd7148e
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_minimal.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_minimal.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:10 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -37,7 +37,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "999"
       X-Request-Id:
-      - 02ee0909-1702-4c28-88e5-b83e3cb13f12
+      - feef29ef-cea8-4117-9a87-55785b761636
     status: 200 OK
     code: 200
     duration: ""
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -66,13 +66,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "549"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:14 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"786d5374035b29433c7d68f31c618264"
+      - W/"137b10129b421fd5b21a6014fed1266d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "994"
       X-Request-Id:
-      - ebacc394-4aba-4543-82c4-2bb71b4db595
+      - 6314c20d-1c54-448f-8e44-7611a98f5cf9
     status: 200 OK
     code: 200
     duration: ""
@@ -94,10 +94,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -108,55 +108,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:14 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"2f3ce063a8417469e1ef1750e98f47f2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - 2db61972-7b53-4762-8276-9a8c263958d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "570"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:14 GMT
-      Etag:
-      - W/"2f3ce063a8417469e1ef1750e98f47f2"
+      - W/"e2dd9834428ed6e25c43af1579322fc9"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -166,13 +124,55 @@ interactions:
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - 39e28dc7-61aa-4059-832a-184c1a4c3c46
+      - cf772766-f598-4ca6-a165-28ad6d222dc2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "567"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:31 GMT
+      Etag:
+      - W/"e2dd9834428ed6e25c43af1579322fc9"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 0cae80b0-e0bc-43d6-a4c2-cbae76049a09
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_bNVeyLPKVqujq5xL</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-clumsy-polar-crow</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_hc3GUyhBe6toov2e</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-nutritious-grey-dog</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_tLGvLZzIyCdMkwnA","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","state":"pending"},"virtual_machine_build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","state":"pending"},"hostname":"tf-acc-test-clumsy-polar-crow"}'
+    body: '{"task":{"id":"task_OVVwUUvBbg4rpfyc","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_Z2DidVmg2RNPGHTY","state":"pending"},"virtual_machine_build":{"id":"vmbuild_Z2DidVmg2RNPGHTY","state":"pending"},"hostname":"tf-acc-test-nutritious-grey-dog"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -193,13 +193,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "268"
+      - "270"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:14 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"199e4b2b1bdf69c73e4278e4af6e45e8"
+      - W/"054fcaaaca9c0af13ae77d4704275392"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -207,9 +207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "984"
       X-Request-Id:
-      - 0dc0b467-3eb6-49bc-988e-35d6cfa887c3
+      - b336e446-13c6-440a-8d6c-98eb571d810c
     status: 201 Created
     code: 201
     duration: ""
@@ -221,17 +221,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OGNDEk3gBz7dBVSD
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Z2DidVmg2RNPGHTY
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Z2DidVmg2RNPGHTY","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clumsy-polar-crow\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-nutritious-grey-dog\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506694}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -240,13 +240,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1577"
+      - "1584"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:16 GMT
+      - Thu, 23 Mar 2023 10:54:33 GMT
       Etag:
-      - W/"f128737c34fbce8686988295a2563234"
+      - W/"7a3631a3a95e677909e55b006f4a3025"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -254,9 +254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "982"
       X-Request-Id:
-      - 7296dfcd-1983-4eea-8126-9f0c569a8ade
+      - 5a1facb4-5963-49e4-a553-8ff50b60cf6d
     status: 200 OK
     code: 200
     duration: ""
@@ -268,17 +268,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OGNDEk3gBz7dBVSD
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Z2DidVmg2RNPGHTY
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Z2DidVmg2RNPGHTY","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clumsy-polar-crow\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-nutritious-grey-dog\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506694}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -287,13 +287,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1577"
+      - "1584"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:21 GMT
+      - Thu, 23 Mar 2023 10:54:38 GMT
       Etag:
-      - W/"f128737c34fbce8686988295a2563234"
+      - W/"7a3631a3a95e677909e55b006f4a3025"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -301,9 +301,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "980"
+      - "973"
       X-Request-Id:
-      - ea099b7c-2a5b-469a-9a46-76b19891438f
+      - 60adfedb-fe86-4f1f-a97d-c3c049760a73
     status: 200 OK
     code: 200
     duration: ""
@@ -315,17 +315,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OGNDEk3gBz7dBVSD
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Z2DidVmg2RNPGHTY
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Z2DidVmg2RNPGHTY","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clumsy-polar-crow\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-nutritious-grey-dog\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679506694}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -334,149 +334,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1578"
+      - "1585"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:31 GMT
+      - Thu, 23 Mar 2023 10:54:48 GMT
       Etag:
-      - W/"c6ddf0a81055934a68057c99578fe0b5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - aeba34d0-f29c-43b9-b943-87f62cbbc687
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2192"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
-      Etag:
-      - W/"b6ab724f20cdf4f54cacec34d95c654f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "970"
-      X-Request-Id:
-      - 1a9e53fc-ca3c-4106-80a8-262e2d3f4822
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2192"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
-      Etag:
-      - W/"b6ab724f20cdf4f54cacec34d95c654f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - 0adc7b66-bbaf-4783-842e-d98b55c358a9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_JkDj0WSMvpNARrxM","name":"Public
-      Network on tf-acc-test-clumsy-polar-crow","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "357"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
-      Etag:
-      - W/"5ed60ead3dba0b5ca8f71fc7049041b1"
+      - W/"f4dc026d6c88afe3f3dcf9a0615d6128"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -486,7 +350,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "968"
       X-Request-Id:
-      - 0bfee329-2d82-4cd0-891a-b60bf5c0f94e
+      - 9850ccbf-bd95-4efa-a0c6-ecd9096673e8
     status: 200 OK
     code: 200
     duration: ""
@@ -498,12 +362,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_JkDj0WSMvpNARrxM
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_JkDj0WSMvpNARrxM","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow"},"name":"Public
-      Network on tf-acc-test-clumsy-polar-crow","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:67:d9:22:d9:1a","state":"detached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"VZ1AWUp4agM01r4Y","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dHerDXRriZEBcACp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -512,13 +381,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "487"
+      - "2199"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
+      - Thu, 23 Mar 2023 10:54:50 GMT
       Etag:
-      - W/"37afdd3fa0cdd6f26e0c7fcd401ef85a"
+      - W/"002168c31ec4153355c1779d243c7989"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -526,9 +395,187 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "966"
       X-Request-Id:
-      - 5b664c05-1407-4e6e-bfcf-b4887b2f9565
+      - d4e9e4c0-0728-42ae-891d-c2784bd42c59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"VZ1AWUp4agM01r4Y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dHerDXRriZEBcACp","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"87668c2b44122276e5aa2fa891893609"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - 7606e345-10f7-4465-81cb-154511ee7921
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"VZ1AWUp4agM01r4Y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dHerDXRriZEBcACp","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"87668c2b44122276e5aa2fa891893609"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - 7a9b0d0a-840e-4922-aef8-69e7dda7ca67
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_1jvhCbMJHyRrMlrK","name":"Public
+      Network on tf-acc-test-nutritious-grey-dog","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "358"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"500e142ffcdaa4a41887db0ccda79fd0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - baa5ce2c-0941-473f-8356-9c476b6f03c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_1jvhCbMJHyRrMlrK
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1jvhCbMJHyRrMlrK","virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog"},"name":"Public
+      Network on tf-acc-test-nutritious-grey-dog","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:6e:5b:96:38:ac","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "490"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"3f5f23091244472fa7ce378d6b0ea223"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "940"
+      X-Request-Id:
+      - 71237c18-5b3b-4d75-966f-3686785bd934
     status: 200 OK
     code: 200
     duration: ""
@@ -540,17 +587,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"VZ1AWUp4agM01r4Y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dHerDXRriZEBcACp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -559,13 +606,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2192"
+      - "2198"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"b6ab724f20cdf4f54cacec34d95c654f"
+      - W/"87668c2b44122276e5aa2fa891893609"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -573,9 +620,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "939"
       X-Request-Id:
-      - c032e232-ad8b-432e-8577-eecc2e88683e
+      - 8346737b-6806-4aaf-92bb-c4b2f5dc26d3
     status: 200 OK
     code: 200
     duration: ""
@@ -587,12 +634,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dHerDXRriZEBcACp","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -601,13 +648,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "724"
+      - "726"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"8d13345bbb1fc456c9f636bf7a1a388c"
+      - W/"eab1c93da977079da4d4d62dd80865b4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -615,9 +662,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "933"
       X-Request-Id:
-      - d736e476-1991-4146-a206-7d9a685aa25b
+      - 028448ef-b3a4-43d7-b362-ccd288de1c2b
     status: 200 OK
     code: 200
     duration: ""
@@ -629,17 +676,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"VZ1AWUp4agM01r4Y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dHerDXRriZEBcACp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -648,13 +695,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2192"
+      - "2198"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"b6ab724f20cdf4f54cacec34d95c654f"
+      - W/"87668c2b44122276e5aa2fa891893609"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -662,9 +709,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "932"
       X-Request-Id:
-      - 8f7a9596-4394-4887-9cf6-58b019e0d3b3
+      - 20bfa76c-4ab4-4b1f-b9b8-8443bfeb76d4
     status: 200 OK
     code: 200
     duration: ""
@@ -676,12 +723,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_JkDj0WSMvpNARrxM","name":"Public
-      Network on tf-acc-test-clumsy-polar-crow","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_1jvhCbMJHyRrMlrK","name":"Public
+      Network on tf-acc-test-nutritious-grey-dog","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -690,13 +737,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "357"
+      - "358"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"5ed60ead3dba0b5ca8f71fc7049041b1"
+      - W/"500e142ffcdaa4a41887db0ccda79fd0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -704,9 +751,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "931"
       X-Request-Id:
-      - 2820220e-42cd-4b4a-9292-663752160c84
+      - ecc7660b-a886-4268-acdb-4059b5e71a09
     status: 200 OK
     code: 200
     duration: ""
@@ -718,12 +765,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_JkDj0WSMvpNARrxM
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_1jvhCbMJHyRrMlrK
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_JkDj0WSMvpNARrxM","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow"},"name":"Public
-      Network on tf-acc-test-clumsy-polar-crow","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:67:d9:22:d9:1a","state":"detached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_1jvhCbMJHyRrMlrK","virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog"},"name":"Public
+      Network on tf-acc-test-nutritious-grey-dog","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:6e:5b:96:38:ac","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -732,13 +779,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "487"
+      - "490"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"37afdd3fa0cdd6f26e0c7fcd401ef85a"
+      - W/"3f5f23091244472fa7ce378d6b0ea223"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -746,9 +793,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "930"
       X-Request-Id:
-      - d83c46c1-dde0-4ade-83de-2fac7cfa6709
+      - c578fdeb-4961-426e-bd29-b84ef853c111
     status: 200 OK
     code: 200
     duration: ""
@@ -760,17 +807,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"VZ1AWUp4agM01r4Y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dHerDXRriZEBcACp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -779,13 +826,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2192"
+      - "2198"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"b6ab724f20cdf4f54cacec34d95c654f"
+      - W/"87668c2b44122276e5aa2fa891893609"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -793,9 +840,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "924"
       X-Request-Id:
-      - c0bb4f18-eb25-4131-8803-22a48118c665
+      - 9ed29ad0-165e-46d6-b38a-390b77e31797
     status: 200 OK
     code: 200
     duration: ""
@@ -807,10 +854,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
     method: POST
   response:
-    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_ihgs8VC7uWHO6ZL4","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -823,9 +870,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:34 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"c3113b9564441e4020ed4ac6cd6af62e"
+      - W/"369e884985a525ee48451b83cfed8eae"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -833,9 +880,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "923"
       X-Request-Id:
-      - 44027600-1fd6-4da3-ab97-1e86c62e1492
+      - c3f3007d-3ff9-4603-adff-ad67e778080a
     status: 200 OK
     code: 200
     duration: ""
@@ -847,10 +894,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_wstLqncNU7lOGtet
+    url: https://api.katapult.io/core/v1/tasks/task_ihgs8VC7uWHO6ZL4
     method: GET
   response:
-    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"pending","created_at":1679506714,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_ihgs8VC7uWHO6ZL4","name":"Stop virtual machine","status":"pending","created_at":1679568896,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -863,9 +910,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:35 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"6543e911f1dd3d21a56578e96318d64d"
+      - W/"b6ca486cafe9f06488bd7bab3f9be231"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -873,9 +920,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "921"
       X-Request-Id:
-      - 4898d247-603a-41d1-8ed3-204660581c7a
+      - be4ff060-8f32-45c4-b439-e4cc61cdc0fe
     status: 200 OK
     code: 200
     duration: ""
@@ -887,10 +934,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_wstLqncNU7lOGtet
+    url: https://api.katapult.io/core/v1/tasks/task_ihgs8VC7uWHO6ZL4
     method: GET
   response:
-    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"pending","created_at":1679506714,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_ihgs8VC7uWHO6ZL4","name":"Stop virtual machine","status":"pending","created_at":1679568896,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -903,9 +950,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"6543e911f1dd3d21a56578e96318d64d"
+      - W/"b6ca486cafe9f06488bd7bab3f9be231"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -913,9 +960,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "934"
+      - "965"
       X-Request-Id:
-      - ee686708-de95-4dd1-b593-0a6a74e4828d
+      - 4f7646bf-a2c7-4388-8349-528b9d99bebe
     status: 200 OK
     code: 200
     duration: ""
@@ -927,10 +974,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_wstLqncNU7lOGtet
+    url: https://api.katapult.io/core/v1/tasks/task_ihgs8VC7uWHO6ZL4
     method: GET
   response:
-    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"running","created_at":1679506714,"started_at":1679506729,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_ihgs8VC7uWHO6ZL4","name":"Stop virtual machine","status":"running","created_at":1679568896,"started_at":1679568911,"finished_at":null,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -943,9 +990,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:50 GMT
+      - Thu, 23 Mar 2023 10:55:12 GMT
       Etag:
-      - W/"18f41bfe19193e7c4c363921ad3f4eb1"
+      - W/"369e22567f13d4ded3b1292c0ad5fb17"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -953,9 +1000,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "911"
+      - "928"
       X-Request-Id:
-      - 95c0cf00-0479-4a1f-b939-1f71cf973530
+      - 6677aee6-e716-411a-b6c0-a24b0f577d0b
     status: 200 OK
     code: 200
     duration: ""
@@ -967,10 +1014,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_wstLqncNU7lOGtet
+    url: https://api.katapult.io/core/v1/tasks/task_ihgs8VC7uWHO6ZL4
     method: GET
   response:
-    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"completed","created_at":1679506714,"started_at":1679506729,"finished_at":1679506732,"progress":100}}'
+    body: '{"task":{"id":"task_ihgs8VC7uWHO6ZL4","name":"Stop virtual machine","status":"completed","created_at":1679568896,"started_at":1679568911,"finished_at":1679568914,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -983,9 +1030,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:00 GMT
+      - Thu, 23 Mar 2023 10:55:22 GMT
       Etag:
-      - W/"2338cf9457ebd6b82f8caedf407c6fcd"
+      - W/"3d0b380f232b579b0880f54d2895918b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -993,9 +1040,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "919"
       X-Request-Id:
-      - f5f51a77-084b-4e7c-abaa-e15994c11ef6
+      - 2f0bae2f-500e-47f3-a14b-d162814de481
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,17 +1054,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_dtvgtnWJnvVJejV4","keep_until":1679679540,"object_id":"vm_bX2AccNaC0Ojfv97","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_w8SZiOUYg4gF76yb","keep_until":1679741722,"object_id":"vm_dHerDXRriZEBcACp","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_dHerDXRriZEBcACp","name":"tf-acc-test-nutritious-grey-dog","hostname":"tf-acc-test-nutritious-grey-dog","fqdn":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"VZ1AWUp4agM01r4Y","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-nutritious-grey-dog.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dHerDXRriZEBcACp","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1026,13 +1073,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2327"
+      - "2333"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:01 GMT
+      - Thu, 23 Mar 2023 10:55:22 GMT
       Etag:
-      - W/"9fe800b500a8d8ad9730dde09c728b46"
+      - W/"a16e6d06811fed7f3ab6e3ebd1c9693c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1040,9 +1087,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "918"
       X-Request-Id:
-      - fdc847aa-6b9a-45c5-b8ff-cabba6fc4abb
+      - e31cba0b-d407-4f97-85d8-bf31641158f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1054,7 +1101,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: POST
   response:
     body: '{}'
@@ -1070,7 +1117,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:01 GMT
+      - Thu, 23 Mar 2023 10:55:22 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1080,9 +1127,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "917"
       X-Request-Id:
-      - 17d67f68-5998-42cb-be96-42667911fd1c
+      - 27d2abe1-a669-4c10-8d57-85a1c0ee677b
     status: 200 OK
     code: 200
     duration: ""
@@ -1094,10 +1141,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dtvgtnWJnvVJejV4
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_w8SZiOUYg4gF76yb
     method: DELETE
   response:
-    body: '{"task":{"id":"task_8pnkPapiUGUZu8ij","name":"Purge items from trash","status":"pending","created_at":1679506741,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_XH6qbSNvyAewpFlK","name":"Purge items from trash","status":"pending","created_at":1679568922,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1110,9 +1157,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:01 GMT
+      - Thu, 23 Mar 2023 10:55:22 GMT
       Etag:
-      - W/"09f128d2b7f8e22292b0d9b1225dce3a"
+      - W/"a90fa6def945f84da9da3b75c50a85cf"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1120,9 +1167,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "982"
+      - "916"
       X-Request-Id:
-      - 773691e8-a765-4cdc-b79c-8fd2656a8410
+      - 1d153ed7-3153-4b75-a997-e5bd825cbcd5
     status: 200 OK
     code: 200
     duration: ""
@@ -1134,10 +1181,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dtvgtnWJnvVJejV4
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_w8SZiOUYg4gF76yb
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_dtvgtnWJnvVJejV4","keep_until":1679679540,"object_id":"vm_bX2AccNaC0Ojfv97","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_w8SZiOUYg4gF76yb","keep_until":1679741722,"object_id":"vm_dHerDXRriZEBcACp","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1150,9 +1197,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:02 GMT
+      - Thu, 23 Mar 2023 10:55:23 GMT
       Etag:
-      - W/"d015c62a0b62c3c3e5f9228f9cda740e"
+      - W/"bbe9645a7d8423062d817dd6c6e905c4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1160,9 +1207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "979"
+      - "911"
       X-Request-Id:
-      - da2b1a90-4d24-409e-8a84-7740182826de
+      - f80201da-f014-4801-94a2-d7410218849e
     status: 200 OK
     code: 200
     duration: ""
@@ -1174,7 +1221,87 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dtvgtnWJnvVJejV4
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_w8SZiOUYg4gF76yb
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_w8SZiOUYg4gF76yb","keep_until":1679741722,"object_id":"vm_dHerDXRriZEBcACp","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:28 GMT
+      Etag:
+      - W/"bbe9645a7d8423062d817dd6c6e905c4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "902"
+      X-Request-Id:
+      - 802267c6-d796-47e8-a807-5c1af746d9f1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_w8SZiOUYg4gF76yb
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_w8SZiOUYg4gF76yb","keep_until":1679741722,"object_id":"vm_dHerDXRriZEBcACp","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:39 GMT
+      Etag:
+      - W/"bbe9645a7d8423062d817dd6c6e905c4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "887"
+      X-Request-Id:
+      - e2168982-22d4-48a2-b8b6-81b8bb3d12cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_w8SZiOUYg4gF76yb
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -1191,7 +1318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:07 GMT
+      - Thu, 23 Mar 2023 10:55:49 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1201,9 +1328,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "850"
       X-Request-Id:
-      - 8bd6c7be-b3d0-406a-96a5-47a3eb8ef6fb
+      - bcc394f3-5918-4e6a-a0b4-82812c019b9e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1215,7 +1342,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: DELETE
   response:
     body: '{}'
@@ -1231,7 +1358,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:07 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1241,9 +1368,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "849"
       X-Request-Id:
-      - 73e8f35c-f987-48ec-8e46-b417714d0d39
+      - 47caa8a6-057f-4831-906a-1654362d8fac
     status: 200 OK
     code: 200
     duration: ""
@@ -1255,7 +1382,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dHerDXRriZEBcACp
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1272,7 +1399,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:07 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1282,9 +1409,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "950"
+      - "837"
       X-Request-Id:
-      - 124cbe30-686a-4f29-8c64-7e94f5cb870e
+      - 7227f867-9b11-4e7c-8fea-1054b074c917
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1296,7 +1423,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_dHerDXRriZEBcACp
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:52 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "836"
+      X-Request-Id:
+      - ce748a78-696f-4c4f-85f0-d22bfba3bbcb
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -1313,7 +1481,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:07 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1323,9 +1491,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "949"
+      - "835"
       X-Request-Id:
-      - dfd6a371-d38b-4338-8a78-d59e1852035f
+      - 72aacfb0-d983-40eb-bc59-62e1b2acba33
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_minimal.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_minimal.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:04 GMT
+      - Wed, 22 Mar 2023 17:38:10 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "999"
       X-Request-Id:
-      - 3dad084c-74e9-4e6f-a0e4-99f8733b30fa
+      - 02ee0909-1702-4c28-88e5-b83e3cb13f12
     status: 200 OK
     code: 200
     duration: ""
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"185-199-222-238.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -70,9 +70,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:04 GMT
+      - Wed, 22 Mar 2023 17:38:14 GMT
       Etag:
-      - W/"da896ea2082a872e05ac7030f2151ede"
+      - W/"786d5374035b29433c7d68f31c618264"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "997"
       X-Request-Id:
-      - 90e6f774-184d-42c3-a7da-c63bcd81e5e0
+      - ebacc394-4aba-4543-82c4-2bb71b4db595
     status: 200 OK
     code: 200
     duration: ""
@@ -94,10 +94,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"185-199-222-238.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -112,9 +112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:04 GMT
+      - Wed, 22 Mar 2023 17:38:14 GMT
       Etag:
-      - W/"8af94df87e3760eb2c77da699d9a7007"
+      - W/"2f3ce063a8417469e1ef1750e98f47f2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -122,9 +122,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "987"
       X-Request-Id:
-      - e561948d-b81a-43c6-be0b-f509cf0366b8
+      - 2db61972-7b53-4762-8276-9a8c263958d7
     status: 200 OK
     code: 200
     duration: ""
@@ -136,10 +136,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"185-199-222-238.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -154,9 +154,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:04 GMT
+      - Wed, 22 Mar 2023 17:38:14 GMT
       Etag:
-      - W/"8af94df87e3760eb2c77da699d9a7007"
+      - W/"2f3ce063a8417469e1ef1750e98f47f2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -164,15 +164,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "986"
       X-Request-Id:
-      - 547d4316-3ef5-4450-9321-4185360832ba
+      - 39e28dc7-61aa-4059-832a-184c1a4c3c46
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_lMARBMFBAmCoffcW</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-icy-faint-grapefruit</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_bNVeyLPKVqujq5xL</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-clumsy-polar-crow</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_oHWRsTkOLhoqIEcU","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_ftupQlbuFW48vGue","state":"pending"},"virtual_machine_build":{"id":"vmbuild_ftupQlbuFW48vGue","state":"pending"},"hostname":"tf-acc-test-icy-faint-grapefruit"}'
+    body: '{"task":{"id":"task_tLGvLZzIyCdMkwnA","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","state":"pending"},"virtual_machine_build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","state":"pending"},"hostname":"tf-acc-test-clumsy-polar-crow"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -193,13 +193,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "271"
+      - "268"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:04 GMT
+      - Wed, 22 Mar 2023 17:38:14 GMT
       Etag:
-      - W/"a5dacce404b8e478aaea74c38f3e16e2"
+      - W/"199e4b2b1bdf69c73e4278e4af6e45e8"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -207,9 +207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "985"
       X-Request-Id:
-      - d12ccf16-150f-4714-88f3-7da5c9716636
+      - 0dc0b467-3eb6-49bc-988e-35d6cfa887c3
     status: 201 Created
     code: 201
     duration: ""
@@ -221,17 +221,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ftupQlbuFW48vGue
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OGNDEk3gBz7dBVSD
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ftupQlbuFW48vGue","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.238\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-faint-grapefruit\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clumsy-polar-crow\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031304}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506694}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -240,13 +240,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1589"
+      - "1577"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:06 GMT
+      - Wed, 22 Mar 2023 17:38:16 GMT
       Etag:
-      - W/"0ff4e8a872e057a535bed2615174a47c"
+      - W/"f128737c34fbce8686988295a2563234"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -254,9 +254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "944"
+      - "984"
       X-Request-Id:
-      - e7f7be77-f329-4234-8850-3897026130bf
+      - 7296dfcd-1983-4eea-8126-9f0c569a8ade
     status: 200 OK
     code: 200
     duration: ""
@@ -268,17 +268,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ftupQlbuFW48vGue
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OGNDEk3gBz7dBVSD
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ftupQlbuFW48vGue","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.238\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-faint-grapefruit\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clumsy-polar-crow\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031304}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506694}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -287,13 +287,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1589"
+      - "1577"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:11 GMT
+      - Wed, 22 Mar 2023 17:38:21 GMT
       Etag:
-      - W/"0ff4e8a872e057a535bed2615174a47c"
+      - W/"f128737c34fbce8686988295a2563234"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -301,9 +301,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "903"
+      - "980"
       X-Request-Id:
-      - 939b8f05-85a0-4f33-8935-eb3b6423cb82
+      - ea099b7c-2a5b-469a-9a46-76b19891438f
     status: 200 OK
     code: 200
     duration: ""
@@ -315,17 +315,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ftupQlbuFW48vGue
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_OGNDEk3gBz7dBVSD
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ftupQlbuFW48vGue","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_OGNDEk3gBz7dBVSD","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.238\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-faint-grapefruit\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clumsy-polar-crow\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1676031304}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679506694}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -334,13 +334,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1589"
+      - "1578"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:21 GMT
+      - Wed, 22 Mar 2023 17:38:31 GMT
       Etag:
-      - W/"56242079f1d00d7b6c2e4a5332eb2724"
+      - W/"c6ddf0a81055934a68057c99578fe0b5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -348,9 +348,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "894"
+      - "971"
       X-Request-Id:
-      - eaa71dcd-4986-4a61-b30f-e7c919e43c78
+      - aeba34d0-f29c-43b9-b943-87f62cbbc687
     status: 200 OK
     code: 200
     duration: ""
@@ -362,17 +362,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031305,"initial_root_password":"ZemP2XH25YIlV7ug","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dm2CRkhUR4EhLHOA","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -381,13 +381,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2163"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"7055e7939d07b156e2917b2916abbc5d"
+      - W/"b6ab724f20cdf4f54cacec34d95c654f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -395,9 +395,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "893"
+      - "970"
       X-Request-Id:
-      - c512caab-5344-4dc4-a20d-90dcc729affe
+      - 1a9e53fc-ca3c-4106-80a8-262e2d3f4822
     status: 200 OK
     code: 200
     duration: ""
@@ -409,17 +409,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031305,"initial_root_password":"ZemP2XH25YIlV7ug","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dm2CRkhUR4EhLHOA","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -428,13 +428,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2163"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"7055e7939d07b156e2917b2916abbc5d"
+      - W/"b6ab724f20cdf4f54cacec34d95c654f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -442,9 +442,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "892"
+      - "969"
       X-Request-Id:
-      - 22af2973-a10c-4fa9-bb22-f6f0664a00db
+      - 0adc7b66-bbaf-4783-842e-d98b55c358a9
     status: 200 OK
     code: 200
     duration: ""
@@ -456,12 +456,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_pxdYX08ryS3SNDpB","name":"Public
-      Network on tf-acc-test-icy-faint-grapefruit","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_JkDj0WSMvpNARrxM","name":"Public
+      Network on tf-acc-test-clumsy-polar-crow","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -470,13 +470,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "360"
+      - "357"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"cab5847c6592323fc099a7927e8ee4e5"
+      - W/"5ed60ead3dba0b5ca8f71fc7049041b1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -484,9 +484,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "891"
+      - "968"
       X-Request-Id:
-      - 0f5389d3-e530-4892-bc37-68f31664a6ad
+      - 0bfee329-2d82-4cd0-891a-b60bf5c0f94e
     status: 200 OK
     code: 200
     duration: ""
@@ -498,12 +498,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_pxdYX08ryS3SNDpB
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_JkDj0WSMvpNARrxM
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_pxdYX08ryS3SNDpB","virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit"},"name":"Public
-      Network on tf-acc-test-icy-faint-grapefruit","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:67:9d:c6:69:53","state":"attached","ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_JkDj0WSMvpNARrxM","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow"},"name":"Public
+      Network on tf-acc-test-clumsy-polar-crow","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:67:d9:22:d9:1a","state":"detached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -512,13 +512,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "493"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"874d8919d697aa15cd1aac90773046d8"
+      - W/"37afdd3fa0cdd6f26e0c7fcd401ef85a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -526,9 +526,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "890"
+      - "967"
       X-Request-Id:
-      - d14377a3-4883-4d42-9925-b365fa01b68c
+      - 5b664c05-1407-4e6e-bfcf-b4887b2f9565
     status: 200 OK
     code: 200
     duration: ""
@@ -540,17 +540,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031305,"initial_root_password":"ZemP2XH25YIlV7ug","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dm2CRkhUR4EhLHOA","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -559,13 +559,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2163"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"7055e7939d07b156e2917b2916abbc5d"
+      - W/"b6ab724f20cdf4f54cacec34d95c654f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -573,9 +573,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "889"
+      - "966"
       X-Request-Id:
-      - 15dffc00-f244-4e6e-9a96-5c6af2c78e90
+      - c032e232-ad8b-432e-8577-eecc2e88683e
     status: 200 OK
     code: 200
     duration: ""
@@ -587,12 +587,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dm2CRkhUR4EhLHOA","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -601,13 +601,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "730"
+      - "724"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"a186ba5c30a74340ac9f6fd7ca00e9fa"
+      - W/"8d13345bbb1fc456c9f636bf7a1a388c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -615,9 +615,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "888"
+      - "965"
       X-Request-Id:
-      - 4cd9ea02-cc19-419b-9de3-a5992256b0e3
+      - d736e476-1991-4146-a206-7d9a685aa25b
     status: 200 OK
     code: 200
     duration: ""
@@ -629,17 +629,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031305,"initial_root_password":"ZemP2XH25YIlV7ug","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dm2CRkhUR4EhLHOA","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -648,13 +648,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2163"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"7055e7939d07b156e2917b2916abbc5d"
+      - W/"b6ab724f20cdf4f54cacec34d95c654f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -662,9 +662,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "887"
+      - "964"
       X-Request-Id:
-      - 968bc45e-5775-4878-88f9-3446296a8040
+      - 8f7a9596-4394-4887-9cf6-58b019e0d3b3
     status: 200 OK
     code: 200
     duration: ""
@@ -676,12 +676,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_pxdYX08ryS3SNDpB","name":"Public
-      Network on tf-acc-test-icy-faint-grapefruit","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_JkDj0WSMvpNARrxM","name":"Public
+      Network on tf-acc-test-clumsy-polar-crow","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -690,13 +690,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "360"
+      - "357"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"cab5847c6592323fc099a7927e8ee4e5"
+      - W/"5ed60ead3dba0b5ca8f71fc7049041b1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -704,9 +704,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "886"
+      - "963"
       X-Request-Id:
-      - ca45f43b-844f-4057-b7c9-4b02a675b343
+      - 2820220e-42cd-4b4a-9292-663752160c84
     status: 200 OK
     code: 200
     duration: ""
@@ -718,12 +718,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_pxdYX08ryS3SNDpB
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_JkDj0WSMvpNARrxM
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_pxdYX08ryS3SNDpB","virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit"},"name":"Public
-      Network on tf-acc-test-icy-faint-grapefruit","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:67:9d:c6:69:53","state":"attached","ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_JkDj0WSMvpNARrxM","virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow"},"name":"Public
+      Network on tf-acc-test-clumsy-polar-crow","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:67:d9:22:d9:1a","state":"detached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -732,13 +732,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "493"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"874d8919d697aa15cd1aac90773046d8"
+      - W/"37afdd3fa0cdd6f26e0c7fcd401ef85a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -746,9 +746,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "885"
+      - "962"
       X-Request-Id:
-      - d7a3554c-535f-4949-9845-07955f0048af
+      - d83c46c1-dde0-4ade-83de-2fac7cfa6709
     status: 200 OK
     code: 200
     duration: ""
@@ -760,17 +760,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031305,"initial_root_password":"ZemP2XH25YIlV7ug","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dm2CRkhUR4EhLHOA","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -779,13 +779,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2163"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"7055e7939d07b156e2917b2916abbc5d"
+      - W/"b6ab724f20cdf4f54cacec34d95c654f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -793,9 +793,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "884"
+      - "961"
       X-Request-Id:
-      - 8376f56a-b02b-42b7-b27e-d184afeb88eb
+      - c0bb4f18-eb25-4131-8803-22a48118c665
     status: 200 OK
     code: 200
     duration: ""
@@ -807,10 +807,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: POST
   response:
-    body: '{"task":{"id":"task_6MOzH19IjoOB3Jau","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -823,9 +823,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:24 GMT
+      - Wed, 22 Mar 2023 17:38:34 GMT
       Etag:
-      - W/"d34fc79c224df8298707779f08a99197"
+      - W/"c3113b9564441e4020ed4ac6cd6af62e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -833,9 +833,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "883"
+      - "960"
       X-Request-Id:
-      - d9f5d54b-4fc0-41bb-b0e8-a80bba9852f4
+      - 44027600-1fd6-4da3-ab97-1e86c62e1492
     status: 200 OK
     code: 200
     duration: ""
@@ -847,10 +847,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_6MOzH19IjoOB3Jau
+    url: https://api.katapult.io/core/v1/tasks/task_wstLqncNU7lOGtet
     method: GET
   response:
-    body: '{"task":{"id":"task_6MOzH19IjoOB3Jau","name":"Stop virtual machine","status":"pending","created_at":1676031324,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"pending","created_at":1679506714,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -863,9 +863,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:25 GMT
+      - Wed, 22 Mar 2023 17:38:35 GMT
       Etag:
-      - W/"28886cc1ba67bd4bfec94f267bf0d17f"
+      - W/"6543e911f1dd3d21a56578e96318d64d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -873,9 +873,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "882"
+      - "959"
       X-Request-Id:
-      - b2f1ee25-8a45-401a-8f9c-c5c93d64833b
+      - 4898d247-603a-41d1-8ed3-204660581c7a
     status: 200 OK
     code: 200
     duration: ""
@@ -887,10 +887,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_6MOzH19IjoOB3Jau
+    url: https://api.katapult.io/core/v1/tasks/task_wstLqncNU7lOGtet
     method: GET
   response:
-    body: '{"task":{"id":"task_6MOzH19IjoOB3Jau","name":"Stop virtual machine","status":"pending","created_at":1676031324,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"pending","created_at":1679506714,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -903,9 +903,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:30 GMT
+      - Wed, 22 Mar 2023 17:38:40 GMT
       Etag:
-      - W/"28886cc1ba67bd4bfec94f267bf0d17f"
+      - W/"6543e911f1dd3d21a56578e96318d64d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -913,9 +913,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "845"
+      - "934"
       X-Request-Id:
-      - ab65d100-b101-4ce9-8fa4-422aebdea426
+      - ee686708-de95-4dd1-b593-0a6a74e4828d
     status: 200 OK
     code: 200
     duration: ""
@@ -927,10 +927,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_6MOzH19IjoOB3Jau
+    url: https://api.katapult.io/core/v1/tasks/task_wstLqncNU7lOGtet
     method: GET
   response:
-    body: '{"task":{"id":"task_6MOzH19IjoOB3Jau","name":"Stop virtual machine","status":"running","created_at":1676031324,"started_at":1676031339,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"running","created_at":1679506714,"started_at":1679506729,"finished_at":null,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -943,9 +943,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:40 GMT
+      - Wed, 22 Mar 2023 17:38:50 GMT
       Etag:
-      - W/"bd40d3f0ef77ec98929becb9311d298e"
+      - W/"18f41bfe19193e7c4c363921ad3f4eb1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -953,9 +953,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "824"
+      - "911"
       X-Request-Id:
-      - edc5b6a7-061a-4310-940a-a39e7f2439e5
+      - 95c0cf00-0479-4a1f-b939-1f71cf973530
     status: 200 OK
     code: 200
     duration: ""
@@ -967,10 +967,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_6MOzH19IjoOB3Jau
+    url: https://api.katapult.io/core/v1/tasks/task_wstLqncNU7lOGtet
     method: GET
   response:
-    body: '{"task":{"id":"task_6MOzH19IjoOB3Jau","name":"Stop virtual machine","status":"completed","created_at":1676031324,"started_at":1676031339,"finished_at":1676031342,"progress":100}}'
+    body: '{"task":{"id":"task_wstLqncNU7lOGtet","name":"Stop virtual machine","status":"completed","created_at":1679506714,"started_at":1679506729,"finished_at":1679506732,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -983,9 +983,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:50 GMT
+      - Wed, 22 Mar 2023 17:39:00 GMT
       Etag:
-      - W/"f97147927cae12fc32cca0103bf88ea2"
+      - W/"2338cf9457ebd6b82f8caedf407c6fcd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -993,9 +993,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "821"
+      - "989"
       X-Request-Id:
-      - c7feacc1-84b4-4b2f-8093-990d65036b3d
+      - f5f51a77-084b-4e7c-abaa-e15994c11ef6
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,17 +1007,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_ugnqJcOUUnVgPR89","keep_until":1676204151,"object_id":"vm_dm2CRkhUR4EhLHOA","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_dm2CRkhUR4EhLHOA","name":"tf-acc-test-icy-faint-grapefruit","hostname":"tf-acc-test-icy-faint-grapefruit","fqdn":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031305,"initial_root_password":"ZemP2XH25YIlV7ug","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_dtvgtnWJnvVJejV4","keep_until":1679679540,"object_id":"vm_bX2AccNaC0Ojfv97","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_bX2AccNaC0Ojfv97","name":"tf-acc-test-clumsy-polar-crow","hostname":"tf-acc-test-clumsy-polar-crow","fqdn":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506696,"initial_root_password":"4IADL9jAMsHKWApb","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-icy-faint-grapefruit.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-clumsy-polar-crow.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dm2CRkhUR4EhLHOA","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bX2AccNaC0Ojfv97","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1026,13 +1026,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2298"
+      - "2327"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:51 GMT
+      - Wed, 22 Mar 2023 17:39:01 GMT
       Etag:
-      - W/"4e97df5b883b14f3339720710d789cd5"
+      - W/"9fe800b500a8d8ad9730dde09c728b46"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1040,9 +1040,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "820"
+      - "988"
       X-Request-Id:
-      - 83f54555-f07f-41bb-a8da-10c67571224c
+      - fdc847aa-6b9a-45c5-b8ff-cabba6fc4abb
     status: 200 OK
     code: 200
     duration: ""
@@ -1054,7 +1054,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
     method: POST
   response:
     body: '{}'
@@ -1070,7 +1070,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:51 GMT
+      - Wed, 22 Mar 2023 17:39:01 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1080,9 +1080,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "819"
+      - "987"
       X-Request-Id:
-      - c568a333-6d8e-492d-915e-431717d671bd
+      - 17d67f68-5998-42cb-be96-42667911fd1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1094,10 +1094,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_ugnqJcOUUnVgPR89
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dtvgtnWJnvVJejV4
     method: DELETE
   response:
-    body: '{"task":{"id":"task_3xIT6jzHBCTywj7n","name":"Purge items from trash","status":"pending","created_at":1676031351,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_8pnkPapiUGUZu8ij","name":"Purge items from trash","status":"pending","created_at":1679506741,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1110,9 +1110,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:51 GMT
+      - Wed, 22 Mar 2023 17:39:01 GMT
       Etag:
-      - W/"e94a95ac2b6bb8c47dea66f23af0d0fc"
+      - W/"09f128d2b7f8e22292b0d9b1225dce3a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1120,9 +1120,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "818"
+      - "982"
       X-Request-Id:
-      - 8f12edb6-96be-482f-bd86-87e8eb5142e8
+      - 773691e8-a765-4cdc-b79c-8fd2656a8410
     status: 200 OK
     code: 200
     duration: ""
@@ -1134,10 +1134,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_3xIT6jzHBCTywj7n
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dtvgtnWJnvVJejV4
     method: GET
   response:
-    body: '{"task":{"id":"task_3xIT6jzHBCTywj7n","name":"Purge items from trash","status":"running","created_at":1676031351,"started_at":1676031352,"finished_at":null,"progress":5}}'
+    body: '{"trash_object":{"id":"trsh_dtvgtnWJnvVJejV4","keep_until":1679679540,"object_id":"vm_bX2AccNaC0Ojfv97","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1146,13 +1146,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:52 GMT
+      - Wed, 22 Mar 2023 17:39:02 GMT
       Etag:
-      - W/"36adfe3fd803c83dabf402ecda67e1b0"
+      - W/"d015c62a0b62c3c3e5f9228f9cda740e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1160,9 +1160,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "817"
+      - "979"
       X-Request-Id:
-      - e4cf17d9-6fde-4a43-bd84-8d17ec7e3268
+      - da2b1a90-4d24-409e-8a84-7740182826de
     status: 200 OK
     code: 200
     duration: ""
@@ -1174,37 +1174,38 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_3xIT6jzHBCTywj7n
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dtvgtnWJnvVJejV4
     method: GET
   response:
-    body: '{"task":{"id":"task_3xIT6jzHBCTywj7n","name":"Purge items from trash","status":"completed","created_at":1676031351,"started_at":1676031352,"finished_at":1676031354,"progress":100}}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "180"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:57 GMT
-      Etag:
-      - W/"8ef4fc8cf7e8c0410e7cedca8529d912"
+      - Wed, 22 Mar 2023 17:39:07 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "812"
+      - "954"
       X-Request-Id:
-      - ee7ed299-e6a8-4e4e-b217-59025fb5d3a6
-    status: 200 OK
-    code: 200
+      - 8bd6c7be-b3d0-406a-96a5-47a3eb8ef6fb
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -1214,7 +1215,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
     method: DELETE
   response:
     body: '{}'
@@ -1230,7 +1231,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:57 GMT
+      - Wed, 22 Mar 2023 17:39:07 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1240,9 +1241,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "811"
+      - "953"
       X-Request-Id:
-      - 74da1351-8c1f-4730-8c30-932fd266b138
+      - 73e8f35c-f987-48ec-8e46-b417714d0d39
     status: 200 OK
     code: 200
     duration: ""
@@ -1254,7 +1255,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dm2CRkhUR4EhLHOA
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bX2AccNaC0Ojfv97
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1271,7 +1272,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:57 GMT
+      - Wed, 22 Mar 2023 17:39:07 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1281,9 +1282,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "810"
+      - "950"
       X-Request-Id:
-      - 24138bd8-eba2-494c-8048-d399aaab367e
+      - 124cbe30-686a-4f29-8c64-7e94f5cb870e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1295,7 +1296,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -1312,7 +1313,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:57 GMT
+      - Wed, 22 Mar 2023 17:39:07 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1322,9 +1323,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "809"
+      - "949"
       X-Request-Id:
-      - b12cc4b6-10c9-4f7b-a292-e2177960083f
+      - dfd6a371-d38b-4338-8a78-d59e1852035f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update.cassette.rand_id
@@ -1,1 +1,1 @@
-9fvvnwndieu1
+yma21d7a76g8

--- a/internal/provider/testdata/VirtualMachine_update.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update.cassette.rand_id
@@ -1,1 +1,1 @@
-nopeoejp19qq
+9fvvnwndieu1

--- a/internal/provider/testdata/VirtualMachine_update.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:08 GMT
+      - Thu, 23 Mar 2023 10:55:24 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "940"
+      - "909"
       X-Request-Id:
-      - 74996409-8dd1-4184-a893-8877327acc89
+      - 1e093859-f466-43e0-b534-cc9844a78b2b
     status: 200 OK
     code: 200
     duration: ""
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -70,9 +70,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:12 GMT
+      - Thu, 23 Mar 2023 10:55:24 GMT
       Etag:
-      - W/"a6b5cdab485741d1838e65e88fa9f2ba"
+      - W/"70ae5cda48cd0cdf599bd81704faa419"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "939"
+      - "908"
       X-Request-Id:
-      - fd8878c5-eef2-42f4-93dc-a0fb0ab16828
+      - 7d616de0-db08-4632-a967-13218eecdd42
     status: 200 OK
     code: 200
     duration: ""
@@ -94,10 +94,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -112,9 +112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:12 GMT
+      - Thu, 23 Mar 2023 10:55:24 GMT
       Etag:
-      - W/"7a47cc20d8813bde7d5bd5698f451dee"
+      - W/"7367639e17424126d908b7a96b17219f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -122,9 +122,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "934"
+      - "907"
       X-Request-Id:
-      - baf6708b-e8cd-4d4a-b90a-8ec471724db3
+      - c685e4c2-dd33-4e85-9d12-a1af52846e41
     status: 200 OK
     code: 200
     duration: ""
@@ -136,10 +136,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -154,9 +154,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:12 GMT
+      - Thu, 23 Mar 2023 10:55:24 GMT
       Etag:
-      - W/"7a47cc20d8813bde7d5bd5698f451dee"
+      - W/"7367639e17424126d908b7a96b17219f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -164,15 +164,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "933"
+      - "906"
       X-Request-Id:
-      - 5ac7d83d-5b3a-4507-ab61-5e52a3acb374
+      - f746ce62-4197-41f2-a394-652cf5a6de65
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_U9UlK0AeOdMthOJ5</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-9fvvnwndieu1-host</Hostname></Hostname><Name>tf-acc-test-update-9fvvnwndieu1</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_2bjWpH3KQBlrSjJ0</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-yma21d7a76g8-host</Hostname></Hostname><Name>tf-acc-test-update-yma21d7a76g8</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_oHzVP2QCLtArfkl0","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","state":"pending"},"virtual_machine_build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","state":"pending"},"hostname":"tf-acc-test-update-9fvvnwndieu1-host"}'
+    body: '{"task":{"id":"task_yLXTlBbMX29KEXwB","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_pXBq3e1A9dPknxnl","state":"pending"},"virtual_machine_build":{"id":"vmbuild_pXBq3e1A9dPknxnl","state":"pending"},"hostname":"tf-acc-test-update-yma21d7a76g8-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -197,9 +197,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:12 GMT
+      - Thu, 23 Mar 2023 10:55:24 GMT
       Etag:
-      - W/"3bb334878594c2dd591469e3f684ca54"
+      - W/"27ac41a331d49110e5efe9e4b42b32b1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -207,9 +207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "932"
+      - "905"
       X-Request-Id:
-      - 04963ee2-1ca2-4e24-9063-9abd4c5fc085
+      - bd8470ca-4785-4db8-9c5e-4428994e040d
     status: 201 Created
     code: 201
     duration: ""
@@ -221,17 +221,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_yrvFjUmEw6z5c6Sk
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_pXBq3e1A9dPknxnl
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_pXBq3e1A9dPknxnl","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-9fvvnwndieu1-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-9fvvnwndieu1\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-yma21d7a76g8-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-yma21d7a76g8\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506752}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679568924}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -240,13 +240,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1932"
+      - "1719"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:14 GMT
+      - Thu, 23 Mar 2023 10:55:26 GMT
       Etag:
-      - W/"a79ddaacfe9861774b8460718391f4bd"
+      - W/"3549393dedce155eea1521fefb03a261"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -254,9 +254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "931"
+      - "903"
       X-Request-Id:
-      - 85495dc0-c682-4b34-b670-7ea0bf2d4850
+      - 1ac58c05-4745-4037-93b5-c3862e0999cf
     status: 200 OK
     code: 200
     duration: ""
@@ -268,17 +268,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_yrvFjUmEw6z5c6Sk
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_pXBq3e1A9dPknxnl
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_pXBq3e1A9dPknxnl","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-9fvvnwndieu1-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-9fvvnwndieu1\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-yma21d7a76g8-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-yma21d7a76g8\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506752}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8","hostname":"tf-acc-test-update-yma21d7a76g8-host","fqdn":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568924}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -291,9 +291,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:19 GMT
+      - Thu, 23 Mar 2023 10:55:31 GMT
       Etag:
-      - W/"a79ddaacfe9861774b8460718391f4bd"
+      - W/"9a4507ecf9a50877322936f83f195eeb"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -301,9 +301,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "919"
+      - "900"
       X-Request-Id:
-      - 0f7ebab0-1ce6-4716-84de-b9715f803541
+      - 5a91a3ab-877c-4596-8e27-24b73b5f12f3
     status: 200 OK
     code: 200
     duration: ""
@@ -315,17 +315,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_yrvFjUmEw6z5c6Sk
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_pXBq3e1A9dPknxnl
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_pXBq3e1A9dPknxnl","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-9fvvnwndieu1-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-9fvvnwndieu1\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-yma21d7a76g8-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-yma21d7a76g8\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679506752}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8","hostname":"tf-acc-test-update-yma21d7a76g8-host","fqdn":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679568924}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -334,13 +334,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1932"
+      - "1933"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:29 GMT
+      - Thu, 23 Mar 2023 10:55:41 GMT
       Etag:
-      - W/"28f56afc16a15b48b3757c1d16546c84"
+      - W/"0c2effbd8541a41e6ee201764b851a5e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -348,15 +348,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "901"
+      - "874"
       X-Request-Id:
-      - c2875f0b-3804-42ac-9284-b54626a5e6c3
+      - 2c3f5780-7218-4dc7-8ff1-33ace7bdcc81
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -368,15 +368,63 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8","hostname":"tf-acc-test-update-yma21d7a76g8-host","fqdn":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2414"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:41 GMT
+      Etag:
+      - W/"6a9221421270d87a3ace074a284f52ff"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "873"
+      X-Request-Id:
+      - 68b8a0f3-1783-4a57-9ac7-4d443e185bca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8","hostname":"tf-acc-test-update-yma21d7a76g8-host","fqdn":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -389,9 +437,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:29 GMT
+      - Thu, 23 Mar 2023 10:55:43 GMT
       Etag:
-      - W/"a88c1d389d4e6b986ab9f4751adf56db"
+      - W/"c7df3b8c956180963f175981b5db77d4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -399,9 +447,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "900"
+      - "872"
       X-Request-Id:
-      - f2309274-46c1-4137-9f8d-3678128b5ce3
+      - 00d030ff-c6f0-42a2-bdb1-b4630b912fe6
     status: 200 OK
     code: 200
     duration: ""
@@ -413,18 +461,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8","hostname":"tf-acc-test-update-yma21d7a76g8-host","fqdn":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -437,9 +485,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:31 GMT
+      - Thu, 23 Mar 2023 10:55:43 GMT
       Etag:
-      - W/"a88c1d389d4e6b986ab9f4751adf56db"
+      - W/"c7df3b8c956180963f175981b5db77d4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -447,9 +495,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "897"
+      - "871"
       X-Request-Id:
-      - 2dfc48ab-670a-4d92-b147-27dbaec68011
+      - 50b1121c-543f-4407-af69-a598af9b6b0e
     status: 200 OK
     code: 200
     duration: ""
@@ -461,60 +509,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2413"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:31 GMT
-      Etag:
-      - W/"a88c1d389d4e6b986ab9f4751adf56db"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "896"
-      X-Request-Id:
-      - 107dc62d-f328-4a68-b813-f730f07ea1eb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_6gnTe3tv2eg9243r","name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -527,9 +527,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:31 GMT
+      - Thu, 23 Mar 2023 10:55:43 GMT
       Etag:
-      - W/"35c8715f4c92515c6eaeb6accf2f5025"
+      - W/"e6571d6d8d3b24e79aa6da5e7ed236ac"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -537,9 +537,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "895"
+      - "870"
       X-Request-Id:
-      - 22c674de-dbf8-4e09-8e2d-382f31835e27
+      - d50ddd7b-db14-4879-b161-86e59a443502
     status: 200 OK
     code: 200
     duration: ""
@@ -551,12 +551,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_6gnTe3tv2eg9243r
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"},"name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_6gnTe3tv2eg9243r","virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8"},"name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:67:ac:33:96:1f","state":"detached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -569,9 +569,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:31 GMT
+      - Thu, 23 Mar 2023 10:55:43 GMT
       Etag:
-      - W/"22ab45dfdbc7486efc102e4bf0cf5609"
+      - W/"cbc63ba31ade382c36aab52525a74d6b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -579,9 +579,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "894"
+      - "869"
       X-Request-Id:
-      - 5f4e4a19-17a8-48a5-bdb9-eaf40139e2dc
+      - f80109e8-d4d7-476d-81b9-2e5bdfe92d26
     status: 200 OK
     code: 200
     duration: ""
@@ -593,18 +593,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8","hostname":"tf-acc-test-update-yma21d7a76g8-host","fqdn":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -617,9 +617,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:31 GMT
+      - Thu, 23 Mar 2023 10:55:43 GMT
       Etag:
-      - W/"a88c1d389d4e6b986ab9f4751adf56db"
+      - W/"c7df3b8c956180963f175981b5db77d4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -627,9 +627,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "893"
+      - "868"
       X-Request-Id:
-      - 5f2d01e9-82bf-4602-8d37-7dc1618a43b8
+      - 59e1e499-e98c-46ed-bde4-0d763a699283
     status: 200 OK
     code: 200
     duration: ""
@@ -641,12 +641,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -659,9 +659,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:31 GMT
+      - Thu, 23 Mar 2023 10:55:44 GMT
       Etag:
-      - W/"bcfbc859172142928ac00447b6c64f6f"
+      - W/"24853e41e2a0c1b1cb02c4cc135c2753"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -669,9 +669,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "892"
+      - "867"
       X-Request-Id:
-      - 98d3bb59-9ccb-4889-8dc3-e668b12af195
+      - b9adfbe7-16ab-4640-aea7-4ef2b324e962
     status: 200 OK
     code: 200
     duration: ""
@@ -683,18 +683,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8","hostname":"tf-acc-test-update-yma21d7a76g8-host","fqdn":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -707,9 +707,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:44 GMT
       Etag:
-      - W/"a88c1d389d4e6b986ab9f4751adf56db"
+      - W/"c7df3b8c956180963f175981b5db77d4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -717,9 +717,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "891"
+      - "866"
       X-Request-Id:
-      - 7ce59904-16fe-4d94-8576-082a6bfde7d6
+      - 00dd81b4-6293-47d3-8799-0d940227c523
     status: 200 OK
     code: 200
     duration: ""
@@ -731,12 +731,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_6gnTe3tv2eg9243r","name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -749,9 +749,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:44 GMT
       Etag:
-      - W/"35c8715f4c92515c6eaeb6accf2f5025"
+      - W/"e6571d6d8d3b24e79aa6da5e7ed236ac"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -759,9 +759,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "890"
+      - "865"
       X-Request-Id:
-      - c1116428-6581-4864-bc94-331656ca2370
+      - cb5e33e3-1515-4192-92f2-6bfd49cb7111
     status: 200 OK
     code: 200
     duration: ""
@@ -773,12 +773,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_6gnTe3tv2eg9243r
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"},"name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_6gnTe3tv2eg9243r","virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8"},"name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:67:ac:33:96:1f","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -791,9 +791,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:44 GMT
       Etag:
-      - W/"22ab45dfdbc7486efc102e4bf0cf5609"
+      - W/"3d4f62d23db27bc8736730a279a45f03"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -801,9 +801,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "889"
+      - "864"
       X-Request-Id:
-      - 44b73630-88ce-40f6-a138-5464b02573bc
+      - d11c0f52-c755-4c4a-87e3-c8c9a5e17a57
     status: 200 OK
     code: 200
     duration: ""
@@ -815,12 +815,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -833,9 +833,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:44 GMT
       Etag:
-      - W/"bcfbc859172142928ac00447b6c64f6f"
+      - W/"24853e41e2a0c1b1cb02c4cc135c2753"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -843,9 +843,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "888"
+      - "863"
       X-Request-Id:
-      - 84586cac-7d3c-4f32-8e4e-99011da071fc
+      - 2d6b4173-d8a7-4f76-9792-f90c56682933
     status: 200 OK
     code: 200
     duration: ""
@@ -857,18 +857,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8","hostname":"tf-acc-test-update-yma21d7a76g8-host","fqdn":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -881,9 +881,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:44 GMT
       Etag:
-      - W/"a88c1d389d4e6b986ab9f4751adf56db"
+      - W/"c7df3b8c956180963f175981b5db77d4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -891,9 +891,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "887"
+      - "862"
       X-Request-Id:
-      - 826878cc-7407-46cf-9e24-33acaec5ca7c
+      - e60eb87a-17cd-4b12-affb-e4fe658e18e2
     status: 200 OK
     code: 200
     duration: ""
@@ -905,12 +905,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_6gnTe3tv2eg9243r","name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -923,9 +923,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:44 GMT
       Etag:
-      - W/"35c8715f4c92515c6eaeb6accf2f5025"
+      - W/"e6571d6d8d3b24e79aa6da5e7ed236ac"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -933,9 +933,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "886"
+      - "861"
       X-Request-Id:
-      - 137cf642-6ace-48a4-b972-754ea3c346e7
+      - dfd35a1b-f8a5-424f-a153-7f478b6b5fff
     status: 200 OK
     code: 200
     duration: ""
@@ -947,12 +947,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_6gnTe3tv2eg9243r
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"},"name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_6gnTe3tv2eg9243r","virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8"},"name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:67:ac:33:96:1f","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -965,9 +965,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:44 GMT
       Etag:
-      - W/"22ab45dfdbc7486efc102e4bf0cf5609"
+      - W/"3d4f62d23db27bc8736730a279a45f03"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -975,9 +975,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "885"
+      - "860"
       X-Request-Id:
-      - ed9900a8-04b9-45f4-8021-3a36a8cf0aa3
+      - afe4d9d5-2116-410b-8a88-71db587579a6
     status: 200 OK
     code: 200
     duration: ""
@@ -989,12 +989,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_6gnTe3tv2eg9243r","name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1007,9 +1007,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:45 GMT
       Etag:
-      - W/"77a8bc2df073ad24ad070b198aff3b75"
+      - W/"445cd0b08df6fa43e1427d55ff178b97"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1017,15 +1017,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "884"
+      - "855"
       X-Request-Id:
-      - 8dd8608d-92e8-4f64-b6c2-2a45e6cd3e90
+      - 712e451b-4a72-4e64-bdc6-39e253ba3d79
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE"},"speed_profile":{"permalink":"10gbps"}}
+      {"virtual_machine_network_interface":{"id":"vmnet_6gnTe3tv2eg9243r"},"speed_profile":{"permalink":"10gbps"}}
     form: {}
     headers:
       Accept:
@@ -1037,8 +1037,8 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/update_speed_profile
     method: PATCH
   response:
-    body: '{"task":{"id":"task_bW00NGsyotE03sd6","name":"Change network interface
-      speed profile","status":"pending","created_at":1679506772,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_lS3hxfquxaWZTcZ3","name":"Change network interface
+      speed profile","status":"pending","created_at":1679568945,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1051,9 +1051,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:32 GMT
+      - Thu, 23 Mar 2023 10:55:45 GMT
       Etag:
-      - W/"bd5f9bbf44e67d1d81e00aa8b9520e4d"
+      - W/"2dbf763be1b75348692b5f6e3eeb8bbd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1061,9 +1061,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "883"
+      - "854"
       X-Request-Id:
-      - ce27660b-2da0-4bc1-93f2-9c91c4eef841
+      - 69d8ce3a-7b23-468d-bd6f-b775ccd8f258
     status: 200 OK
     code: 200
     duration: ""
@@ -1075,11 +1075,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_bW00NGsyotE03sd6
+    url: https://api.katapult.io/core/v1/tasks/task_lS3hxfquxaWZTcZ3
     method: GET
   response:
-    body: '{"task":{"id":"task_bW00NGsyotE03sd6","name":"Change network interface
-      speed profile","status":"running","created_at":1679506772,"started_at":1679506773,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_lS3hxfquxaWZTcZ3","name":"Change network interface
+      speed profile","status":"running","created_at":1679568945,"started_at":1679568946,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1092,9 +1092,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:33 GMT
+      - Thu, 23 Mar 2023 10:55:46 GMT
       Etag:
-      - W/"1b9aaa21bc6042d50ea3aa70a24e7507"
+      - W/"52bc3886178b9be7aa57ff8a9da97b9f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1102,9 +1102,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "882"
+      - "853"
       X-Request-Id:
-      - 561d9309-36a3-44dc-b1be-d7a8243fc29c
+      - 386cb454-f5b1-4be8-b5c2-347061434d5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1116,11 +1116,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_bW00NGsyotE03sd6
+    url: https://api.katapult.io/core/v1/tasks/task_lS3hxfquxaWZTcZ3
     method: GET
   response:
-    body: '{"task":{"id":"task_bW00NGsyotE03sd6","name":"Change network interface
-      speed profile","status":"completed","created_at":1679506772,"started_at":1679506773,"finished_at":1679506774,"progress":100}}'
+    body: '{"task":{"id":"task_lS3hxfquxaWZTcZ3","name":"Change network interface
+      speed profile","status":"completed","created_at":1679568945,"started_at":1679568946,"finished_at":1679568947,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1133,9 +1133,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:38 GMT
+      - Thu, 23 Mar 2023 10:55:51 GMT
       Etag:
-      - W/"1a9e6db3628834813fd0266b28e37928"
+      - W/"6abb777fe8f5d06af9a947940afb16a8"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1143,15 +1143,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "879"
+      - "848"
       X-Request-Id:
-      - 53c5b1e0-2bae-4ed3-89bd-aeb898fd68fc
+      - c601682e-c36a-4d94-a712-924080770fcd
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7"},"properties":{"name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","description":"A app server.","tag_names":["lb","app","web"]}}
+      {"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi"},"properties":{"name":"tf-acc-test-update-yma21d7a76g8-diff","hostname":"tf-acc-test-update-yma21d7a76g8-host-diff","description":"A app server.","tag_names":["lb","app","web"]}}
     form: {}
     headers:
       Accept:
@@ -1163,15 +1163,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff","hostname":"tf-acc-test-update-yma21d7a76g8-host-diff","fqdn":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1184,9 +1184,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:39 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"65026bd2febb7f18088e1f41539ef5b2"
+      - W/"bb0a0be96eabe26b3955aa501e774fb0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1194,9 +1194,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "878"
+      - "847"
       X-Request-Id:
-      - 292a4add-7f2d-46f7-b0d6-f274911b2336
+      - badb83ff-d527-4613-83d0-3c04122d56f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,18 +1208,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff","hostname":"tf-acc-test-update-yma21d7a76g8-host-diff","fqdn":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1232,9 +1232,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:39 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"65026bd2febb7f18088e1f41539ef5b2"
+      - W/"bb0a0be96eabe26b3955aa501e774fb0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1242,9 +1242,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "877"
+      - "842"
       X-Request-Id:
-      - 7c477d82-9715-4cca-a14e-4ab509916845
+      - 42aac289-18b5-4408-b4c1-8e52107bccdc
     status: 200 OK
     code: 200
     duration: ""
@@ -1256,12 +1256,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_6gnTe3tv2eg9243r","name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1274,9 +1274,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:39 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"3ecad0a8113b219de3b0477b0c4e4f74"
+      - W/"c7f2dd3a32a83675fb76c5cd69a3ed77"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1284,9 +1284,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "876"
+      - "840"
       X-Request-Id:
-      - ef2232cc-6221-4411-891c-d2132fe60fa3
+      - e2cd52a6-405d-47c0-acd3-96df01eff3e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1298,12 +1298,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_6gnTe3tv2eg9243r
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff"},"name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_6gnTe3tv2eg9243r","virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff"},"name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:67:ac:33:96:1f","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1316,9 +1316,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:39 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"7a89270c80a03d6cd9dca90e137e33c4"
+      - W/"c44107bf5add18df972f5ce4e41a76a7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1326,9 +1326,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "875"
+      - "839"
       X-Request-Id:
-      - 70c41838-d964-480b-978f-a0c5b90684a4
+      - ead2b3fb-6389-41f9-9dc4-230a0659e415
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,18 +1340,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff","hostname":"tf-acc-test-update-yma21d7a76g8-host-diff","fqdn":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1364,9 +1364,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:39 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"65026bd2febb7f18088e1f41539ef5b2"
+      - W/"bb0a0be96eabe26b3955aa501e774fb0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1374,9 +1374,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "874"
+      - "838"
       X-Request-Id:
-      - d3dc0b17-5b3c-4908-ad68-15b7023534c5
+      - bf4e6569-8b8e-449f-839d-d3e361ae4279
     status: 200 OK
     code: 200
     duration: ""
@@ -1388,12 +1388,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1406,9 +1406,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:40 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"fac506a03630a20d33376ab6bf746a1d"
+      - W/"b52d084dd9625029ca7e1f4a9dc2d610"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1416,9 +1416,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "873"
+      - "834"
       X-Request-Id:
-      - c8f1ce00-5f66-4494-a5fa-1a7dba2bdc54
+      - b9a1c3d6-bf9f-420e-b830-312b74f74f1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1430,18 +1430,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff","hostname":"tf-acc-test-update-yma21d7a76g8-host-diff","fqdn":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1454,9 +1454,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:40 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"65026bd2febb7f18088e1f41539ef5b2"
+      - W/"bb0a0be96eabe26b3955aa501e774fb0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1464,9 +1464,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "872"
+      - "833"
       X-Request-Id:
-      - b55d3bcb-b748-4561-aed4-62ce86398f11
+      - 50aa3323-6d7b-418d-9795-379b28e80272
     status: 200 OK
     code: 200
     duration: ""
@@ -1478,12 +1478,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_6gnTe3tv2eg9243r","name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1496,9 +1496,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:40 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"3ecad0a8113b219de3b0477b0c4e4f74"
+      - W/"c7f2dd3a32a83675fb76c5cd69a3ed77"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1506,9 +1506,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "871"
+      - "832"
       X-Request-Id:
-      - 8f5fa6d3-e45f-4142-b221-6e26a424cf36
+      - 19dee6a5-ec79-4ec8-bbb0-be08beabea1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1520,12 +1520,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_6gnTe3tv2eg9243r
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff"},"name":"Public
-      Network on tf-acc-test-update-9fvvnwndieu1-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_6gnTe3tv2eg9243r","virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff"},"name":"Public
+      Network on tf-acc-test-update-yma21d7a76g8-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:67:ac:33:96:1f","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1538,9 +1538,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:40 GMT
+      - Thu, 23 Mar 2023 10:55:52 GMT
       Etag:
-      - W/"7a89270c80a03d6cd9dca90e137e33c4"
+      - W/"c44107bf5add18df972f5ce4e41a76a7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1548,9 +1548,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "870"
+      - "831"
       X-Request-Id:
-      - 2957b267-ce6a-408e-a02f-7a060092e77a
+      - a1f99ea6-ecaa-4277-b237-f9ffb02d80f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1562,18 +1562,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff","hostname":"tf-acc-test-update-yma21d7a76g8-host-diff","fqdn":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1586,9 +1586,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:40 GMT
+      - Thu, 23 Mar 2023 10:55:53 GMT
       Etag:
-      - W/"65026bd2febb7f18088e1f41539ef5b2"
+      - W/"bb0a0be96eabe26b3955aa501e774fb0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1596,9 +1596,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "869"
+      - "830"
       X-Request-Id:
-      - 4da32b05-d9c2-435f-bdfd-e5e598f8464d
+      - 8b4e7546-88ad-45b2-8e53-fe3c8ac63437
     status: 200 OK
     code: 200
     duration: ""
@@ -1610,10 +1610,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: POST
   response:
-    body: '{"task":{"id":"task_IOa3s3wYmyqWzaG1","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_LfAaQaz96Y50CEcW","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1626,9 +1626,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:40 GMT
+      - Thu, 23 Mar 2023 10:55:53 GMT
       Etag:
-      - W/"4c5154a4e957110bb6d7edf7c9a84487"
+      - W/"044bad03b368acc57d0a2eb412fdda7f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1636,9 +1636,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "868"
+      - "829"
       X-Request-Id:
-      - 658a90ee-3ae4-4bbd-ae29-12d35dfae447
+      - 5211652f-afc2-4a10-8897-c36639174af0
     status: 200 OK
     code: 200
     duration: ""
@@ -1650,10 +1650,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IOa3s3wYmyqWzaG1
+    url: https://api.katapult.io/core/v1/tasks/task_LfAaQaz96Y50CEcW
     method: GET
   response:
-    body: '{"task":{"id":"task_IOa3s3wYmyqWzaG1","name":"Stop virtual machine","status":"running","created_at":1679506780,"started_at":1679506781,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_LfAaQaz96Y50CEcW","name":"Stop virtual machine","status":"running","created_at":1679568953,"started_at":1679568953,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1666,9 +1666,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:41 GMT
+      - Thu, 23 Mar 2023 10:55:54 GMT
       Etag:
-      - W/"259f1ce19d99ca6700e547d7beb21a09"
+      - W/"3b65d904ea63079785658dd69e1b5d43"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1676,9 +1676,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "863"
+      - "828"
       X-Request-Id:
-      - cbf2ac0e-99e6-4380-9308-0038ca704820
+      - 5ce815a1-e3b8-48a5-9222-1c8d19176165
     status: 200 OK
     code: 200
     duration: ""
@@ -1690,10 +1690,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IOa3s3wYmyqWzaG1
+    url: https://api.katapult.io/core/v1/tasks/task_LfAaQaz96Y50CEcW
     method: GET
   response:
-    body: '{"task":{"id":"task_IOa3s3wYmyqWzaG1","name":"Stop virtual machine","status":"completed","created_at":1679506780,"started_at":1679506781,"finished_at":1679506784,"progress":100}}'
+    body: '{"task":{"id":"task_LfAaQaz96Y50CEcW","name":"Stop virtual machine","status":"completed","created_at":1679568953,"started_at":1679568953,"finished_at":1679568956,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1706,9 +1706,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:46 GMT
+      - Thu, 23 Mar 2023 10:55:59 GMT
       Etag:
-      - W/"c0f84aab543d00fdfb8336df8bb8f0c9"
+      - W/"424b5a43d1509fb227cdae5d5cb79279"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1716,9 +1716,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "852"
+      - "826"
       X-Request-Id:
-      - 81a923e6-5974-41a4-9b36-d6d643ca58ca
+      - 373481bf-d988-49f3-9723-2a7b4eeafb95
     status: 200 OK
     code: 200
     duration: ""
@@ -1730,18 +1730,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_YGiBsRshyU6NXyOL","keep_until":1679679586,"object_id":"vm_EBYmJgWCwJwiJLs7","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_LbEfL9Grh4Z4EnaB","keep_until":1679741759,"object_id":"vm_Jop8ZpCAtGqubcpi","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_Jop8ZpCAtGqubcpi","name":"tf-acc-test-update-yma21d7a76g8-diff","hostname":"tf-acc-test-update-yma21d7a76g8-host-diff","fqdn":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679568925,"initial_root_password":"Dz6daK7Q3LYkq3GF","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-update-yma21d7a76g8-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jop8ZpCAtGqubcpi","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1754,9 +1754,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:46 GMT
+      - Thu, 23 Mar 2023 10:55:59 GMT
       Etag:
-      - W/"c8c34d230ed53adf8c4f10a35f473fb6"
+      - W/"d797f0c6dd5f2a791e8d52b863e1a202"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1764,9 +1764,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "851"
+      - "825"
       X-Request-Id:
-      - b705497b-fe9f-4be1-917c-8a27958dc911
+      - 35883c5d-f878-4b3b-952a-3a963aca1b57
     status: 200 OK
     code: 200
     duration: ""
@@ -1778,7 +1778,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: POST
   response:
     body: '{}'
@@ -1794,7 +1794,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:47 GMT
+      - Thu, 23 Mar 2023 10:55:59 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1804,9 +1804,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "850"
+      - "823"
       X-Request-Id:
-      - e2b9f99f-6ebd-4a12-a535-82c0a238a1cd
+      - 227fd93b-895c-4b5a-a8ce-269b57d82872
     status: 200 OK
     code: 200
     duration: ""
@@ -1818,10 +1818,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YGiBsRshyU6NXyOL
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_LbEfL9Grh4Z4EnaB
     method: DELETE
   response:
-    body: '{"task":{"id":"task_aucoqVqn7WuG2BEF","name":"Purge items from trash","status":"pending","created_at":1679506787,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_ONqj1aRhDgG40GpP","name":"Purge items from trash","status":"pending","created_at":1679568959,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1834,9 +1834,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:47 GMT
+      - Thu, 23 Mar 2023 10:55:59 GMT
       Etag:
-      - W/"07ed120f8f7d7543f5372f26283b71d0"
+      - W/"01e324ccdf8ee1bbeb5889ad3ca095b9"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1844,9 +1844,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "849"
+      - "822"
       X-Request-Id:
-      - fade57d8-7627-43cd-a7f7-dbb1def6788c
+      - 5edcc042-643e-44e1-abbd-91262b3a8633
     status: 200 OK
     code: 200
     duration: ""
@@ -1858,10 +1858,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YGiBsRshyU6NXyOL
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_LbEfL9Grh4Z4EnaB
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_YGiBsRshyU6NXyOL","keep_until":1679679586,"object_id":"vm_EBYmJgWCwJwiJLs7","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_LbEfL9Grh4Z4EnaB","keep_until":1679741759,"object_id":"vm_Jop8ZpCAtGqubcpi","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1874,9 +1874,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:48 GMT
+      - Thu, 23 Mar 2023 10:56:00 GMT
       Etag:
-      - W/"f10c0b7bb100e1af499b1cb155c43e0d"
+      - W/"52005202256636189cc6b578e90f0ae6"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1884,9 +1884,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "846"
+      - "999"
       X-Request-Id:
-      - ab4efc2b-2d7e-46f4-bf9c-027ca6e1531c
+      - 56603701-7a71-4b0a-8f96-ddd684ec7010
     status: 200 OK
     code: 200
     duration: ""
@@ -1898,47 +1898,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YGiBsRshyU6NXyOL
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_YGiBsRshyU6NXyOL","keep_until":1679679586,"object_id":"vm_EBYmJgWCwJwiJLs7","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
-      Etag:
-      - W/"f10c0b7bb100e1af499b1cb155c43e0d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "833"
-      X-Request-Id:
-      - 76e71338-4d11-410d-80dc-2d0bfec9a19a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YGiBsRshyU6NXyOL
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_LbEfL9Grh4Z4EnaB
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -1955,7 +1915,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:03 GMT
+      - Thu, 23 Mar 2023 10:56:05 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1967,7 +1927,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "997"
       X-Request-Id:
-      - d25a0ba9-2012-4f73-b063-70b9d2563728
+      - 7cdf3961-86dc-47b0-bfd3-ba5370efec32
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1979,7 +1939,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: DELETE
   response:
     body: '{}'
@@ -1995,7 +1955,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:03 GMT
+      - Thu, 23 Mar 2023 10:56:05 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2007,7 +1967,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "996"
       X-Request-Id:
-      - b001d6f4-3c05-4134-b581-e7207d895b25
+      - fed990aa-471e-4747-9e94-eb1eabe7fb3a
     status: 200 OK
     code: 200
     duration: ""
@@ -2019,7 +1979,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jop8ZpCAtGqubcpi
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2036,7 +1996,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:03 GMT
+      - Thu, 23 Mar 2023 10:56:06 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2048,7 +2008,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "995"
       X-Request-Id:
-      - 64a18b13-077a-407b-9513-f0fb2f27a879
+      - 53d4a184-2e7d-4ee8-87ac-02d6b472b0d2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2060,7 +2020,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Jop8ZpCAtGqubcpi
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:56:06 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 563dcebf-1cf7-4e7a-8542-2e23207531f9
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2077,7 +2078,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:03 GMT
+      - Thu, 23 Mar 2023 10:56:06 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2087,9 +2088,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "993"
       X-Request-Id:
-      - fa195447-3d26-46d6-98f3-b5fea2f0624f
+      - 5a0ab012-0c84-4c08-af92-509a4c4a905d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:31 GMT
+      - Wed, 22 Mar 2023 17:39:08 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "827"
+      - "940"
       X-Request-Id:
-      - 749e863c-7b91-4271-940d-f68dd87400d9
+      - 74996409-8dd1-4184-a893-8877327acc89
     status: 200 OK
     code: 200
     duration: ""
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"185-199-222-21.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -70,9 +70,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:31 GMT
+      - Wed, 22 Mar 2023 17:39:12 GMT
       Etag:
-      - W/"3800ced61b87a06fdc1ed4f888deb861"
+      - W/"a6b5cdab485741d1838e65e88fa9f2ba"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "826"
+      - "939"
       X-Request-Id:
-      - 4f94651b-f52f-42e1-bccd-3fd62c6268b1
+      - fd8878c5-eef2-42f4-93dc-a0fb0ab16828
     status: 200 OK
     code: 200
     duration: ""
@@ -94,10 +94,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3Mc6zF0VP1zK9Z7n
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"185-199-222-21.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -112,9 +112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:31 GMT
+      - Wed, 22 Mar 2023 17:39:12 GMT
       Etag:
-      - W/"d73e9de6162e4a6972c8f55598b5f968"
+      - W/"7a47cc20d8813bde7d5bd5698f451dee"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -122,9 +122,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "825"
+      - "934"
       X-Request-Id:
-      - 72559db9-66f5-44f7-9955-4122df513cfa
+      - baf6708b-e8cd-4d4a-b90a-8ec471724db3
     status: 200 OK
     code: 200
     duration: ""
@@ -136,10 +136,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3Mc6zF0VP1zK9Z7n
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"185-199-222-21.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -154,9 +154,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:31 GMT
+      - Wed, 22 Mar 2023 17:39:12 GMT
       Etag:
-      - W/"d73e9de6162e4a6972c8f55598b5f968"
+      - W/"7a47cc20d8813bde7d5bd5698f451dee"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -164,15 +164,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "824"
+      - "933"
       X-Request-Id:
-      - fc7fa202-3454-4f1f-b585-8adb1d7386f4
+      - 5ac7d83d-5b3a-4507-ab61-5e52a3acb374
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_3Mc6zF0VP1zK9Z7n</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-nopeoejp19qq-host</Hostname></Hostname><Name>tf-acc-test-update-nopeoejp19qq</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_U9UlK0AeOdMthOJ5</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-9fvvnwndieu1-host</Hostname></Hostname><Name>tf-acc-test-update-9fvvnwndieu1</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_ukkae6zqFe59keRE","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_DfVUViGHKFFlwYW4","state":"pending"},"virtual_machine_build":{"id":"vmbuild_DfVUViGHKFFlwYW4","state":"pending"},"hostname":"tf-acc-test-update-nopeoejp19qq-host"}'
+    body: '{"task":{"id":"task_oHzVP2QCLtArfkl0","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","state":"pending"},"virtual_machine_build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","state":"pending"},"hostname":"tf-acc-test-update-9fvvnwndieu1-host"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -197,9 +197,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:31 GMT
+      - Wed, 22 Mar 2023 17:39:12 GMT
       Etag:
-      - W/"cec29eb10da6b48a516c9c1ffbcdde81"
+      - W/"3bb334878594c2dd591469e3f684ca54"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -207,9 +207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "823"
+      - "932"
       X-Request-Id:
-      - 5b4587fe-1b9a-41d8-9d8d-31cfab2702e3
+      - 04963ee2-1ca2-4e24-9063-9abd4c5fc085
     status: 201 Created
     code: 201
     duration: ""
@@ -221,17 +221,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_DfVUViGHKFFlwYW4
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_yrvFjUmEw6z5c6Sk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DfVUViGHKFFlwYW4","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.21\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-nopeoejp19qq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-nopeoejp19qq\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-9fvvnwndieu1-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-9fvvnwndieu1\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031271}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506752}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -244,9 +244,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:33 GMT
+      - Wed, 22 Mar 2023 17:39:14 GMT
       Etag:
-      - W/"ae5e831fc9ab749b6031b3b01fe53ddc"
+      - W/"a79ddaacfe9861774b8460718391f4bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -254,9 +254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "821"
+      - "931"
       X-Request-Id:
-      - 5d971abc-cf82-417c-ab72-5f6d852b6933
+      - 85495dc0-c682-4b34-b670-7ea0bf2d4850
     status: 200 OK
     code: 200
     duration: ""
@@ -268,17 +268,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_DfVUViGHKFFlwYW4
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_yrvFjUmEw6z5c6Sk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DfVUViGHKFFlwYW4","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.21\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-nopeoejp19qq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-nopeoejp19qq\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-9fvvnwndieu1-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-9fvvnwndieu1\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031271}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506752}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -291,9 +291,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:38 GMT
+      - Wed, 22 Mar 2023 17:39:19 GMT
       Etag:
-      - W/"ae5e831fc9ab749b6031b3b01fe53ddc"
+      - W/"a79ddaacfe9861774b8460718391f4bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -301,9 +301,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "815"
+      - "919"
       X-Request-Id:
-      - a3efdadb-fcf4-4654-b03f-f43c38b86825
+      - 0f7ebab0-1ce6-4716-84de-b9715f803541
     status: 200 OK
     code: 200
     duration: ""
@@ -315,17 +315,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_DfVUViGHKFFlwYW4
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_yrvFjUmEw6z5c6Sk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DfVUViGHKFFlwYW4","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_yrvFjUmEw6z5c6Sk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.21\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-nopeoejp19qq-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-nopeoejp19qq\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-9fvvnwndieu1-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-9fvvnwndieu1\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1676031271}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679506752}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -338,9 +338,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:48 GMT
+      - Wed, 22 Mar 2023 17:39:29 GMT
       Etag:
-      - W/"212a60b148a4f8edf27a28c67fd78731"
+      - W/"28f56afc16a15b48b3757c1d16546c84"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -348,15 +348,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "806"
+      - "901"
       X-Request-Id:
-      - 87dc5e26-bb3c-448c-9028-ea97b0c0be8c
+      - c2875f0b-3804-42ac-9284-b54626a5e6c3
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -368,15 +368,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -385,13 +385,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2372"
+      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:48 GMT
+      - Wed, 22 Mar 2023 17:39:29 GMT
       Etag:
-      - W/"0e0c4a42ce9eb86e3ebe3bafb625a0f6"
+      - W/"a88c1d389d4e6b986ab9f4751adf56db"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -399,9 +399,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "805"
+      - "900"
       X-Request-Id:
-      - 9198c657-4b94-4aa3-bc08-2e4bb7430dd2
+      - f2309274-46c1-4137-9f8d-3678128b5ce3
     status: 200 OK
     code: 200
     duration: ""
@@ -413,18 +413,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -433,13 +433,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2372"
+      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:50 GMT
+      - Wed, 22 Mar 2023 17:39:31 GMT
       Etag:
-      - W/"0e0c4a42ce9eb86e3ebe3bafb625a0f6"
+      - W/"a88c1d389d4e6b986ab9f4751adf56db"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -447,9 +447,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "803"
+      - "897"
       X-Request-Id:
-      - 1bfe945f-15df-403e-b746-914a01c1fe00
+      - 2dfc48ab-670a-4d92-b147-27dbaec68011
     status: 200 OK
     code: 200
     duration: ""
@@ -461,18 +461,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -481,13 +481,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2372"
+      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:50 GMT
+      - Wed, 22 Mar 2023 17:39:31 GMT
       Etag:
-      - W/"0e0c4a42ce9eb86e3ebe3bafb625a0f6"
+      - W/"a88c1d389d4e6b986ab9f4751adf56db"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -495,9 +495,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "802"
+      - "896"
       X-Request-Id:
-      - c8bb3d76-43d6-479a-9ab2-80440b76cadd
+      - 107dc62d-f328-4a68-b813-f730f07ea1eb
     status: 200 OK
     code: 200
     duration: ""
@@ -509,12 +509,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eWbnp4Tigp1qhtf3","name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -527,9 +527,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:50 GMT
+      - Wed, 22 Mar 2023 17:39:31 GMT
       Etag:
-      - W/"88ad751eee59dec90185e870bf3a5a39"
+      - W/"35c8715f4c92515c6eaeb6accf2f5025"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -537,9 +537,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "801"
+      - "895"
       X-Request-Id:
-      - f27c7341-3fe3-4622-87a6-891f0be1dfb8
+      - 22c674de-dbf8-4e09-8e2d-382f31835e27
     status: 200 OK
     code: 200
     duration: ""
@@ -551,12 +551,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eWbnp4Tigp1qhtf3
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_eWbnp4Tigp1qhtf3","virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq"},"name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:d8:db:22:ec:98","state":"attached","ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"},"name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -569,9 +569,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:50 GMT
+      - Wed, 22 Mar 2023 17:39:31 GMT
       Etag:
-      - W/"884ec6bd103ecfb813a0262b1882faf9"
+      - W/"22ab45dfdbc7486efc102e4bf0cf5609"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -579,9 +579,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "800"
+      - "894"
       X-Request-Id:
-      - bee4d01e-3c20-4af5-af26-5302eff33fa5
+      - 5f4e4a19-17a8-48a5-bdb9-eaf40139e2dc
     status: 200 OK
     code: 200
     duration: ""
@@ -593,18 +593,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -613,13 +613,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2372"
+      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:51 GMT
+      - Wed, 22 Mar 2023 17:39:31 GMT
       Etag:
-      - W/"0e0c4a42ce9eb86e3ebe3bafb625a0f6"
+      - W/"a88c1d389d4e6b986ab9f4751adf56db"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -627,9 +627,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "799"
+      - "893"
       X-Request-Id:
-      - 3dd638c0-dfb9-4fc7-8d7e-54503b855eca
+      - 5f2d01e9-82bf-4602-8d37-7dc1618a43b8
     status: 200 OK
     code: 200
     duration: ""
@@ -641,12 +641,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3Mc6zF0VP1zK9Z7n
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -659,9 +659,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:51 GMT
+      - Wed, 22 Mar 2023 17:39:31 GMT
       Etag:
-      - W/"5867994ec60ed743d416b5d982145d71"
+      - W/"bcfbc859172142928ac00447b6c64f6f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -669,9 +669,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "798"
+      - "892"
       X-Request-Id:
-      - e0eed856-d588-4def-9afe-c77b8f8531d3
+      - 98d3bb59-9ccb-4889-8dc3-e668b12af195
     status: 200 OK
     code: 200
     duration: ""
@@ -683,18 +683,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -703,13 +703,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2372"
+      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:51 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"0e0c4a42ce9eb86e3ebe3bafb625a0f6"
+      - W/"a88c1d389d4e6b986ab9f4751adf56db"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -717,9 +717,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "796"
+      - "891"
       X-Request-Id:
-      - 1ff1dab4-5eeb-4135-b019-7feb477189c8
+      - 7ce59904-16fe-4d94-8576-082a6bfde7d6
     status: 200 OK
     code: 200
     duration: ""
@@ -731,12 +731,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eWbnp4Tigp1qhtf3","name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -749,9 +749,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:51 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"88ad751eee59dec90185e870bf3a5a39"
+      - W/"35c8715f4c92515c6eaeb6accf2f5025"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -759,9 +759,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "794"
+      - "890"
       X-Request-Id:
-      - 88c763c1-3f24-4e87-8650-3357592a0658
+      - c1116428-6581-4864-bc94-331656ca2370
     status: 200 OK
     code: 200
     duration: ""
@@ -773,12 +773,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eWbnp4Tigp1qhtf3
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_eWbnp4Tigp1qhtf3","virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq"},"name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:d8:db:22:ec:98","state":"attached","ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"},"name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -791,9 +791,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:51 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"884ec6bd103ecfb813a0262b1882faf9"
+      - W/"22ab45dfdbc7486efc102e4bf0cf5609"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -801,9 +801,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "793"
+      - "889"
       X-Request-Id:
-      - c89fdeac-66ea-47c1-abda-354a21e86bf9
+      - 44b73630-88ce-40f6-a138-5464b02573bc
     status: 200 OK
     code: 200
     duration: ""
@@ -815,12 +815,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3Mc6zF0VP1zK9Z7n
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -833,9 +833,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:51 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"5867994ec60ed743d416b5d982145d71"
+      - W/"bcfbc859172142928ac00447b6c64f6f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -843,9 +843,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "792"
+      - "888"
       X-Request-Id:
-      - f7c86f76-3aea-4f25-9f54-46fa6e8428af
+      - 84586cac-7d3c-4f32-8e4e-99011da071fc
     status: 200 OK
     code: 200
     duration: ""
@@ -857,18 +857,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq","hostname":"tf-acc-test-update-nopeoejp19qq-host","fqdn":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1","hostname":"tf-acc-test-update-9fvvnwndieu1-host","fqdn":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -877,13 +877,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2372"
+      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:51 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"0e0c4a42ce9eb86e3ebe3bafb625a0f6"
+      - W/"a88c1d389d4e6b986ab9f4751adf56db"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -891,9 +891,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "789"
+      - "887"
       X-Request-Id:
-      - 62805760-211a-4990-a59a-b192ba6fdbcd
+      - 826878cc-7407-46cf-9e24-33acaec5ca7c
     status: 200 OK
     code: 200
     duration: ""
@@ -905,12 +905,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eWbnp4Tigp1qhtf3","name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -923,9 +923,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:51 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"88ad751eee59dec90185e870bf3a5a39"
+      - W/"35c8715f4c92515c6eaeb6accf2f5025"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -933,9 +933,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "788"
+      - "886"
       X-Request-Id:
-      - 446da023-df5b-41e7-9ddd-5d77892af1ad
+      - 137cf642-6ace-48a4-b972-754ea3c346e7
     status: 200 OK
     code: 200
     duration: ""
@@ -947,12 +947,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eWbnp4Tigp1qhtf3
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_eWbnp4Tigp1qhtf3","virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq"},"name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:d8:db:22:ec:98","state":"attached","ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1"},"name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -965,9 +965,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:52 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"884ec6bd103ecfb813a0262b1882faf9"
+      - W/"22ab45dfdbc7486efc102e4bf0cf5609"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -975,9 +975,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "787"
+      - "885"
       X-Request-Id:
-      - 63b35379-2e47-4922-b59f-62c1f213c295
+      - ed9900a8-04b9-45f4-8021-3a36a8cf0aa3
     status: 200 OK
     code: 200
     duration: ""
@@ -989,12 +989,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eWbnp4Tigp1qhtf3","name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1007,9 +1007,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:52 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"484fccbca43f1363bad18500632d6a02"
+      - W/"77a8bc2df073ad24ad070b198aff3b75"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1017,15 +1017,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "780"
+      - "884"
       X-Request-Id:
-      - 6323be22-a7ed-455f-a195-93fe82c4f2cf
+      - 8dd8608d-92e8-4f64-b6c2-2a45e6cd3e90
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_eWbnp4Tigp1qhtf3"},"speed_profile":{"permalink":"10gbps"}}
+      {"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE"},"speed_profile":{"permalink":"10gbps"}}
     form: {}
     headers:
       Accept:
@@ -1037,8 +1037,8 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/update_speed_profile
     method: PATCH
   response:
-    body: '{"task":{"id":"task_RHie8tZ2UZIcerqJ","name":"Change network interface
-      speed profile","status":"pending","created_at":1676031292,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_bW00NGsyotE03sd6","name":"Change network interface
+      speed profile","status":"pending","created_at":1679506772,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1051,9 +1051,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:52 GMT
+      - Wed, 22 Mar 2023 17:39:32 GMT
       Etag:
-      - W/"6d5075790d5f3f13654c5293e9fee112"
+      - W/"bd5f9bbf44e67d1d81e00aa8b9520e4d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1061,9 +1061,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "778"
+      - "883"
       X-Request-Id:
-      - 44bf1e14-406b-43cc-a1bf-deb862d5b771
+      - ce27660b-2da0-4bc1-93f2-9c91c4eef841
     status: 200 OK
     code: 200
     duration: ""
@@ -1075,11 +1075,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_RHie8tZ2UZIcerqJ
+    url: https://api.katapult.io/core/v1/tasks/task_bW00NGsyotE03sd6
     method: GET
   response:
-    body: '{"task":{"id":"task_RHie8tZ2UZIcerqJ","name":"Change network interface
-      speed profile","status":"running","created_at":1676031292,"started_at":1676031293,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_bW00NGsyotE03sd6","name":"Change network interface
+      speed profile","status":"running","created_at":1679506772,"started_at":1679506773,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1092,9 +1092,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:53 GMT
+      - Wed, 22 Mar 2023 17:39:33 GMT
       Etag:
-      - W/"ed825435789447f52cf5c3d23cd315c5"
+      - W/"1b9aaa21bc6042d50ea3aa70a24e7507"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1102,9 +1102,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "772"
+      - "882"
       X-Request-Id:
-      - 94775fc7-b151-4f85-bff2-2961ebdf7792
+      - 561d9309-36a3-44dc-b1be-d7a8243fc29c
     status: 200 OK
     code: 200
     duration: ""
@@ -1116,11 +1116,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_RHie8tZ2UZIcerqJ
+    url: https://api.katapult.io/core/v1/tasks/task_bW00NGsyotE03sd6
     method: GET
   response:
-    body: '{"task":{"id":"task_RHie8tZ2UZIcerqJ","name":"Change network interface
-      speed profile","status":"completed","created_at":1676031292,"started_at":1676031293,"finished_at":1676031294,"progress":100}}'
+    body: '{"task":{"id":"task_bW00NGsyotE03sd6","name":"Change network interface
+      speed profile","status":"completed","created_at":1679506772,"started_at":1679506773,"finished_at":1679506774,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1133,9 +1133,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:58 GMT
+      - Wed, 22 Mar 2023 17:39:38 GMT
       Etag:
-      - W/"c75366adfb590c1c205dddfef9952d46"
+      - W/"1a9e6db3628834813fd0266b28e37928"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1143,15 +1143,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "752"
+      - "879"
       X-Request-Id:
-      - fc6f429c-8bb1-47a7-8d3e-58175ecdeced
+      - 53c5b1e0-2bae-4ed3-89bd-aeb898fd68fc
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ"},"properties":{"name":"tf-acc-test-update-nopeoejp19qq-diff","hostname":"tf-acc-test-update-nopeoejp19qq-host-diff","description":"A app server.","tag_names":["lb","app","web"]}}
+      {"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7"},"properties":{"name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","description":"A app server.","tag_names":["lb","app","web"]}}
     form: {}
     headers:
       Accept:
@@ -1163,15 +1163,15 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff","hostname":"tf-acc-test-update-nopeoejp19qq-host-diff","fqdn":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1180,13 +1180,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2487"
+      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:58 GMT
+      - Wed, 22 Mar 2023 17:39:39 GMT
       Etag:
-      - W/"1efe4312dda44ad19158c9ff7acb1d3c"
+      - W/"65026bd2febb7f18088e1f41539ef5b2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1194,9 +1194,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "751"
+      - "878"
       X-Request-Id:
-      - d9458eae-69b4-4ba6-8eb5-2790c0a955cd
+      - 292a4add-7f2d-46f7-b0d6-f274911b2336
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,18 +1208,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff","hostname":"tf-acc-test-update-nopeoejp19qq-host-diff","fqdn":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1228,13 +1228,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2487"
+      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:58 GMT
+      - Wed, 22 Mar 2023 17:39:39 GMT
       Etag:
-      - W/"1efe4312dda44ad19158c9ff7acb1d3c"
+      - W/"65026bd2febb7f18088e1f41539ef5b2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1242,9 +1242,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "749"
+      - "877"
       X-Request-Id:
-      - f618d79c-a5ab-4fd7-bc45-5fb915cd157f
+      - 7c477d82-9715-4cca-a14e-4ab509916845
     status: 200 OK
     code: 200
     duration: ""
@@ -1256,12 +1256,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eWbnp4Tigp1qhtf3","name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1274,9 +1274,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:58 GMT
+      - Wed, 22 Mar 2023 17:39:39 GMT
       Etag:
-      - W/"d8f628a7a07afeec519913b235f66450"
+      - W/"3ecad0a8113b219de3b0477b0c4e4f74"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1284,9 +1284,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "747"
+      - "876"
       X-Request-Id:
-      - 0e9c7ce9-5d5a-4c75-b780-aefa8eb448a9
+      - ef2232cc-6221-4411-891c-d2132fe60fa3
     status: 200 OK
     code: 200
     duration: ""
@@ -1298,12 +1298,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eWbnp4Tigp1qhtf3
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_eWbnp4Tigp1qhtf3","virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff"},"name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:d8:db:22:ec:98","state":"attached","ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff"},"name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1316,9 +1316,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:58 GMT
+      - Wed, 22 Mar 2023 17:39:39 GMT
       Etag:
-      - W/"75c3174e0d1b7817074e48137d046aa0"
+      - W/"7a89270c80a03d6cd9dca90e137e33c4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1326,9 +1326,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "746"
+      - "875"
       X-Request-Id:
-      - 39d1d095-8a59-4017-9721-f821990c3dd9
+      - 70c41838-d964-480b-978f-a0c5b90684a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,18 +1340,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff","hostname":"tf-acc-test-update-nopeoejp19qq-host-diff","fqdn":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1360,13 +1360,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2487"
+      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:59 GMT
+      - Wed, 22 Mar 2023 17:39:39 GMT
       Etag:
-      - W/"1efe4312dda44ad19158c9ff7acb1d3c"
+      - W/"65026bd2febb7f18088e1f41539ef5b2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1374,9 +1374,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "745"
+      - "874"
       X-Request-Id:
-      - 44537f10-7f8f-4cd2-bc35-16fb0e15eeb8
+      - d3dc0b17-5b3c-4908-ad68-15b7023534c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1388,12 +1388,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3Mc6zF0VP1zK9Z7n
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1406,9 +1406,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:59 GMT
+      - Wed, 22 Mar 2023 17:39:40 GMT
       Etag:
-      - W/"da4556589e7b5ae561ffbe6dcc9cae22"
+      - W/"fac506a03630a20d33376ab6bf746a1d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1416,9 +1416,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "743"
+      - "873"
       X-Request-Id:
-      - 1625e1c0-ff2a-4225-b4d1-3e1f3b21c13f
+      - c8f1ce00-5f66-4494-a5fa-1a7dba2bdc54
     status: 200 OK
     code: 200
     duration: ""
@@ -1430,18 +1430,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff","hostname":"tf-acc-test-update-nopeoejp19qq-host-diff","fqdn":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1450,13 +1450,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2487"
+      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:59 GMT
+      - Wed, 22 Mar 2023 17:39:40 GMT
       Etag:
-      - W/"1efe4312dda44ad19158c9ff7acb1d3c"
+      - W/"65026bd2febb7f18088e1f41539ef5b2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1464,9 +1464,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "742"
+      - "872"
       X-Request-Id:
-      - 4098a1a7-8665-4f55-b846-0a69846803cb
+      - b55d3bcb-b748-4561-aed4-62ce86398f11
     status: 200 OK
     code: 200
     duration: ""
@@ -1478,12 +1478,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eWbnp4Tigp1qhtf3","name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_nzR0aU6NhnfFxsNE","name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1496,9 +1496,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:59 GMT
+      - Wed, 22 Mar 2023 17:39:40 GMT
       Etag:
-      - W/"d8f628a7a07afeec519913b235f66450"
+      - W/"3ecad0a8113b219de3b0477b0c4e4f74"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1506,9 +1506,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "740"
+      - "871"
       X-Request-Id:
-      - 40af5ef6-9c9f-4937-a508-89482b84e253
+      - 8f5fa6d3-e45f-4142-b221-6e26a424cf36
     status: 200 OK
     code: 200
     duration: ""
@@ -1520,12 +1520,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eWbnp4Tigp1qhtf3
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_nzR0aU6NhnfFxsNE
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_eWbnp4Tigp1qhtf3","virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff"},"name":"Public
-      Network on tf-acc-test-update-nopeoejp19qq-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:d8:db:22:ec:98","state":"attached","ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_nzR0aU6NhnfFxsNE","virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff"},"name":"Public
+      Network on tf-acc-test-update-9fvvnwndieu1-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:2a:ff:e2:18:8a","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1538,9 +1538,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:59 GMT
+      - Wed, 22 Mar 2023 17:39:40 GMT
       Etag:
-      - W/"75c3174e0d1b7817074e48137d046aa0"
+      - W/"7a89270c80a03d6cd9dca90e137e33c4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1548,9 +1548,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "739"
+      - "870"
       X-Request-Id:
-      - f9ae9475-1cc4-4bd2-a6f4-311c2b7be7dd
+      - 2957b267-ce6a-408e-a02f-7a060092e77a
     status: 200 OK
     code: 200
     duration: ""
@@ -1562,18 +1562,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff","hostname":"tf-acc-test-update-nopeoejp19qq-host-diff","fqdn":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1582,13 +1582,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2487"
+      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:59 GMT
+      - Wed, 22 Mar 2023 17:39:40 GMT
       Etag:
-      - W/"1efe4312dda44ad19158c9ff7acb1d3c"
+      - W/"65026bd2febb7f18088e1f41539ef5b2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1596,9 +1596,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "737"
+      - "869"
       X-Request-Id:
-      - ddf67824-bd19-4926-a69b-d930db036293
+      - 4da32b05-d9c2-435f-bdfd-e5e598f8464d
     status: 200 OK
     code: 200
     duration: ""
@@ -1610,10 +1610,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: POST
   response:
-    body: '{"task":{"id":"task_RBTQ919XAkfGvSFw","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_IOa3s3wYmyqWzaG1","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1626,9 +1626,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:59 GMT
+      - Wed, 22 Mar 2023 17:39:40 GMT
       Etag:
-      - W/"c4a148e846916276a4aa1488aad18e26"
+      - W/"4c5154a4e957110bb6d7edf7c9a84487"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1636,9 +1636,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "736"
+      - "868"
       X-Request-Id:
-      - e5c1aef2-7d32-47b5-a6ea-47446a9986d7
+      - 658a90ee-3ae4-4bbd-ae29-12d35dfae447
     status: 200 OK
     code: 200
     duration: ""
@@ -1650,10 +1650,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_RBTQ919XAkfGvSFw
+    url: https://api.katapult.io/core/v1/tasks/task_IOa3s3wYmyqWzaG1
     method: GET
   response:
-    body: '{"task":{"id":"task_RBTQ919XAkfGvSFw","name":"Stop virtual machine","status":"running","created_at":1676031299,"started_at":1676031300,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_IOa3s3wYmyqWzaG1","name":"Stop virtual machine","status":"running","created_at":1679506780,"started_at":1679506781,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1666,9 +1666,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:00 GMT
+      - Wed, 22 Mar 2023 17:39:41 GMT
       Etag:
-      - W/"2e1ee5688c2417e7db29a5d76d786053"
+      - W/"259f1ce19d99ca6700e547d7beb21a09"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1676,9 +1676,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "863"
       X-Request-Id:
-      - 13c0818e-b37c-4871-a116-9040d9ab8fba
+      - cbf2ac0e-99e6-4380-9308-0038ca704820
     status: 200 OK
     code: 200
     duration: ""
@@ -1690,10 +1690,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_RBTQ919XAkfGvSFw
+    url: https://api.katapult.io/core/v1/tasks/task_IOa3s3wYmyqWzaG1
     method: GET
   response:
-    body: '{"task":{"id":"task_RBTQ919XAkfGvSFw","name":"Stop virtual machine","status":"completed","created_at":1676031299,"started_at":1676031300,"finished_at":1676031303,"progress":100}}'
+    body: '{"task":{"id":"task_IOa3s3wYmyqWzaG1","name":"Stop virtual machine","status":"completed","created_at":1679506780,"started_at":1679506781,"finished_at":1679506784,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1706,9 +1706,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:05 GMT
+      - Wed, 22 Mar 2023 17:39:46 GMT
       Etag:
-      - W/"40f22fc7d67918d60b623bbaf1aa40e4"
+      - W/"c0f84aab543d00fdfb8336df8bb8f0c9"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1716,9 +1716,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "852"
       X-Request-Id:
-      - be4b0242-7114-4ef6-9aea-9a2dacc5d479
+      - 81a923e6-5974-41a4-9b36-d6d643ca58ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1730,18 +1730,18 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_Wpx4AJrHQuOEGBF3","keep_until":1676204105,"object_id":"vm_XLuhPjHeQ5Nu9kzQ","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_XLuhPjHeQ5Nu9kzQ","name":"tf-acc-test-update-nopeoejp19qq-diff","hostname":"tf-acc-test-update-nopeoejp19qq-host-diff","fqdn":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1676031272,"initial_root_password":"giWEXXMINP1C7Euk","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_YGiBsRshyU6NXyOL","keep_until":1679679586,"object_id":"vm_EBYmJgWCwJwiJLs7","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_EBYmJgWCwJwiJLs7","name":"tf-acc-test-update-9fvvnwndieu1-diff","hostname":"tf-acc-test-update-9fvvnwndieu1-host-diff","fqdn":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1679506753,"initial_root_password":"1asPkzS1AG1KWXOG","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_3Mc6zF0VP1zK9Z7n","address":"185.199.222.21","reverse_dns":"tf-acc-test-update-nopeoejp19qq-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.21/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-update-9fvvnwndieu1-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_XLuhPjHeQ5Nu9kzQ","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_EBYmJgWCwJwiJLs7","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1750,13 +1750,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2622"
+      - "2663"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:05 GMT
+      - Wed, 22 Mar 2023 17:39:46 GMT
       Etag:
-      - W/"0aaf2f395418667d846f27a3a84747c4"
+      - W/"c8c34d230ed53adf8c4f10a35f473fb6"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1764,9 +1764,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "851"
       X-Request-Id:
-      - 4c956f85-7e81-4fbb-a670-1a5d9a694ee8
+      - b705497b-fe9f-4be1-917c-8a27958dc911
     status: 200 OK
     code: 200
     duration: ""
@@ -1778,7 +1778,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_3Mc6zF0VP1zK9Z7n
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: POST
   response:
     body: '{}'
@@ -1794,7 +1794,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:06 GMT
+      - Wed, 22 Mar 2023 17:39:47 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1804,9 +1804,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "952"
+      - "850"
       X-Request-Id:
-      - 7acf9e50-398e-4ca8-ad99-2871a841d2fd
+      - e2b9f99f-6ebd-4a12-a535-82c0a238a1cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1818,10 +1818,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_Wpx4AJrHQuOEGBF3
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YGiBsRshyU6NXyOL
     method: DELETE
   response:
-    body: '{"task":{"id":"task_1mMuT42Y4OuOWDPj","name":"Purge items from trash","status":"pending","created_at":1676031306,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_aucoqVqn7WuG2BEF","name":"Purge items from trash","status":"pending","created_at":1679506787,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1834,9 +1834,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:06 GMT
+      - Wed, 22 Mar 2023 17:39:47 GMT
       Etag:
-      - W/"eab6c23f559703a0a86403c3edd748b1"
+      - W/"07ed120f8f7d7543f5372f26283b71d0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1844,9 +1844,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "849"
       X-Request-Id:
-      - 1533ae22-a901-4d18-9382-5122917c5c8b
+      - fade57d8-7627-43cd-a7f7-dbb1def6788c
     status: 200 OK
     code: 200
     duration: ""
@@ -1858,10 +1858,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_1mMuT42Y4OuOWDPj
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YGiBsRshyU6NXyOL
     method: GET
   response:
-    body: '{"task":{"id":"task_1mMuT42Y4OuOWDPj","name":"Purge items from trash","status":"running","created_at":1676031306,"started_at":1676031307,"finished_at":null,"progress":5}}'
+    body: '{"trash_object":{"id":"trsh_YGiBsRshyU6NXyOL","keep_until":1679679586,"object_id":"vm_EBYmJgWCwJwiJLs7","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1870,13 +1870,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:07 GMT
+      - Wed, 22 Mar 2023 17:39:48 GMT
       Etag:
-      - W/"e14021c724050adeb5cc6bff305aeba3"
+      - W/"f10c0b7bb100e1af499b1cb155c43e0d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1884,9 +1884,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "846"
       X-Request-Id:
-      - 26d6a45d-fc40-442d-9f6e-5b53034d93fb
+      - ab4efc2b-2d7e-46f4-bf9c-027ca6e1531c
     status: 200 OK
     code: 200
     duration: ""
@@ -1898,10 +1898,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_1mMuT42Y4OuOWDPj
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YGiBsRshyU6NXyOL
     method: GET
   response:
-    body: '{"task":{"id":"task_1mMuT42Y4OuOWDPj","name":"Purge items from trash","status":"completed","created_at":1676031306,"started_at":1676031307,"finished_at":1676031309,"progress":100}}'
+    body: '{"trash_object":{"id":"trsh_YGiBsRshyU6NXyOL","keep_until":1679679586,"object_id":"vm_EBYmJgWCwJwiJLs7","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1910,13 +1910,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "180"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:12 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"26b2d80a8934e255fe61b28399bf7a8c"
+      - W/"f10c0b7bb100e1af499b1cb155c43e0d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1924,9 +1924,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "901"
+      - "833"
       X-Request-Id:
-      - 57d6289e-d5d8-402b-8a87-e66087517a17
+      - 76e71338-4d11-410d-80dc-2d0bfec9a19a
     status: 200 OK
     code: 200
     duration: ""
@@ -1938,7 +1938,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3Mc6zF0VP1zK9Z7n
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YGiBsRshyU6NXyOL
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:03 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - d25a0ba9-2012-4f73-b063-70b9d2563728
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: DELETE
   response:
     body: '{}'
@@ -1954,7 +1995,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:12 GMT
+      - Wed, 22 Mar 2023 17:40:03 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1964,9 +2005,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "900"
+      - "996"
       X-Request-Id:
-      - 5e1421b7-9dfd-4604-ab20-9c615106e287
+      - b001d6f4-3c05-4134-b581-e7207d895b25
     status: 200 OK
     code: 200
     duration: ""
@@ -1978,7 +2019,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_XLuhPjHeQ5Nu9kzQ
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_EBYmJgWCwJwiJLs7
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -1995,7 +2036,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:12 GMT
+      - Wed, 22 Mar 2023 17:40:03 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2005,9 +2046,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "899"
+      - "995"
       X-Request-Id:
-      - 4107a1a8-a2ed-49b5-bf4d-62181e8e0359
+      - 64a18b13-077a-407b-9513-f0fb2f27a879
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2019,7 +2060,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3Mc6zF0VP1zK9Z7n
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2036,7 +2077,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:12 GMT
+      - Wed, 22 Mar 2023 17:40:03 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2046,9 +2087,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "898"
+      - "994"
       X-Request-Id:
-      - 263acf7c-51dc-4b5a-8d34-d65a4453fd04
+      - fa195447-3d26-46d6-98f3-b5fea2f0624f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_group.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_group.cassette.rand_id
@@ -1,1 +1,1 @@
-7kdow0kqjwsz
+qm6n0dgp9ab8

--- a/internal/provider/testdata/VirtualMachine_update_group.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_group.cassette.rand_id
@@ -1,1 +1,1 @@
-qm6n0dgp9ab8
+mhs2p69yvzor

--- a/internal/provider/testdata/VirtualMachine_update_group.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_group.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:24 GMT
+      - Wed, 22 Mar 2023 17:39:42 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,15 +35,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "862"
       X-Request-Id:
-      - c8d4dcac-547f-459e-afb3-5535014215fb
+      - 98f5d23c-252f-4cbe-9f71-d863d618adbf
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -68,9 +68,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:24 GMT
+      - Wed, 22 Mar 2023 17:39:42 GMT
       Etag:
-      - W/"5525da457bef9be75c9cb8d888480ea7"
+      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -78,9 +78,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "861"
       X-Request-Id:
-      - fc8b78b3-44f7-460b-b29a-6c97eb1b4518
+      - dab5908e-00da-4db9-8dfa-3246b123aac3
     status: 200 OK
     code: 200
     duration: ""
@@ -92,10 +92,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_OobE39xSZMFdgRfF
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -108,9 +108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:24 GMT
+      - Wed, 22 Mar 2023 17:39:42 GMT
       Etag:
-      - W/"5525da457bef9be75c9cb8d888480ea7"
+      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "859"
       X-Request-Id:
-      - 1f51b233-1822-4b6d-ae4a-d799431b6fc1
+      - 95660856-1ea7-441c-87c6-adc69991372e
     status: 200 OK
     code: 200
     duration: ""
@@ -138,7 +138,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"185-199-221-200.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -153,9 +153,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:26 GMT
+      - Wed, 22 Mar 2023 17:39:46 GMT
       Etag:
-      - W/"cfecafe8267c6f5d7cccffa64b581ac0"
+      - W/"3a687f736929f55327502ce877b5ad62"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -163,9 +163,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "860"
       X-Request-Id:
-      - fc3c7b66-a172-4951-b1d4-994439d69bb0
+      - d6a4f048-2377-4321-b1c9-80217b5bcf6b
     status: 200 OK
     code: 200
     duration: ""
@@ -177,10 +177,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"185-199-221-200.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -195,9 +195,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:26 GMT
+      - Wed, 22 Mar 2023 17:39:46 GMT
       Etag:
-      - W/"a6f4e0e9fa715c3de379e0d2ba0839ba"
+      - W/"b5edb1f478fa37e762d80d507cfdce5d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -205,9 +205,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "855"
       X-Request-Id:
-      - 7c1b815c-1aa9-48f4-8f27-51f48b0d3614
+      - f2eb9990-09e5-494b-8a34-94838aef991d
     status: 200 OK
     code: 200
     duration: ""
@@ -219,10 +219,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"185-199-221-200.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -237,9 +237,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:26 GMT
+      - Wed, 22 Mar 2023 17:39:46 GMT
       Etag:
-      - W/"a6f4e0e9fa715c3de379e0d2ba0839ba"
+      - W/"b5edb1f478fa37e762d80d507cfdce5d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -247,15 +247,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "854"
       X-Request-Id:
-      - e6fd4db6-9b7f-4781-a161-8da398ba5297
+      - 2fc0119d-4b6a-40bc-9945-fe39e1af9ef9
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_ugW5LZiANk0pPODW</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-clever-thankful-rickshaw</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_ThTjuc3gzLUgUUVg</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-icy-whining-tulip</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -267,7 +267,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Nn1QpEEdTXJyGdfH","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_Rkb3gWpKdDXWNVhh","state":"pending"},"virtual_machine_build":{"id":"vmbuild_Rkb3gWpKdDXWNVhh","state":"pending"},"hostname":"tf-acc-test-clever-thankful-rickshaw"}'
+    body: '{"task":{"id":"task_UaGHXevk74ps2ioQ","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","state":"pending"},"virtual_machine_build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","state":"pending"},"hostname":"tf-acc-test-icy-whining-tulip"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -276,13 +276,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "275"
+      - "268"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:26 GMT
+      - Wed, 22 Mar 2023 17:39:46 GMT
       Etag:
-      - W/"493f23494528fc7962d8b7d33623a037"
+      - W/"77869540499d5a1769a7cfc20d8fe239"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -290,9 +290,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "853"
       X-Request-Id:
-      - 76202c8e-8e2b-4ed3-9f4f-d392649254cd
+      - 1d6e914a-09b3-4c1f-a515-4eb71782f74a
     status: 201 Created
     code: 201
     duration: ""
@@ -304,17 +304,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Rkb3gWpKdDXWNVhh
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6CjpxXg7SXxSg1KD
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_Rkb3gWpKdDXWNVhh","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.200\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clever-thankful-rickshaw\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-whining-tulip\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1678292126}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679506786}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -323,13 +323,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1605"
+      - "1380"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:28 GMT
+      - Wed, 22 Mar 2023 17:39:48 GMT
       Etag:
-      - W/"ef6ed8bb0b2565eeb08b4a096edae3a7"
+      - W/"642ad74a44eab65c52c09069a758d8cf"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -337,9 +337,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "982"
+      - "847"
       X-Request-Id:
-      - 7662c05e-b18e-49e5-9822-903ccc958770
+      - da1e44aa-5b6f-42bb-8f2d-aa512c38f762
     status: 200 OK
     code: 200
     duration: ""
@@ -351,17 +351,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Rkb3gWpKdDXWNVhh
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6CjpxXg7SXxSg1KD
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_Rkb3gWpKdDXWNVhh","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.200\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clever-thankful-rickshaw\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-whining-tulip\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1678292126}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506786}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -370,13 +370,627 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1605"
+      - "1577"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:33 GMT
+      - Wed, 22 Mar 2023 17:39:53 GMT
       Etag:
-      - W/"ef6ed8bb0b2565eeb08b4a096edae3a7"
+      - W/"915f1c99407e563cea6f46cbbd7097e4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "840"
+      X-Request-Id:
+      - 2af2acbc-12a3-4983-8c31-e14e16491fd5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6CjpxXg7SXxSg1KD
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-whining-tulip\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679506786}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "1577"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:03 GMT
+      Etag:
+      - W/"f8ba8e7a9c40e5fddbd1d7b05e73c46f"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - a80a258c-1f3a-4c51-b830-1843fd59b933
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2192"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 9bfda331-f990-47bc-8acd-83f566033ef9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2192"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - a5ee3aad-0c2e-4048-96b8-63d97b44fcec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "357"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 5d54deb1-16c8-4b04-ad5e-6cf737a9a276
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "487"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"41daece6c11e4f3aec9ddede49c67443"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - ed389475-a367-4ec3-8792-4b9769b0a5d9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2192"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 01dfb951-8e62-4ad1-b22e-93295bd4a243
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "145"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 17deca9a-7a30-4815-8cc0-6410d9277014
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "724"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"74764379323d158321fb86d356b54e85"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 430aa9de-4435-4529-b445-3527b7bbdb76
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2192"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 70e6da4a-1293-4e04-901c-7792a26bdd8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "357"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 5db25a74-19b3-468c-96cb-b45bda99cb06
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "487"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:05 GMT
+      Etag:
+      - W/"41daece6c11e4f3aec9ddede49c67443"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 6c556aa0-0c10-444b-9038-cba5e237e0d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "145"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:06 GMT
+      Etag:
+      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 06c6bd99-10b4-41d6-8200-c0a40ede94b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "724"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:06 GMT
+      Etag:
+      - W/"74764379323d158321fb86d356b54e85"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 001674bc-35b2-4d9c-9e6a-6a9de115bf80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2192"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:06 GMT
+      Etag:
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -386,7 +1000,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "981"
       X-Request-Id:
-      - ab611f78-f174-4c8b-9ea2-cb7cd7b090a9
+      - baae1ad6-04fa-461b-a519-d0f3a6f00724
     status: 200 OK
     code: 200
     duration: ""
@@ -398,17 +1012,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Rkb3gWpKdDXWNVhh
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_Rkb3gWpKdDXWNVhh","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.200\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-clever-thankful-rickshaw\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1678292126}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -417,13 +1026,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1605"
+      - "357"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:43 GMT
+      - Wed, 22 Mar 2023 17:40:06 GMT
       Etag:
-      - W/"d18983bf6559af8fc3cfee10c983ba17"
+      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -433,7 +1042,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "980"
       X-Request-Id:
-      - d9c6d526-7c33-4263-9fdf-4923bfb33275
+      - fa748e6b-cc66-45ac-9af3-f29dd6a80602
     status: 200 OK
     code: 200
     duration: ""
@@ -445,17 +1054,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -464,13 +1068,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:06 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"41daece6c11e4f3aec9ddede49c67443"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -480,29 +1084,32 @@ interactions:
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - ce8627a6-f58d-4b9e-bc17-593f498d1c9a
+      - 045d46a2-ec1a-4dfd-9c58-2fbb69abea8c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: |
+      {"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5"},"properties":{"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS"}}}
     form: {}
     headers:
       Accept:
       - application/json
+      Content-Type:
+      - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
-    method: GET
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -511,13 +1118,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "2307"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:07 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"759e3c7d54fae9cb07f4713174a8df69"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -527,7 +1134,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "978"
       X-Request-Id:
-      - ab23f6ab-4f4d-48a9-b9ff-aec818fa433f
+      - a0779e51-be88-49da-8792-7a1470c511fd
     status: 200 OK
     code: 200
     duration: ""
@@ -539,12 +1146,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_adJo4gzVjYikHJvc","name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -553,13 +1165,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "364"
+      - "2307"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:07 GMT
       Etag:
-      - W/"e6e38e3a44cea3561f6d50c72ae513f1"
+      - W/"759e3c7d54fae9cb07f4713174a8df69"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -569,7 +1181,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "977"
       X-Request-Id:
-      - 1b82fdc6-acba-478e-a2a6-db33903ea17b
+      - d7ab5f40-df78-48e8-80e5-38cf69611b9a
     status: 200 OK
     code: 200
     duration: ""
@@ -581,12 +1193,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_adJo4gzVjYikHJvc
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_adJo4gzVjYikHJvc","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"},"name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:79:f9:53:d5:44","state":"attached","ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -595,13 +1207,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "501"
+      - "357"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:07 GMT
       Etag:
-      - W/"12ed36d52fc1d355198b172cab066dbc"
+      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -611,7 +1223,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - 62042674-9216-432f-9459-d0680bd69fa3
+      - 7b9df861-12d6-4388-8dfc-2a7486909839
     status: 200 OK
     code: 200
     duration: ""
@@ -622,18 +1234,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -642,13 +1249,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:07 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"41daece6c11e4f3aec9ddede49c67443"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -658,7 +1265,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "975"
       X-Request-Id:
-      - 3b62e6b3-69ea-4687-9ba9-52d2de41664a
+      - 040aafd7-301f-4d78-bbe3-5e71b39e4ad3
     status: 200 OK
     code: 200
     duration: ""
@@ -669,53 +1276,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_OobE39xSZMFdgRfF
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
-      Etag:
-      - W/"5525da457bef9be75c9cb8d888480ea7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "973"
-      X-Request-Id:
-      - 69731b0f-3c80-4a6f-9f2e-9eb0254a832d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -724,13 +1296,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "738"
+      - "2307"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:07 GMT
       Etag:
-      - W/"7b95ffa0f10a4b5a87cac79cc4fb40d7"
+      - W/"759e3c7d54fae9cb07f4713174a8df69"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -740,7 +1312,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "974"
       X-Request-Id:
-      - 5d1f9202-c35a-4074-a97a-c345976feaed
+      - 6dac1085-dca6-4244-ae7d-4b5a83922943
     status: 200 OK
     code: 200
     duration: ""
@@ -752,17 +1324,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -771,13 +1336,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "145"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:08 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -785,9 +1350,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "972"
+      - "973"
       X-Request-Id:
-      - b08147b5-4e23-4182-9e15-dd085153fd44
+      - abe3a055-6bc4-48bc-b52f-e7e6adb4dac6
     status: 200 OK
     code: 200
     duration: ""
@@ -799,12 +1364,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_adJo4gzVjYikHJvc","name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}]}]}'
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -813,13 +1378,60 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "364"
+      - "724"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:08 GMT
       Etag:
-      - W/"e6e38e3a44cea3561f6d50c72ae513f1"
+      - W/"74764379323d158321fb86d356b54e85"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 1f645c2f-125c-4aa3-86b5-1cd45cf35fc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2307"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:40:08 GMT
+      Etag:
+      - W/"759e3c7d54fae9cb07f4713174a8df69"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -829,7 +1441,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "971"
       X-Request-Id:
-      - 6fac1e83-5a08-4487-b111-21605ac35dc1
+      - 0dc1a794-ba17-45e1-824c-7276ac927162
     status: 200 OK
     code: 200
     duration: ""
@@ -841,12 +1453,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_adJo4gzVjYikHJvc
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_adJo4gzVjYikHJvc","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"},"name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:79:f9:53:d5:44","state":"attached","ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -855,13 +1467,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "501"
+      - "357"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:08 GMT
       Etag:
-      - W/"12ed36d52fc1d355198b172cab066dbc"
+      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -871,7 +1483,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "970"
       X-Request-Id:
-      - f8bfd228-ae21-4db3-b2ea-28af49cdbd40
+      - 6481fcbd-32d2-49b1-806b-0ae5547966eb
     status: 200 OK
     code: 200
     duration: ""
@@ -883,10 +1495,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_OobE39xSZMFdgRfF
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -895,13 +1509,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "145"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:08 GMT
       Etag:
-      - W/"5525da457bef9be75c9cb8d888480ea7"
+      - W/"41daece6c11e4f3aec9ddede49c67443"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -911,7 +1525,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "969"
       X-Request-Id:
-      - 63906826-9160-48a0-9d52-93098309350a
+      - d7cd6d84-3fb8-48a2-a153-a60ac56716e9
     status: 200 OK
     code: 200
     duration: ""
@@ -923,12 +1537,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"}}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -937,13 +1549,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "738"
+      - "145"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"7b95ffa0f10a4b5a87cac79cc4fb40d7"
+      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -953,7 +1565,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "968"
       X-Request-Id:
-      - a8f60a2c-49cd-45f4-b14f-1050512cab55
+      - 7fbc01c0-f440-4163-8120-d028fdd89d6a
     status: 200 OK
     code: 200
     duration: ""
@@ -965,17 +1577,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -984,13 +1591,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "724"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"74764379323d158321fb86d356b54e85"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -998,9 +1605,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "968"
       X-Request-Id:
-      - c9b365f6-91c1-4194-946c-3e570be13b7e
+      - 6989155e-0b70-4945-99db-560f102a7c0d
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,12 +1619,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_adJo4gzVjYikHJvc","name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1026,13 +1638,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "364"
+      - "2307"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"e6e38e3a44cea3561f6d50c72ae513f1"
+      - W/"759e3c7d54fae9cb07f4713174a8df69"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1042,7 +1654,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "966"
       X-Request-Id:
-      - 58014646-f10b-4e5d-9d7d-5fd3a4aadc0a
+      - cb41fb30-9098-4e8b-b417-7f9a602a8ecf
     status: 200 OK
     code: 200
     duration: ""
@@ -1054,12 +1666,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_adJo4gzVjYikHJvc
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_adJo4gzVjYikHJvc","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"},"name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:79:f9:53:d5:44","state":"attached","ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1068,13 +1680,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "501"
+      - "357"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:46 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"12ed36d52fc1d355198b172cab066dbc"
+      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1084,32 +1696,24 @@ interactions:
       X-Ratelimit-Remaining:
       - "965"
       X-Request-Id:
-      - 72083f0c-0f28-4e7c-a639-8e5bf1f5fa3a
+      - 2609d1ce-4cf4-4ec1-8157-4cd40860f120
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: |
-      {"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz"},"properties":{"group":{"id":"vmgrp_OobE39xSZMFdgRfF"}}}
+    body: ""
     form: {}
     headers:
       Accept:
       - application/json
-      Content-Type:
-      - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
+    method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1118,13 +1722,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2294"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:47 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"581dc7f60f5da02153c727b32ec4f028"
+      - W/"41daece6c11e4f3aec9ddede49c67443"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1134,7 +1738,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "964"
       X-Request-Id:
-      - 30ec8472-b0e0-4103-a380-36f8a81c2a1c
+      - 04f1bfff-cb44-4dd2-81c8-c09fe50905ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1146,17 +1750,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
-    method: GET
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_fEqbVrs5Wn4sMUwS
+    method: DELETE
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1165,13 +1762,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2294"
+      - "145"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:47 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"581dc7f60f5da02153c727b32ec4f028"
+      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1181,610 +1778,13 @@ interactions:
       X-Ratelimit-Remaining:
       - "963"
       X-Request-Id:
-      - da290d63-0805-4a75-83f9-d12c65651465
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_adJo4gzVjYikHJvc","name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:47 GMT
-      Etag:
-      - W/"e6e38e3a44cea3561f6d50c72ae513f1"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "962"
-      X-Request-Id:
-      - d00c17f2-8e90-4825-972d-d210a19c1bad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_adJo4gzVjYikHJvc
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_adJo4gzVjYikHJvc","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"},"name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:79:f9:53:d5:44","state":"attached","ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "501"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:47 GMT
-      Etag:
-      - W/"12ed36d52fc1d355198b172cab066dbc"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "961"
-      X-Request-Id:
-      - 5266ed24-1907-45e1-8bf1-8d818efebbdf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2294"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"581dc7f60f5da02153c727b32ec4f028"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "960"
-      X-Request-Id:
-      - 82506c43-b3aa-4516-8c64-c718951b3971
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_OobE39xSZMFdgRfF
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"5525da457bef9be75c9cb8d888480ea7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "959"
-      X-Request-Id:
-      - 9e980ae9-4852-41ef-b681-4c62e74d04a5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "738"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"7b95ffa0f10a4b5a87cac79cc4fb40d7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "958"
-      X-Request-Id:
-      - 15160555-af06-420f-8a96-a52b8e896fb4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2294"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"581dc7f60f5da02153c727b32ec4f028"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "957"
-      X-Request-Id:
-      - a2966dbb-ad63-4297-adc8-cf78cd83b1d4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_adJo4gzVjYikHJvc","name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"e6e38e3a44cea3561f6d50c72ae513f1"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "956"
-      X-Request-Id:
-      - 19b26619-1f3a-4695-a179-0be53fe42258
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_adJo4gzVjYikHJvc
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_adJo4gzVjYikHJvc","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"},"name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:79:f9:53:d5:44","state":"attached","ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "501"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"12ed36d52fc1d355198b172cab066dbc"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "955"
-      X-Request-Id:
-      - 49daf8e4-b38f-48f9-8b8c-1ed4f6702ef3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_OobE39xSZMFdgRfF
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"5525da457bef9be75c9cb8d888480ea7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "953"
-      X-Request-Id:
-      - 0b20e19c-1a94-4608-9875-35de5ea3b2f8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "738"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"7b95ffa0f10a4b5a87cac79cc4fb40d7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "954"
-      X-Request-Id:
-      - d5e61ae7-2cab-4c2c-abd2-1797dc51c316
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2294"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"581dc7f60f5da02153c727b32ec4f028"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - e59ec433-0d48-4b22-bd77-3c61572dda74
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_adJo4gzVjYikHJvc","name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"e6e38e3a44cea3561f6d50c72ae513f1"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "951"
-      X-Request-Id:
-      - 1fca6cff-482b-4403-9ff3-6c5c5a7e2264
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_adJo4gzVjYikHJvc
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_adJo4gzVjYikHJvc","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"},"name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:79:f9:53:d5:44","state":"attached","ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "501"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:48 GMT
-      Etag:
-      - W/"12ed36d52fc1d355198b172cab066dbc"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - a433eb4f-fbe2-45bc-99ca-f0f08848f7b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_OobE39xSZMFdgRfF
-    method: DELETE
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_OobE39xSZMFdgRfF","name":"tf-acc-test-update-group-7kdow0kqjwsz","segregate":true,"created_at":1678292124}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
-      Etag:
-      - W/"5525da457bef9be75c9cb8d888480ea7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "949"
-      X-Request-Id:
-      - 4e6e4526-2837-45ef-8292-29e94eda92b4
+      - 1d8f6de8-c095-4554-962b-b907bc7afc5e
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz"},"properties":{"group":null}}
+      {"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5"},"properties":{"group":null}}
     form: {}
     headers:
       Accept:
@@ -1796,14 +1796,14 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1812,13 +1812,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1826,9 +1826,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "961"
       X-Request-Id:
-      - bce4b9c6-6447-427f-928d-aca04a6077eb
+      - e7343d95-ff7a-40c8-a6ce-216caaec5df9
     status: 200 OK
     code: 200
     duration: ""
@@ -1840,17 +1840,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1859,13 +1859,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1873,9 +1873,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "947"
+      - "960"
       X-Request-Id:
-      - 140b30ad-c06a-48c1-a22e-c7c9ccfa46ec
+      - 81b3032a-a991-4ccf-b909-5a0e6fc2a327
     status: 200 OK
     code: 200
     duration: ""
@@ -1887,12 +1887,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_adJo4gzVjYikHJvc","name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1901,13 +1901,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "364"
+      - "357"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:09 GMT
       Etag:
-      - W/"e6e38e3a44cea3561f6d50c72ae513f1"
+      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1915,9 +1915,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "946"
+      - "959"
       X-Request-Id:
-      - 24f4c8c3-9eb3-4c1d-acd1-2377e297279d
+      - 0056a14f-bbdd-4a98-9492-b70cfb2a172e
     status: 200 OK
     code: 200
     duration: ""
@@ -1929,12 +1929,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_adJo4gzVjYikHJvc
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_adJo4gzVjYikHJvc","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"},"name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:79:f9:53:d5:44","state":"attached","ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1943,13 +1943,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "501"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:10 GMT
       Etag:
-      - W/"12ed36d52fc1d355198b172cab066dbc"
+      - W/"41daece6c11e4f3aec9ddede49c67443"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1957,9 +1957,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "945"
+      - "958"
       X-Request-Id:
-      - 74c9788b-cdd9-4ed2-977f-8603e7ab0793
+      - d618ffa7-6abb-4943-933b-cdd685f33a26
     status: 200 OK
     code: 200
     duration: ""
@@ -1971,17 +1971,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1990,13 +1990,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:10 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2004,9 +2004,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "944"
+      - "957"
       X-Request-Id:
-      - ef1c678f-c2a7-499b-9056-16bb006e8e0f
+      - 3c8be4dc-5f79-4bed-a53a-025d5b0d6d8d
     status: 200 OK
     code: 200
     duration: ""
@@ -2018,12 +2018,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2032,13 +2032,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "738"
+      - "724"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:10 GMT
       Etag:
-      - W/"7b95ffa0f10a4b5a87cac79cc4fb40d7"
+      - W/"74764379323d158321fb86d356b54e85"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2046,9 +2046,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "943"
+      - "956"
       X-Request-Id:
-      - 1677f2e1-bf2b-4890-9fdd-91cd360d1e33
+      - e13dac7d-ae50-48ea-957d-8587c01675d5
     status: 200 OK
     code: 200
     duration: ""
@@ -2060,17 +2060,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2079,13 +2079,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:10 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2093,9 +2093,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "942"
+      - "955"
       X-Request-Id:
-      - 70ac475f-07c0-44f9-bf86-8e1fe780afcf
+      - 55664ea3-8b20-479e-bcbe-ea0dca0e6c6d
     status: 200 OK
     code: 200
     duration: ""
@@ -2107,12 +2107,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_adJo4gzVjYikHJvc","name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2121,13 +2121,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "364"
+      - "357"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:10 GMT
       Etag:
-      - W/"e6e38e3a44cea3561f6d50c72ae513f1"
+      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2135,9 +2135,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "954"
       X-Request-Id:
-      - 09cd92d0-2be4-4537-8f42-636ab1a7ea66
+      - ee17f808-4ada-4f94-915b-80551bb86410
     status: 200 OK
     code: 200
     duration: ""
@@ -2149,12 +2149,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_adJo4gzVjYikHJvc
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_adJo4gzVjYikHJvc","virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw"},"name":"Public
-      Network on tf-acc-test-clever-thankful-rickshaw","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:79:f9:53:d5:44","state":"attached","ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
+      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2163,13 +2163,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "501"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:10 GMT
       Etag:
-      - W/"12ed36d52fc1d355198b172cab066dbc"
+      - W/"41daece6c11e4f3aec9ddede49c67443"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2177,9 +2177,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "940"
+      - "953"
       X-Request-Id:
-      - ef480dd9-a591-4556-b7b2-b1d49fe488da
+      - 02f7fc23-4d0e-449a-aec4-0d4f708bc5fc
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,17 +2191,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2210,13 +2210,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2179"
+      - "2192"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:10 GMT
       Etag:
-      - W/"870bb597c2b4f7548f8b85fc5d8ce4b7"
+      - W/"0daa32790d63cc3b53f93f00ed64be07"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2224,9 +2224,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "939"
+      - "952"
       X-Request-Id:
-      - 5bfc4c2a-8873-4fa4-9160-a023528f1ae8
+      - 7e03bc4a-ce50-461a-bdf8-367d80a4b17d
     status: 200 OK
     code: 200
     duration: ""
@@ -2238,10 +2238,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: POST
   response:
-    body: '{"task":{"id":"task_IpfJrd8Q2CHmWSHU","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2254,9 +2254,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:49 GMT
+      - Wed, 22 Mar 2023 17:40:10 GMT
       Etag:
-      - W/"49c2bf245d248092ea6f8237defce285"
+      - W/"8d56e60edafd053a1141a05d23a9f81f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2264,9 +2264,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "938"
+      - "951"
       X-Request-Id:
-      - 0996ebb4-d441-47b0-ae66-c481f56628de
+      - 9b2cb62a-1f86-4140-b5d8-c35697260d01
     status: 200 OK
     code: 200
     duration: ""
@@ -2278,10 +2278,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IpfJrd8Q2CHmWSHU
+    url: https://api.katapult.io/core/v1/tasks/task_n0EbKTVCsGJTOYbN
     method: GET
   response:
-    body: '{"task":{"id":"task_IpfJrd8Q2CHmWSHU","name":"Stop virtual machine","status":"pending","created_at":1678292149,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"pending","created_at":1679506810,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2294,9 +2294,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:50 GMT
+      - Wed, 22 Mar 2023 17:40:11 GMT
       Etag:
-      - W/"c8a22a82fa8e1a23fc0f38dbf584818c"
+      - W/"7f3e6f09fc900dd44cba6a5c042f1a3c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2304,9 +2304,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "937"
+      - "950"
       X-Request-Id:
-      - 85ebe25b-df7e-4bf2-9a60-8df9a6c60183
+      - a5f311a3-7cfa-4fb3-b236-2daa584f4260
     status: 200 OK
     code: 200
     duration: ""
@@ -2318,10 +2318,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IpfJrd8Q2CHmWSHU
+    url: https://api.katapult.io/core/v1/tasks/task_n0EbKTVCsGJTOYbN
     method: GET
   response:
-    body: '{"task":{"id":"task_IpfJrd8Q2CHmWSHU","name":"Stop virtual machine","status":"pending","created_at":1678292149,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"pending","created_at":1679506810,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2334,9 +2334,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:15:55 GMT
+      - Wed, 22 Mar 2023 17:40:16 GMT
       Etag:
-      - W/"c8a22a82fa8e1a23fc0f38dbf584818c"
+      - W/"7f3e6f09fc900dd44cba6a5c042f1a3c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2344,9 +2344,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "936"
+      - "942"
       X-Request-Id:
-      - b8c185a5-ea65-4c4a-9e25-6b93c6c32c3e
+      - 9e82f1e7-7bc6-4d51-9627-c85242d19ddd
     status: 200 OK
     code: 200
     duration: ""
@@ -2358,10 +2358,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IpfJrd8Q2CHmWSHU
+    url: https://api.katapult.io/core/v1/tasks/task_n0EbKTVCsGJTOYbN
     method: GET
   response:
-    body: '{"task":{"id":"task_IpfJrd8Q2CHmWSHU","name":"Stop virtual machine","status":"running","created_at":1678292149,"started_at":1678292164,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"running","created_at":1679506810,"started_at":1679506825,"finished_at":null,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2374,9 +2374,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:05 GMT
+      - Wed, 22 Mar 2023 17:40:26 GMT
       Etag:
-      - W/"c4f79b6b280351f10cffddd3bcfe1f8e"
+      - W/"0cd8981d3782ab004b547be6fbd40da0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2384,9 +2384,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "934"
       X-Request-Id:
-      - f1d5646b-e82b-480a-affa-ef2e2d70d6aa
+      - 4402c871-1e4b-426d-aba1-fe3ed9ca1f2c
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,10 +2398,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_IpfJrd8Q2CHmWSHU
+    url: https://api.katapult.io/core/v1/tasks/task_n0EbKTVCsGJTOYbN
     method: GET
   response:
-    body: '{"task":{"id":"task_IpfJrd8Q2CHmWSHU","name":"Stop virtual machine","status":"completed","created_at":1678292149,"started_at":1678292164,"finished_at":1678292166,"progress":100}}'
+    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"completed","created_at":1679506810,"started_at":1679506825,"finished_at":1679506828,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2414,9 +2414,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:15 GMT
+      - Wed, 22 Mar 2023 17:40:36 GMT
       Etag:
-      - W/"37d514fabd4751ce1fc8a64a30b1000f"
+      - W/"e50bf0413218c89c0c28537373edeffc"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2424,9 +2424,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "927"
       X-Request-Id:
-      - 86a7e58c-bccb-4f1d-9b01-be2e7148c210
+      - 393b089e-2ec3-4bd6-bd65-8ca23c34c526
     status: 200 OK
     code: 200
     duration: ""
@@ -2438,17 +2438,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_fexS5Pr0ZmvsOE37","keep_until":1678464975,"object_id":"vm_jKCKt1g56izvgQoz","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_jKCKt1g56izvgQoz","name":"tf-acc-test-clever-thankful-rickshaw","hostname":"tf-acc-test-clever-thankful-rickshaw","fqdn":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","description":null,"created_at":1678292127,"initial_root_password":"nDrCcSEmT5aWmisH","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_dNgeX3yWX9aWxY1p","keep_until":1679679636,"object_id":"vm_f7VMLIKshd9bVZg5","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ugW5LZiANk0pPODW","address":"185.199.221.200","reverse_dns":"tf-acc-test-clever-thankful-rickshaw.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.200/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jKCKt1g56izvgQoz","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2457,13 +2457,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2314"
+      - "2327"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:16 GMT
+      - Wed, 22 Mar 2023 17:40:36 GMT
       Etag:
-      - W/"68ba28d9b56e91ade277f280e3490ed8"
+      - W/"9b5ab835a73f37686635780a37ff3e34"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2471,9 +2471,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "926"
       X-Request-Id:
-      - 28d3ce2a-6f2b-4ece-8933-6b8519f1c8f3
+      - e4d77344-6bcb-4c84-ab0f-f4f6106232f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2485,7 +2485,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: POST
   response:
     body: '{}'
@@ -2501,7 +2501,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:16 GMT
+      - Wed, 22 Mar 2023 17:40:37 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2511,9 +2511,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "925"
       X-Request-Id:
-      - 66270ec5-9c5e-4b3b-a19d-7d4070ed36e9
+      - cde65e5d-945e-4702-8c53-f446c9fe8341
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,10 +2525,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_fexS5Pr0ZmvsOE37
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dNgeX3yWX9aWxY1p
     method: DELETE
   response:
-    body: '{"task":{"id":"task_sZyxEWqH8Zxt9W3w","name":"Purge items from trash","status":"pending","created_at":1678292176,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_uL2GTaWCLjt30YMb","name":"Purge items from trash","status":"pending","created_at":1679506837,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2541,9 +2541,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:16 GMT
+      - Wed, 22 Mar 2023 17:40:37 GMT
       Etag:
-      - W/"cfb7048b9cc161b277116c81b00b17e1"
+      - W/"d0651b871cc853b4002bf2a0358ddb1a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2551,9 +2551,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "924"
       X-Request-Id:
-      - 29f1be74-089e-4b5f-ae8e-194c379637e5
+      - 7fbd7cb4-3424-4322-9859-4623c748a6ea
     status: 200 OK
     code: 200
     duration: ""
@@ -2565,10 +2565,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_sZyxEWqH8Zxt9W3w
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dNgeX3yWX9aWxY1p
     method: GET
   response:
-    body: '{"task":{"id":"task_sZyxEWqH8Zxt9W3w","name":"Purge items from trash","status":"running","created_at":1678292176,"started_at":1678292176,"finished_at":null,"progress":5}}'
+    body: '{"trash_object":{"id":"trsh_dNgeX3yWX9aWxY1p","keep_until":1679679636,"object_id":"vm_f7VMLIKshd9bVZg5","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2577,13 +2577,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:17 GMT
+      - Wed, 22 Mar 2023 17:40:38 GMT
       Etag:
-      - W/"559303b4828c281df8c071436a6fe48e"
+      - W/"a013eb7067932de726f9bfd70ef3e2bc"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2591,9 +2591,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "923"
       X-Request-Id:
-      - a847e755-6b01-495a-a0d7-e7c2a3a1eaac
+      - d25e72b0-e82b-446d-9aee-b67599ef27fb
     status: 200 OK
     code: 200
     duration: ""
@@ -2605,37 +2605,38 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_sZyxEWqH8Zxt9W3w
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dNgeX3yWX9aWxY1p
     method: GET
   response:
-    body: '{"task":{"id":"task_sZyxEWqH8Zxt9W3w","name":"Purge items from trash","status":"completed","created_at":1678292176,"started_at":1678292176,"finished_at":1678292179,"progress":100}}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "180"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:22 GMT
-      Etag:
-      - W/"981eda588709c8b1e6d67b4de5eba511"
+      - Wed, 22 Mar 2023 17:40:43 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "922"
       X-Request-Id:
-      - a9bdebf7-4c03-44ff-b77a-5e049011bec1
-    status: 200 OK
-    code: 200
+      - 2a8234f2-5656-4a33-8a0b-694595057397
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -2645,7 +2646,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: DELETE
   response:
     body: '{}'
@@ -2661,7 +2662,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:23 GMT
+      - Wed, 22 Mar 2023 17:40:44 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2671,9 +2672,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "921"
       X-Request-Id:
-      - 27dccd73-db01-45e5-a316-64d502ca457d
+      - 35d990c3-003c-4a81-84a7-b302698d999c
     status: 200 OK
     code: 200
     duration: ""
@@ -2685,7 +2686,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jKCKt1g56izvgQoz
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2702,7 +2703,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:23 GMT
+      - Wed, 22 Mar 2023 17:40:44 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2712,9 +2713,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "920"
       X-Request-Id:
-      - 6ec16252-bc92-424d-9f17-7ce427bc0b56
+      - 1775fa26-2331-408f-8246-b558dd1c8048
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2726,7 +2727,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ugW5LZiANk0pPODW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2743,7 +2744,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:16:23 GMT
+      - Wed, 22 Mar 2023 17:40:44 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2753,9 +2754,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "919"
       X-Request-Id:
-      - f27eec14-6e68-4a4f-8f29-080e0917d98c
+      - 635b0c50-8621-4344-98db-f8250beb75a9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_group.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_group.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:42 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,15 +35,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "862"
+      - "999"
       X-Request-Id:
-      - 98f5d23c-252f-4cbe-9f71-d863d618adbf
+      - 955c9695-5f21-46f5-b9f5-714d336b5e3c
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -68,9 +68,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:42 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
+      - W/"2af951723576bc8946301cc5efc98631"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -78,9 +78,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "861"
+      - "999"
       X-Request-Id:
-      - dab5908e-00da-4db9-8dfa-3246b123aac3
+      - 9d86800e-62bb-49e0-b153-2fcf0e7f345b
     status: 200 OK
     code: 200
     duration: ""
@@ -92,10 +92,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_bwFf5pVHz1ffEV4N
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -108,9 +108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:42 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
+      - W/"2af951723576bc8946301cc5efc98631"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -118,9 +118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "859"
+      - "991"
       X-Request-Id:
-      - 95660856-1ea7-441c-87c6-adc69991372e
+      - b946fdb3-1424-4393-9f57-26df0a4182cd
     status: 200 OK
     code: 200
     duration: ""
@@ -138,7 +138,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -149,13 +149,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "549"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:46 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"3a687f736929f55327502ce877b5ad62"
+      - W/"70ae5cda48cd0cdf599bd81704faa419"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -163,9 +163,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "860"
+      - "993"
       X-Request-Id:
-      - d6a4f048-2377-4321-b1c9-80217b5bcf6b
+      - 68c1ca83-9542-443b-8f0a-1a855a58dd48
     status: 200 OK
     code: 200
     duration: ""
@@ -177,10 +177,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -191,13 +191,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:46 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"b5edb1f478fa37e762d80d507cfdce5d"
+      - W/"7367639e17424126d908b7a96b17219f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -205,9 +205,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "855"
+      - "989"
       X-Request-Id:
-      - f2eb9990-09e5-494b-8a34-94838aef991d
+      - 51853466-5c9b-4fab-ac7c-8759139da0de
     status: 200 OK
     code: 200
     duration: ""
@@ -219,10 +219,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -233,13 +233,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:46 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"b5edb1f478fa37e762d80d507cfdce5d"
+      - W/"7367639e17424126d908b7a96b17219f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -247,15 +247,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "854"
+      - "988"
       X-Request-Id:
-      - 2fc0119d-4b6a-40bc-9945-fe39e1af9ef9
+      - a6c29a4f-2ce5-4b20-952d-31ee9495b297
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_ThTjuc3gzLUgUUVg</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-icy-whining-tulip</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_2bjWpH3KQBlrSjJ0</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-purple-melodic-lead</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -267,7 +267,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_UaGHXevk74ps2ioQ","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","state":"pending"},"virtual_machine_build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","state":"pending"},"hostname":"tf-acc-test-icy-whining-tulip"}'
+    body: '{"task":{"id":"task_cYQzUvcQoMYHCbYX","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_xeurhBmTaf1Y9UhI","state":"pending"},"virtual_machine_build":{"id":"vmbuild_xeurhBmTaf1Y9UhI","state":"pending"},"hostname":"tf-acc-test-purple-melodic-lead"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -276,13 +276,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "268"
+      - "270"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:46 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
-      - W/"77869540499d5a1769a7cfc20d8fe239"
+      - W/"5124f7a00ac40ae2790fda80f2632657"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -290,9 +290,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "853"
+      - "987"
       X-Request-Id:
-      - 1d6e914a-09b3-4c1f-a515-4eb71782f74a
+      - 41db396d-28b7-4974-8fcf-e451ee744280
     status: 201 Created
     code: 201
     duration: ""
@@ -304,17 +304,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6CjpxXg7SXxSg1KD
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_xeurhBmTaf1Y9UhI
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_xeurhBmTaf1Y9UhI","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-whining-tulip\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-purple-melodic-lead\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679506786}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -323,585 +323,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1380"
+      - "1584"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:48 GMT
+      - Thu, 23 Mar 2023 10:54:33 GMT
       Etag:
-      - W/"642ad74a44eab65c52c09069a758d8cf"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "847"
-      X-Request-Id:
-      - da1e44aa-5b6f-42bb-8f2d-aa512c38f762
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6CjpxXg7SXxSg1KD
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-whining-tulip\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506786}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1577"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:39:53 GMT
-      Etag:
-      - W/"915f1c99407e563cea6f46cbbd7097e4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "840"
-      X-Request-Id:
-      - 2af2acbc-12a3-4983-8c31-e14e16491fd5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_6CjpxXg7SXxSg1KD
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_6CjpxXg7SXxSg1KD","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-icy-whining-tulip\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679506786}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1577"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:03 GMT
-      Etag:
-      - W/"f8ba8e7a9c40e5fddbd1d7b05e73c46f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - a80a258c-1f3a-4c51-b830-1843fd59b933
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2192"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - 9bfda331-f990-47bc-8acd-83f566033ef9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2192"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - a5ee3aad-0c2e-4048-96b8-63d97b44fcec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "357"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "991"
-      X-Request-Id:
-      - 5d54deb1-16c8-4b04-ad5e-6cf737a9a276
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "487"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"41daece6c11e4f3aec9ddede49c67443"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - ed389475-a367-4ec3-8792-4b9769b0a5d9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2192"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - 01dfb951-8e62-4ad1-b22e-93295bd4a243
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - 17deca9a-7a30-4815-8cc0-6410d9277014
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "724"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"74764379323d158321fb86d356b54e85"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - 430aa9de-4435-4529-b445-3527b7bbdb76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2192"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - 70e6da4a-1293-4e04-901c-7792a26bdd8b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "357"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "985"
-      X-Request-Id:
-      - 5db25a74-19b3-468c-96cb-b45bda99cb06
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "487"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:05 GMT
-      Etag:
-      - W/"41daece6c11e4f3aec9ddede49c67443"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 6c556aa0-0c10-444b-9038-cba5e237e0d5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:06 GMT
-      Etag:
-      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
+      - W/"e7d7bfc29b0c82a807069e07ac22684e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -911,7 +339,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "983"
       X-Request-Id:
-      - 06c6bd99-10b4-41d6-8200-c0a40ede94b7
+      - e94dd367-8ba0-48e6-ad84-d085c4e1928c
     status: 200 OK
     code: 200
     duration: ""
@@ -923,12 +351,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_xeurhBmTaf1Y9UhI
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_xeurhBmTaf1Y9UhI","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-purple-melodic-lead\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -937,283 +370,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "724"
+      - "1584"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:06 GMT
+      - Thu, 23 Mar 2023 10:54:38 GMT
       Etag:
-      - W/"74764379323d158321fb86d356b54e85"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - 001674bc-35b2-4d9c-9e6a-6a9de115bf80
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2192"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:06 GMT
-      Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "981"
-      X-Request-Id:
-      - baae1ad6-04fa-461b-a519-d0f3a6f00724
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "357"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:06 GMT
-      Etag:
-      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - fa748e6b-cc66-45ac-9af3-f29dd6a80602
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "487"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:06 GMT
-      Etag:
-      - W/"41daece6c11e4f3aec9ddede49c67443"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - 045d46a2-ec1a-4dfd-9c58-2fbb69abea8c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5"},"properties":{"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS"}}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
-  response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2307"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:07 GMT
-      Etag:
-      - W/"759e3c7d54fae9cb07f4713174a8df69"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "978"
-      X-Request-Id:
-      - a0779e51-be88-49da-8792-7a1470c511fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2307"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:07 GMT
-      Etag:
-      - W/"759e3c7d54fae9cb07f4713174a8df69"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - d7ab5f40-df78-48e8-80e5-38cf69611b9a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "357"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:07 GMT
-      Etag:
-      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
+      - W/"e7d7bfc29b0c82a807069e07ac22684e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1223,7 +386,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - 7b9df861-12d6-4388-8dfc-2a7486909839
+      - b1a9f003-22bc-45b4-8d1c-3d7dbc9e27bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1235,12 +398,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_xeurhBmTaf1Y9UhI
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_xeurhBmTaf1Y9UhI","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-purple-melodic-lead\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1249,13 +417,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "487"
+      - "1585"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:07 GMT
+      - Thu, 23 Mar 2023 10:54:48 GMT
       Etag:
-      - W/"41daece6c11e4f3aec9ddede49c67443"
+      - W/"f3d8d72c198cc9ab7f66b7019ac3a617"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1263,9 +431,234 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "969"
       X-Request-Id:
-      - 040aafd7-301f-4d78-bbe3-5e71b39e4ad3
+      - d4b1a039-31b5-44e6-83f4-4728979edb45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2199"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:50 GMT
+      Etag:
+      - W/"07ebc22fb3b66c2bad09333e5709a309"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - ad89feee-cc5a-4158-8981-f0bb91064ebf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "949"
+      X-Request-Id:
+      - 28773c57-07fc-4287-8c49-460b5f2e6e17
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - 3236193e-ab80-43cf-84b4-36124891ac9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eIujRD1v3L2ME8jz","name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "358"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"bb042da530c94e805a47cd06370d80e5"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - 1c0403d6-8c37-49ba-b0f1-d99beb275938
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eIujRD1v3L2ME8jz
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_eIujRD1v3L2ME8jz","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"},"name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:60:5f:29:ed:c1","state":"detached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "490"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"489cc28956abf767d882b65b49874a46"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 983ede52-5bb4-4ce2-bb63-fb466a78781f
     status: 200 OK
     code: 200
     duration: ""
@@ -1277,17 +670,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1296,13 +689,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2307"
+      - "2198"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:07 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"759e3c7d54fae9cb07f4713174a8df69"
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1310,9 +703,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "974"
+      - "941"
       X-Request-Id:
-      - 6dac1085-dca6-4244-ae7d-4b5a83922943
+      - 9b7a0315-85aa-46e8-984a-b4d0a34d537a
     status: 200 OK
     code: 200
     duration: ""
@@ -1324,10 +717,52 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "726"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:55 GMT
+      Etag:
+      - W/"6e528fc23c446b3a70ce944464e3c1e3"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "938"
+      X-Request-Id:
+      - 4e9f0b47-052a-4c46-a54c-8f15128601cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_bwFf5pVHz1ffEV4N
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1340,9 +775,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:08 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
+      - W/"2af951723576bc8946301cc5efc98631"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1350,9 +785,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "973"
+      - "937"
       X-Request-Id:
-      - abe3a055-6bc4-48bc-b52f-e7e6adb4dac6
+      - afd04bc5-0031-4c1f-9a88-d8c6698d4dc3
     status: 200 OK
     code: 200
     duration: ""
@@ -1364,59 +799,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "724"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:08 GMT
-      Etag:
-      - W/"74764379323d158321fb86d356b54e85"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "973"
-      X-Request-Id:
-      - 1f645c2f-125c-4aa3-86b5-1cd45cf35fc6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1425,13 +818,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2307"
+      - "2198"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:08 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"759e3c7d54fae9cb07f4713174a8df69"
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1439,9 +832,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "971"
+      - "936"
       X-Request-Id:
-      - 0dc1a794-ba17-45e1-824c-7276ac927162
+      - 47b73bf3-678b-473d-8b8e-43c4ad66e6f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1453,12 +846,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eIujRD1v3L2ME8jz","name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1467,13 +860,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "357"
+      - "358"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:08 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
+      - W/"bb042da530c94e805a47cd06370d80e5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1481,9 +874,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "970"
+      - "935"
       X-Request-Id:
-      - 6481fcbd-32d2-49b1-806b-0ae5547966eb
+      - a0755276-bf37-415b-9f1f-9028fd5dfce0
     status: 200 OK
     code: 200
     duration: ""
@@ -1495,12 +888,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eIujRD1v3L2ME8jz
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_eIujRD1v3L2ME8jz","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"},"name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:60:5f:29:ed:c1","state":"detached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1509,13 +902,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "487"
+      - "490"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:08 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"41daece6c11e4f3aec9ddede49c67443"
+      - W/"489cc28956abf767d882b65b49874a46"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1523,9 +916,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "969"
+      - "934"
       X-Request-Id:
-      - d7cd6d84-3fb8-48a2-a153-a60ac56716e9
+      - 5b9edab2-6bd3-4f95-a2a5-e6df2eeda40e
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,10 +930,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_fEqbVrs5Wn4sMUwS
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_bwFf5pVHz1ffEV4N
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1553,9 +946,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
+      - W/"2af951723576bc8946301cc5efc98631"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1563,9 +956,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "968"
+      - "929"
       X-Request-Id:
-      - 7fbc01c0-f440-4163-8120-d028fdd89d6a
+      - 2ca86476-15b2-46d3-8919-69f0c6b72605
     status: 200 OK
     code: 200
     duration: ""
@@ -1577,12 +970,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1591,13 +984,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "724"
+      - "726"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"74764379323d158321fb86d356b54e85"
+      - W/"6e528fc23c446b3a70ce944464e3c1e3"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1605,9 +998,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "968"
+      - "929"
       X-Request-Id:
-      - 6989155e-0b70-4945-99db-560f102a7c0d
+      - 6fae3aea-a3e2-4bed-9bfa-d16d0a434a37
     status: 200 OK
     code: 200
     duration: ""
@@ -1619,17 +1012,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1638,13 +1031,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2307"
+      - "2198"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"759e3c7d54fae9cb07f4713174a8df69"
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1652,9 +1045,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "927"
       X-Request-Id:
-      - cb41fb30-9098-4e8b-b417-7f9a602a8ecf
+      - e51fbdf5-a7ba-4241-aa9d-ed8d1d905131
     status: 200 OK
     code: 200
     duration: ""
@@ -1666,12 +1059,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eIujRD1v3L2ME8jz","name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1680,13 +1073,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "357"
+      - "358"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
+      - W/"bb042da530c94e805a47cd06370d80e5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1694,9 +1087,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "926"
       X-Request-Id:
-      - 2609d1ce-4cf4-4ec1-8157-4cd40860f120
+      - b69b1cba-927e-469c-850c-041dfa09b7d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1708,12 +1101,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eIujRD1v3L2ME8jz
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_eIujRD1v3L2ME8jz","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"},"name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:60:5f:29:ed:c1","state":"detached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1722,13 +1115,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "487"
+      - "490"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:54:56 GMT
       Etag:
-      - W/"41daece6c11e4f3aec9ddede49c67443"
+      - W/"489cc28956abf767d882b65b49874a46"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1736,55 +1129,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "925"
       X-Request-Id:
-      - 04f1bfff-cb44-4dd2-81c8-c09fe50905ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_fEqbVrs5Wn4sMUwS
-    method: DELETE
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_fEqbVrs5Wn4sMUwS","name":"tf-acc-test-update-group-qm6n0dgp9ab8","segregate":true,"created_at":1679506782}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
-      Etag:
-      - W/"5f9aefcf3253e4670ce44dfa7ed96a4e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "963"
-      X-Request-Id:
-      - 1d8f6de8-c095-4554-962b-b907bc7afc5e
+      - 4375428b-6735-4fcb-acdd-3f8b57bd82a1
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5"},"properties":{"group":null}}
+      {"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8"},"properties":{"group":{"id":"vmgrp_bwFf5pVHz1ffEV4N"}}}
     form: {}
     headers:
       Accept:
@@ -1796,14 +1149,14 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1812,13 +1165,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2192"
+      - "2313"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      - W/"282fee7b3b6e9898fac99415cc6f8307"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1826,9 +1179,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "922"
       X-Request-Id:
-      - e7343d95-ff7a-40c8-a6ce-216caaec5df9
+      - 6e902ff9-aef0-4d31-8413-1a8419ec49c7
     status: 200 OK
     code: 200
     duration: ""
@@ -1840,17 +1193,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1859,13 +1212,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2192"
+      - "2313"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      - W/"282fee7b3b6e9898fac99415cc6f8307"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1873,9 +1226,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "915"
       X-Request-Id:
-      - 81b3032a-a991-4ccf-b909-5a0e6fc2a327
+      - db7eaf79-3ed8-428c-8a13-fe474eb9aaa6
     status: 200 OK
     code: 200
     duration: ""
@@ -1887,12 +1240,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eIujRD1v3L2ME8jz","name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1901,13 +1254,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "357"
+      - "358"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:09 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
+      - W/"bb042da530c94e805a47cd06370d80e5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1915,9 +1268,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "914"
       X-Request-Id:
-      - 0056a14f-bbdd-4a98-9492-b70cfb2a172e
+      - 2404b618-fbc4-49e7-9dc2-1131b8bb743b
     status: 200 OK
     code: 200
     duration: ""
@@ -1929,12 +1282,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eIujRD1v3L2ME8jz
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_eIujRD1v3L2ME8jz","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"},"name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:60:5f:29:ed:c1","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1943,13 +1296,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "487"
+      - "490"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:10 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"41daece6c11e4f3aec9ddede49c67443"
+      - W/"eb848237e4a99d8705f55bc20d18ae59"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1957,9 +1310,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "913"
       X-Request-Id:
-      - d618ffa7-6abb-4943-933b-cdd685f33a26
+      - e35469f0-baf1-43f2-a4a0-27dc9736b721
     status: 200 OK
     code: 200
     duration: ""
@@ -1971,17 +1324,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1990,13 +1343,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2192"
+      - "2313"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:10 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      - W/"282fee7b3b6e9898fac99415cc6f8307"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2004,9 +1357,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "912"
       X-Request-Id:
-      - 3c8be4dc-5f79-4bed-a53a-025d5b0d6d8d
+      - 37980b1c-50a6-4c03-99eb-b2468e3dd08c
     status: 200 OK
     code: 200
     duration: ""
@@ -2018,12 +1371,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_bwFf5pVHz1ffEV4N
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"}}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2032,13 +1383,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "724"
+      - "145"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:10 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"74764379323d158321fb86d356b54e85"
+      - W/"2af951723576bc8946301cc5efc98631"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2046,9 +1397,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "907"
       X-Request-Id:
-      - e13dac7d-ae50-48ea-957d-8587c01675d5
+      - 47326676-e588-40ef-b8fb-bcf922fdbb4e
     status: 200 OK
     code: 200
     duration: ""
@@ -2060,17 +1411,59 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "726"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:58 GMT
+      Etag:
+      - W/"6e528fc23c446b3a70ce944464e3c1e3"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "906"
+      X-Request-Id:
+      - 54fcf26b-4708-4671-95ed-9ed094e599f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2079,13 +1472,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2192"
+      - "2313"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:10 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      - W/"282fee7b3b6e9898fac99415cc6f8307"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2093,9 +1486,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "905"
       X-Request-Id:
-      - 55664ea3-8b20-479e-bcbe-ea0dca0e6c6d
+      - ef54aa82-388b-404b-9f8e-e798709de057
     status: 200 OK
     code: 200
     duration: ""
@@ -2107,12 +1500,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KafQkwMyBtNWob8h","name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eIujRD1v3L2ME8jz","name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2121,13 +1514,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "357"
+      - "358"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:10 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"c1ef0a56fd80a62e0e3f53a63b548452"
+      - W/"bb042da530c94e805a47cd06370d80e5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2135,9 +1528,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "904"
       X-Request-Id:
-      - ee17f808-4ada-4f94-915b-80551bb86410
+      - 0a82c717-44fb-43ce-8da5-3bf63bcee7e4
     status: 200 OK
     code: 200
     duration: ""
@@ -2149,12 +1542,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KafQkwMyBtNWob8h
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eIujRD1v3L2ME8jz
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KafQkwMyBtNWob8h","virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip"},"name":"Public
-      Network on tf-acc-test-icy-whining-tulip","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:58:82:66:0f:b4","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_eIujRD1v3L2ME8jz","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"},"name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:60:5f:29:ed:c1","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2163,13 +1556,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "487"
+      - "490"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:10 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"41daece6c11e4f3aec9ddede49c67443"
+      - W/"eb848237e4a99d8705f55bc20d18ae59"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2177,9 +1570,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "903"
       X-Request-Id:
-      - 02f7fc23-4d0e-449a-aec4-0d4f708bc5fc
+      - b8304b20-8c36-4547-8e6b-14f0db0eb1ad
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,17 +1584,99 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "726"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:59 GMT
+      Etag:
+      - W/"6e528fc23c446b3a70ce944464e3c1e3"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "893"
+      X-Request-Id:
+      - 8c3eda93-af67-469e-90ff-6a94fd60a5ec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_bwFf5pVHz1ffEV4N
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "145"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:59 GMT
+      Etag:
+      - W/"2af951723576bc8946301cc5efc98631"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "892"
+      X-Request-Id:
+      - 313c383e-7834-4306-95c3-985dced36730
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2210,13 +1685,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2192"
+      - "2313"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:10 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"0daa32790d63cc3b53f93f00ed64be07"
+      - W/"282fee7b3b6e9898fac99415cc6f8307"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2224,9 +1699,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "952"
+      - "891"
       X-Request-Id:
-      - 7e03bc4a-ce50-461a-bdf8-367d80a4b17d
+      - 895a2f7b-e035-48fb-8ec1-e06cbe14bef0
     status: 200 OK
     code: 200
     duration: ""
@@ -2238,10 +1713,582 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eIujRD1v3L2ME8jz","name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "358"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:59 GMT
+      Etag:
+      - W/"bb042da530c94e805a47cd06370d80e5"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "890"
+      X-Request-Id:
+      - 143fd6ce-89c6-4b1d-bad8-d0b05b3da225
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eIujRD1v3L2ME8jz
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_eIujRD1v3L2ME8jz","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"},"name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:60:5f:29:ed:c1","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "490"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:59 GMT
+      Etag:
+      - W/"eb848237e4a99d8705f55bc20d18ae59"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "889"
+      X-Request-Id:
+      - 92f30ca2-1a16-4d80-b51c-3eb7d940292b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_bwFf5pVHz1ffEV4N
+    method: DELETE
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_bwFf5pVHz1ffEV4N","name":"tf-acc-test-update-group-mhs2p69yvzor","segregate":true,"created_at":1679568871}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "145"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:59 GMT
+      Etag:
+      - W/"2af951723576bc8946301cc5efc98631"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "884"
+      X-Request-Id:
+      - 2e3f9b6a-987c-42a3-88dc-45c17efe664b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8"},"properties":{"group":null}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:59 GMT
+      Etag:
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "882"
+      X-Request-Id:
+      - 044c0296-5e87-47ec-852e-e8118b4ec87a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 698c6214-a0e6-4852-8e77-0f6532fea2b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eIujRD1v3L2ME8jz","name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "358"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"bb042da530c94e805a47cd06370d80e5"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 9f259ece-eebc-4332-8909-37f2f3a85994
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eIujRD1v3L2ME8jz
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_eIujRD1v3L2ME8jz","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"},"name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:60:5f:29:ed:c1","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "490"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"eb848237e4a99d8705f55bc20d18ae59"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 6ceb1d82-ff67-4ecb-b12a-3a74b45815d1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - f31fe707-2550-48c6-9f74-e65b061c8d00
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "726"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"6e528fc23c446b3a70ce944464e3c1e3"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 1c9e8ae4-bbb7-4c03-982b-361a021d5ea9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 03086d88-0dad-4094-a032-78f4e4b3b016
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_eIujRD1v3L2ME8jz","name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "358"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"bb042da530c94e805a47cd06370d80e5"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 52384071-6866-43c2-9ad8-20a034b311f6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_eIujRD1v3L2ME8jz
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_eIujRD1v3L2ME8jz","virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead"},"name":"Public
+      Network on tf-acc-test-purple-melodic-lead","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:60:5f:29:ed:c1","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "490"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"eb848237e4a99d8705f55bc20d18ae59"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - be960e6c-bfbf-4a9c-90bf-bf5fa3cd366d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2198"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"68b3e850c15caf4f146a6c063ebcfd24"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 61912974-644c-437f-8e24-ba6ff54cd8c2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: POST
   response:
-    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_8c4PVSzw7eF4z6ml","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2254,9 +2301,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:10 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"8d56e60edafd053a1141a05d23a9f81f"
+      - W/"d16e2f56b5933c2efc871381cc97868e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2264,9 +2311,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "951"
+      - "971"
       X-Request-Id:
-      - 9b2cb62a-1f86-4140-b5d8-c35697260d01
+      - cf52f5b5-05c3-475f-acf5-f8cf7ef5c1ed
     status: 200 OK
     code: 200
     duration: ""
@@ -2278,10 +2325,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_n0EbKTVCsGJTOYbN
+    url: https://api.katapult.io/core/v1/tasks/task_8c4PVSzw7eF4z6ml
     method: GET
   response:
-    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"pending","created_at":1679506810,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_8c4PVSzw7eF4z6ml","name":"Stop virtual machine","status":"running","created_at":1679568900,"started_at":1679568901,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2290,13 +2337,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "162"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:11 GMT
+      - Thu, 23 Mar 2023 10:55:01 GMT
       Etag:
-      - W/"7f3e6f09fc900dd44cba6a5c042f1a3c"
+      - W/"94da0276434062acfe8928ed4ec04e42"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2304,9 +2351,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "950"
+      - "967"
       X-Request-Id:
-      - a5f311a3-7cfa-4fb3-b236-2daa584f4260
+      - a7d1be51-761d-4a7e-93c3-22257d6e3437
     status: 200 OK
     code: 200
     duration: ""
@@ -2318,90 +2365,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_n0EbKTVCsGJTOYbN
+    url: https://api.katapult.io/core/v1/tasks/task_8c4PVSzw7eF4z6ml
     method: GET
   response:
-    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"pending","created_at":1679506810,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:16 GMT
-      Etag:
-      - W/"7f3e6f09fc900dd44cba6a5c042f1a3c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "942"
-      X-Request-Id:
-      - 9e82f1e7-7bc6-4d51-9627-c85242d19ddd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_n0EbKTVCsGJTOYbN
-    method: GET
-  response:
-    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"running","created_at":1679506810,"started_at":1679506825,"finished_at":null,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "170"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:40:26 GMT
-      Etag:
-      - W/"0cd8981d3782ab004b547be6fbd40da0"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "934"
-      X-Request-Id:
-      - 4402c871-1e4b-426d-aba1-fe3ed9ca1f2c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_n0EbKTVCsGJTOYbN
-    method: GET
-  response:
-    body: '{"task":{"id":"task_n0EbKTVCsGJTOYbN","name":"Stop virtual machine","status":"completed","created_at":1679506810,"started_at":1679506825,"finished_at":1679506828,"progress":100}}'
+    body: '{"task":{"id":"task_8c4PVSzw7eF4z6ml","name":"Stop virtual machine","status":"completed","created_at":1679568900,"started_at":1679568901,"finished_at":1679568904,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2414,9 +2381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:36 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"e50bf0413218c89c0c28537373edeffc"
+      - W/"1ea0d64bda9a3cc814e61ddac34d0760"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2424,9 +2391,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "927"
+      - "948"
       X-Request-Id:
-      - 393b089e-2ec3-4bd6-bd65-8ca23c34c526
+      - 61d91135-18cb-4939-82bd-2c811f1c255b
     status: 200 OK
     code: 200
     duration: ""
@@ -2438,17 +2405,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_dNgeX3yWX9aWxY1p","keep_until":1679679636,"object_id":"vm_f7VMLIKshd9bVZg5","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_f7VMLIKshd9bVZg5","name":"tf-acc-test-icy-whining-tulip","hostname":"tf-acc-test-icy-whining-tulip","fqdn":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506788,"initial_root_password":"D5DsVqvGFfXLMcQP","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_vbxy7xk5HaIik0No","keep_until":1679741707,"object_id":"vm_SJIJ6qG3qb3gQ3X8","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_SJIJ6qG3qb3gQ3X8","name":"tf-acc-test-purple-melodic-lead","hostname":"tf-acc-test-purple-melodic-lead","fqdn":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568872,"initial_root_password":"INnkUaDtRBhdxq03","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-icy-whining-tulip.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-purple-melodic-lead.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f7VMLIKshd9bVZg5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SJIJ6qG3qb3gQ3X8","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2457,13 +2424,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2327"
+      - "2333"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:36 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"9b5ab835a73f37686635780a37ff3e34"
+      - W/"5546ae55b591f68e2cf8c6de8c2af830"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2471,9 +2438,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "926"
+      - "946"
       X-Request-Id:
-      - e4d77344-6bcb-4c84-ab0f-f4f6106232f6
+      - 0000deb6-ebff-4c04-9fcd-b6ae2fba2572
     status: 200 OK
     code: 200
     duration: ""
@@ -2485,7 +2452,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: POST
   response:
     body: '{}'
@@ -2501,7 +2468,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:37 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2511,9 +2478,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "925"
+      - "944"
       X-Request-Id:
-      - cde65e5d-945e-4702-8c53-f446c9fe8341
+      - 494f5472-21f9-4654-8c05-ca68782567df
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,10 +2492,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dNgeX3yWX9aWxY1p
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_vbxy7xk5HaIik0No
     method: DELETE
   response:
-    body: '{"task":{"id":"task_uL2GTaWCLjt30YMb","name":"Purge items from trash","status":"pending","created_at":1679506837,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_7Il4e36acqEfPA5G","name":"Purge items from trash","status":"pending","created_at":1679568907,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2541,9 +2508,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:37 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"d0651b871cc853b4002bf2a0358ddb1a"
+      - W/"5e98dd4b53554caefb54db39c8cdbf14"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2551,9 +2518,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "924"
+      - "937"
       X-Request-Id:
-      - 7fbd7cb4-3424-4322-9859-4623c748a6ea
+      - cd49f481-7285-4c5e-a597-80ca1de000c5
     status: 200 OK
     code: 200
     duration: ""
@@ -2565,10 +2532,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dNgeX3yWX9aWxY1p
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_vbxy7xk5HaIik0No
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_dNgeX3yWX9aWxY1p","keep_until":1679679636,"object_id":"vm_f7VMLIKshd9bVZg5","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_vbxy7xk5HaIik0No","keep_until":1679741707,"object_id":"vm_SJIJ6qG3qb3gQ3X8","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2581,9 +2548,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:38 GMT
+      - Thu, 23 Mar 2023 10:55:08 GMT
       Etag:
-      - W/"a013eb7067932de726f9bfd70ef3e2bc"
+      - W/"da4c78c39f963d527f52026775bafcd1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2591,9 +2558,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "923"
+      - "935"
       X-Request-Id:
-      - d25e72b0-e82b-446d-9aee-b67599ef27fb
+      - 6313811d-1f31-4e60-8c30-a94b0f9b4c53
     status: 200 OK
     code: 200
     duration: ""
@@ -2605,7 +2572,47 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_dNgeX3yWX9aWxY1p
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_vbxy7xk5HaIik0No
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_vbxy7xk5HaIik0No","keep_until":1679741707,"object_id":"vm_SJIJ6qG3qb3gQ3X8","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:13 GMT
+      Etag:
+      - W/"da4c78c39f963d527f52026775bafcd1"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "927"
+      X-Request-Id:
+      - ef13791e-3967-4c88-b1ed-e2bcdbd3f5cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_vbxy7xk5HaIik0No
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2622,7 +2629,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:43 GMT
+      - Thu, 23 Mar 2023 10:55:23 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2632,9 +2639,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "922"
+      - "915"
       X-Request-Id:
-      - 2a8234f2-5656-4a33-8a0b-694595057397
+      - a649386d-6a2e-4d90-8fb0-803240d3b4a4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2646,7 +2653,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: DELETE
   response:
     body: '{}'
@@ -2662,7 +2669,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:44 GMT
+      - Thu, 23 Mar 2023 10:55:23 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2672,9 +2679,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "914"
       X-Request-Id:
-      - 35d990c3-003c-4a81-84a7-b302698d999c
+      - 291310b5-5c28-4874-98de-715b6b7862ec
     status: 200 OK
     code: 200
     duration: ""
@@ -2686,7 +2693,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f7VMLIKshd9bVZg5
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SJIJ6qG3qb3gQ3X8
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2703,7 +2710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:44 GMT
+      - Thu, 23 Mar 2023 10:55:23 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2713,9 +2720,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "920"
+      - "913"
       X-Request-Id:
-      - 1775fa26-2331-408f-8246-b558dd1c8048
+      - be3ae585-f01a-4243-b8ec-8532acda41e7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2727,7 +2734,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_SJIJ6qG3qb3gQ3X8
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:23 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "912"
+      X-Request-Id:
+      - 3cdeac09-dc73-48a3-8d59-bc127344fffb
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2744,7 +2792,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:40:44 GMT
+      - Thu, 23 Mar 2023 10:55:23 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2754,9 +2802,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "919"
+      - "910"
       X-Request-Id:
-      - 635b0c50-8621-4344-98db-f8250beb75a9
+      - d693134d-86cd-4f7f-9687-a0c7e22adde5
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_ips.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_ips.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:27 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "996"
       X-Request-Id:
-      - fc5bbc45-b1e5-4779-bac7-bf89e975bdcd
+      - 9a672c2a-8c94-4332-98ee-a57c0f80f35d
     status: 200 OK
     code: 200
     duration: ""
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"185-199-222-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -66,13 +66,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "549"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:30 GMT
+      - Thu, 23 Mar 2023 10:54:34 GMT
       Etag:
-      - W/"e0788f5c5041aa9d58b3366e98789623"
+      - W/"a6b5cdab485741d1838e65e88fa9f2ba"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "992"
       X-Request-Id:
-      - 01e0490b-f448-41ac-b2d0-affe0291d26c
+      - b9a23070-7d65-486a-b34e-c5d4ca03a5d5
     status: 200 OK
     code: 200
     duration: ""
@@ -94,10 +94,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"185-199-222-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -108,13 +108,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:30 GMT
+      - Thu, 23 Mar 2023 10:54:34 GMT
       Etag:
-      - W/"099ea7765f3a652616e2a40ad38ab29f"
+      - W/"7a47cc20d8813bde7d5bd5698f451dee"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -122,9 +122,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "981"
       X-Request-Id:
-      - 18aa925c-064f-47f9-8500-34142016ff5e
+      - d088c0bb-02dd-4e03-8f72-60e4ec10b66c
     status: 200 OK
     code: 200
     duration: ""
@@ -136,10 +136,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"185-199-222-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"185-199-222-98.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -150,13 +150,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "567"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:30 GMT
+      - Thu, 23 Mar 2023 10:54:34 GMT
       Etag:
-      - W/"099ea7765f3a652616e2a40ad38ab29f"
+      - W/"7a47cc20d8813bde7d5bd5698f451dee"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -164,15 +164,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "980"
       X-Request-Id:
-      - a6914e89-8b74-4b1e-b5a6-d1f60b4f3e1c
+      - 38e867c4-46f5-4cca-bff1-d7804c040360
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_RwFCDb3XqBvIb12H</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-salty-early-dandelion</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_U9UlK0AeOdMthOJ5</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-fast-icy-banana</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_d0ndKQjlDe2m3wXg","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","state":"pending"},"virtual_machine_build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","state":"pending"},"hostname":"tf-acc-test-salty-early-dandelion"}'
+    body: '{"task":{"id":"task_Pt3R8CQZul73kQTT","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_LSxbOkXHvgAhFiP7","state":"pending"},"virtual_machine_build":{"id":"vmbuild_LSxbOkXHvgAhFiP7","state":"pending"},"hostname":"tf-acc-test-fast-icy-banana"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -193,13 +193,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "272"
+      - "266"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:30 GMT
+      - Thu, 23 Mar 2023 10:54:34 GMT
       Etag:
-      - W/"d3460af7a4c9784dc519e1a9d35e4517"
+      - W/"c83120491ddade576c100bf59b31c8d7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -207,9 +207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "979"
       X-Request-Id:
-      - ae19141d-f0da-47ce-a260-60b24a7a082f
+      - fa0e52ff-47e3-4449-b888-f36b7a572c0a
     status: 201 Created
     code: 201
     duration: ""
@@ -221,17 +221,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Wm2iVhorqYcAnTNF
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LSxbOkXHvgAhFiP7
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_LSxbOkXHvgAhFiP7","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-salty-early-dandelion\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-fast-icy-banana\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679507010}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679568874}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -240,13 +240,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1384"
+      - "1377"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:32 GMT
+      - Thu, 23 Mar 2023 10:54:36 GMT
       Etag:
-      - W/"9ceb13c5bf2db68e07c438d2a76cac2e"
+      - W/"e3335cf0210bec7172a599da3ae8bc4d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -254,9 +254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "978"
       X-Request-Id:
-      - 347fa857-c5ab-48f1-9d55-024f1120cda5
+      - 4fafd3fc-fa85-41fa-b329-7db52b4e747a
     status: 200 OK
     code: 200
     duration: ""
@@ -268,17 +268,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Wm2iVhorqYcAnTNF
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LSxbOkXHvgAhFiP7
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_LSxbOkXHvgAhFiP7","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-salty-early-dandelion\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-fast-icy-banana\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679507010}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568874}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -287,13 +287,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1593"
+      - "1568"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:38 GMT
+      - Thu, 23 Mar 2023 10:54:41 GMT
       Etag:
-      - W/"a5d5c04584f3f1b587a5e8c3c4f44884"
+      - W/"f13be1831a04d458ae771aeb169a5841"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -301,9 +301,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "971"
       X-Request-Id:
-      - f4c98c7d-2908-491b-aa74-9b21a2ff87dc
+      - ae725404-6930-4131-9ce5-b0b098c75adb
     status: 200 OK
     code: 200
     duration: ""
@@ -315,17 +315,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Wm2iVhorqYcAnTNF
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LSxbOkXHvgAhFiP7
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_LSxbOkXHvgAhFiP7","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-salty-early-dandelion\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.98\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-fast-icy-banana\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679507010}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679568874}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -334,13 +334,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1593"
+      - "1568"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:48 GMT
+      - Thu, 23 Mar 2023 10:54:51 GMT
       Etag:
-      - W/"235ddc1a8a5d5e8b96ceaa306d97010b"
+      - W/"33cbaffcca8b5c61d7325347dd75b0ff"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -348,9 +348,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "965"
       X-Request-Id:
-      - fb7e1cf5-9a35-4e93-967d-01ac7f94a602
+      - bc9e1bb8-a511-4e1a-8f72-2795cbf93463
     status: 200 OK
     code: 200
     duration: ""
@@ -362,17 +362,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -381,13 +381,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2208"
+      - "2182"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:53 GMT
       Etag:
-      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      - W/"9bf2cffecafda58b07b0e0b3b07111f4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -395,9 +395,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "964"
       X-Request-Id:
-      - d866d59f-5815-4197-9c33-7636e625c860
+      - 3ddb3c42-0746-4da6-955b-272d56070adb
     status: 200 OK
     code: 200
     duration: ""
@@ -409,17 +409,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -428,13 +428,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2208"
+      - "2182"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      - W/"9bf2cffecafda58b07b0e0b3b07111f4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -442,9 +442,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "963"
       X-Request-Id:
-      - 7ef3b16e-b4aa-4460-bad6-f1f43c675663
+      - def753e6-00c1-4805-9903-1e77948498b0
     status: 200 OK
     code: 200
     duration: ""
@@ -456,12 +456,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -470,13 +470,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "361"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"17480b4ac032f1a1c2518883280c08e4"
+      - W/"c2dce1b7471f5535865fae591a236b34"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -484,9 +484,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "962"
       X-Request-Id:
-      - 60dbdfb0-fd69-4cbe-b84c-1f36d29ecb9e
+      - 534ce8f9-eeb0-411c-8cc2-20223425ee39
     status: 200 OK
     code: 200
     duration: ""
@@ -498,12 +498,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGwwzNt4lemXMJ5t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -512,13 +512,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "495"
+      - "482"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      - W/"d3543a03dedd68a19b60bee1bcd15c7d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -526,9 +526,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "961"
       X-Request-Id:
-      - 9cd84ac4-24db-4db0-81fc-6a318af5a863
+      - 9ce632c7-961d-4d06-86ff-d5710b31c6ae
     status: 200 OK
     code: 200
     duration: ""
@@ -540,17 +540,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -559,13 +559,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2208"
+      - "2182"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      - W/"9bf2cffecafda58b07b0e0b3b07111f4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -573,9 +573,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "960"
       X-Request-Id:
-      - e2843080-4846-499a-a430-84641c9d8e3f
+      - 13b06007-2556-498a-b469-dbba7f82cd81
     status: 200 OK
     code: 200
     duration: ""
@@ -587,12 +587,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -601,13 +601,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "718"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"79d932dcd6664ecec44e46d19267806d"
+      - W/"c459ba6fb15d6664455e29f55da102ec"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -615,9 +615,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "959"
       X-Request-Id:
-      - 2be170a1-99d5-42ae-8775-7678fbc5876e
+      - 00986d6f-cdfd-4389-993c-09a77f649171
     status: 200 OK
     code: 200
     duration: ""
@@ -629,17 +629,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -648,13 +648,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2208"
+      - "2182"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      - W/"9bf2cffecafda58b07b0e0b3b07111f4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -662,9 +662,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "958"
       X-Request-Id:
-      - 460d5c1d-bc13-4761-97bb-41ef213a03a7
+      - db2bda6e-5142-42df-8da2-9cf160842344
     status: 200 OK
     code: 200
     duration: ""
@@ -676,12 +676,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -690,13 +690,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "361"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"17480b4ac032f1a1c2518883280c08e4"
+      - W/"c2dce1b7471f5535865fae591a236b34"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -704,9 +704,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "957"
       X-Request-Id:
-      - e461ef57-623b-455e-b3ed-7d34f7f200ce
+      - 0ca713ff-57d7-430d-815e-b82efc6c5848
     status: 200 OK
     code: 200
     duration: ""
@@ -718,12 +718,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGwwzNt4lemXMJ5t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -732,13 +732,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "495"
+      - "482"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      - W/"d3543a03dedd68a19b60bee1bcd15c7d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -746,9 +746,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "956"
       X-Request-Id:
-      - 8381764d-192a-4bf1-9e72-bde463de8f2e
+      - fcae3180-a005-4c84-9deb-9c0cedc66867
     status: 200 OK
     code: 200
     duration: ""
@@ -760,12 +760,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -774,13 +774,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "718"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:54 GMT
       Etag:
-      - W/"79d932dcd6664ecec44e46d19267806d"
+      - W/"c459ba6fb15d6664455e29f55da102ec"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -788,9 +788,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "982"
+      - "955"
       X-Request-Id:
-      - cc1fe2b2-78a3-472b-8579-8201a4d08829
+      - 16042b5f-b704-4acf-a0ed-f5f2b09892c1
     status: 200 OK
     code: 200
     duration: ""
@@ -802,17 +802,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -821,13 +821,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2208"
+      - "2182"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      - W/"9bf2cffecafda58b07b0e0b3b07111f4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -835,9 +835,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "981"
+      - "954"
       X-Request-Id:
-      - 0a24c1c7-1720-41d5-aef9-97f068f7a997
+      - df978a01-0870-4996-b691-4508e1db36a0
     status: 200 OK
     code: 200
     duration: ""
@@ -849,12 +849,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -863,13 +863,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "361"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"17480b4ac032f1a1c2518883280c08e4"
+      - W/"c2dce1b7471f5535865fae591a236b34"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -877,9 +877,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "980"
+      - "953"
       X-Request-Id:
-      - 38d029af-0b64-4770-82ee-b7444bf64781
+      - 6dc339b4-91fe-4550-bca6-1e8b0782e32d
     status: 200 OK
     code: 200
     duration: ""
@@ -891,12 +891,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGwwzNt4lemXMJ5t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -905,13 +905,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "495"
+      - "482"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:50 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      - W/"d3543a03dedd68a19b60bee1bcd15c7d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -919,9 +919,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "979"
+      - "952"
       X-Request-Id:
-      - 547368b1-57db-430f-9020-5eeb9d8cac98
+      - 641595d8-2337-41bc-9cf1-327f36a3113d
     status: 200 OK
     code: 200
     duration: ""
@@ -949,7 +949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:51 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -959,9 +959,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "978"
+      - "951"
       X-Request-Id:
-      - b2941369-328d-4cf7-b4ef-8cda6bec3977
+      - 0faf8c9b-4873-4946-a419-b34b330c0109
     status: 200 OK
     code: 200
     duration: ""
@@ -979,7 +979,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"185-199-222-120.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -994,9 +994,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"3ce3da3a89230c900adcf68ea917e465"
+      - W/"5392ee9f0c9d9fecfd13399b97019a7d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1004,9 +1004,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "977"
+      - "950"
       X-Request-Id:
-      - 0d78fcde-9894-42b8-8019-903bb0f6f125
+      - 3bb95984-cd51-474e-afba-ffed6f46452d
     status: 200 OK
     code: 200
     duration: ""
@@ -1018,10 +1018,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"185-199-222-120.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -1036,9 +1036,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"40e4700975977b320d54253fe3bf4e3a"
+      - W/"c14477dd8b8d2d0e1dc18e3e514e0ad1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1046,9 +1046,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "976"
+      - "899"
       X-Request-Id:
-      - 21d79be8-b60a-4083-bafa-1a22fdbcf1ee
+      - ed76c96c-a6bf-4176-9bd2-d192e1ca7111
     status: 200 OK
     code: 200
     duration: ""
@@ -1060,17 +1060,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1079,13 +1079,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2208"
+      - "2182"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      - W/"9bf2cffecafda58b07b0e0b3b07111f4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1093,9 +1093,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "897"
       X-Request-Id:
-      - 590bf8fb-d2ec-46ca-a7d2-430a9e4f8776
+      - 1ebbb046-cd09-4698-bc3a-b1ac56c6c4c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1107,12 +1107,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1121,13 +1121,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "362"
+      - "355"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"fda32f205223e39c51aff171653e47bd"
+      - W/"7b6071209c7ef0e4cc3396523ab0a3fe"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1135,9 +1135,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "974"
+      - "896"
       X-Request-Id:
-      - 06bc5074-90a8-4359-a4ff-20de1d8d120a
+      - 1f1f6ca1-d80e-40d2-a396-9b12d87248d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1149,10 +1149,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"185-199-222-120.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -1167,9 +1167,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"40e4700975977b320d54253fe3bf4e3a"
+      - W/"c14477dd8b8d2d0e1dc18e3e514e0ad1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1177,15 +1177,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "973"
+      - "895"
       X-Request-Id:
-      - 0454a3c8-74fb-4624-818f-ee85ab683c0e
+      - 166a7ff8-1288-498a-848f-6abb119a94db
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV"},"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW"}}
+      {"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t"},"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv"}}
     form: {}
     headers:
       Accept:
@@ -1197,9 +1197,9 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/allocate_ip
     method: POST
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1208,13 +1208,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "469"
+      - "456"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"e39c03531c2015e429ca15d430ee9b03"
+      - W/"b9efca2cc0c84d6af5993a3051a2b518"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1222,15 +1222,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "972"
+      - "894"
       X-Request-Id:
-      - 0dbfebf3-3caf-4e1c-adc3-a6773dc8810d
+      - e2516544-3cad-485b-9db7-b63f4eddd65c
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_jmpKAarcgRvploVk"},"properties":{}}
+      {"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ"},"properties":{}}
     form: {}
     headers:
       Accept:
@@ -1242,16 +1242,16 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1260,13 +1260,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2807"
+      - "2775"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"6d36958792b1534714f226ad2db1d6ce"
+      - W/"9297731612cd7875d7b32408e5e558bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1274,9 +1274,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "971"
+      - "887"
       X-Request-Id:
-      - bbed7bfd-8e5a-4eb6-95ca-5a744545be3e
+      - c9ad62c6-1930-4399-8c8b-65a25e50e6f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1288,19 +1288,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1309,13 +1309,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2807"
+      - "2775"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"6d36958792b1534714f226ad2db1d6ce"
+      - W/"9297731612cd7875d7b32408e5e558bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1323,9 +1323,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "970"
+      - "886"
       X-Request-Id:
-      - 7ecbe8bc-6e71-47fd-8eb9-bcd1b7654139
+      - 4988a379-1583-479f-b1d7-0f50f0da556d
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,12 +1337,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1351,13 +1351,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "418"
+      - "411"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:54 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"9859472b89c06c30d1c8e6ca1a8fad4d"
+      - W/"386c478e52acacd362acbbf90c65f13e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1365,9 +1365,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "969"
+      - "885"
       X-Request-Id:
-      - 6e9a0dc6-cc96-4021-968e-0726f6ce50b0
+      - 2df76bc2-01c6-4277-bcce-9145577ffb2b
     status: 200 OK
     code: 200
     duration: ""
@@ -1379,12 +1379,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGwwzNt4lemXMJ5t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1393,13 +1393,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "539"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"eeca8360336ad568404d219a8407d118"
+      - W/"2216552cde0fe5c18c02619c4a7ca987"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1407,9 +1407,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "968"
+      - "883"
       X-Request-Id:
-      - 70d0acdb-9452-4a4d-af15-c13786b0b888
+      - 7c982bc1-dcd9-4444-be4d-7fed0ab260af
     status: 200 OK
     code: 200
     duration: ""
@@ -1421,19 +1421,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1442,13 +1442,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2807"
+      - "2775"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:54:59 GMT
       Etag:
-      - W/"6d36958792b1534714f226ad2db1d6ce"
+      - W/"9297731612cd7875d7b32408e5e558bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1456,9 +1456,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "881"
       X-Request-Id:
-      - 1efa6b2c-d63a-4bad-b867-378e599d29bc
+      - ddf1aad4-4b19-40df-8d61-aacf3eefd135
     status: 200 OK
     code: 200
     duration: ""
@@ -1470,12 +1470,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1484,13 +1484,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "718"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"c308c320c02d50fd46d6c50b0ed276cb"
+      - W/"c459ba6fb15d6664455e29f55da102ec"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1498,9 +1498,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "992"
       X-Request-Id:
-      - fc4820b0-12f9-4bf0-8b3e-4215dd17ab4b
+      - 4386cc58-00cf-46b5-901a-9647fcdd6162
     status: 200 OK
     code: 200
     duration: ""
@@ -1512,12 +1512,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1526,13 +1526,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "720"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"79d932dcd6664ecec44e46d19267806d"
+      - W/"8a076d849daf8d84615b9e50e64d0c6a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1540,9 +1540,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "992"
       X-Request-Id:
-      - b5725b14-27ce-4d91-94e8-4a779dc791fa
+      - 3979619b-228b-4fa4-ac55-06fa55a37943
     status: 200 OK
     code: 200
     duration: ""
@@ -1554,19 +1554,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1575,13 +1575,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2807"
+      - "2775"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"6d36958792b1534714f226ad2db1d6ce"
+      - W/"9297731612cd7875d7b32408e5e558bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1589,9 +1589,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "990"
       X-Request-Id:
-      - ead9ddbc-bbbf-4509-9002-01d6b53e44ed
+      - 14198e63-64d7-4d81-a355-a56335da2250
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,12 +1603,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1617,13 +1617,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "418"
+      - "411"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"9859472b89c06c30d1c8e6ca1a8fad4d"
+      - W/"386c478e52acacd362acbbf90c65f13e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1631,9 +1631,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "989"
       X-Request-Id:
-      - 66e2c569-14b3-42cf-aee1-ee683316fba3
+      - 57afaf5e-1a73-41a7-bfd1-cab2004b3c16
     status: 200 OK
     code: 200
     duration: ""
@@ -1645,12 +1645,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGwwzNt4lemXMJ5t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1659,13 +1659,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "539"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"eeca8360336ad568404d219a8407d118"
+      - W/"2216552cde0fe5c18c02619c4a7ca987"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1673,9 +1673,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "988"
       X-Request-Id:
-      - 4f924719-5f3f-4896-bdb3-dc6c67ac008d
+      - edc1fde6-e55d-46a0-82d7-bd808e33df43
     status: 200 OK
     code: 200
     duration: ""
@@ -1687,12 +1687,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1701,13 +1701,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "720"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"c308c320c02d50fd46d6c50b0ed276cb"
+      - W/"8a076d849daf8d84615b9e50e64d0c6a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1715,9 +1715,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "979"
       X-Request-Id:
-      - 84d53785-2f01-45f8-ae55-11f114a05b7e
+      - d72a1f91-3305-49b6-bfa7-29e2b82ea67a
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1729,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1743,13 +1743,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "718"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"79d932dcd6664ecec44e46d19267806d"
+      - W/"c459ba6fb15d6664455e29f55da102ec"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1757,9 +1757,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "979"
       X-Request-Id:
-      - 185f6712-938f-4261-856b-137db4ab6aa9
+      - 4b936bc8-7f94-4b41-a6db-1fdd2744612d
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,19 +1771,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1792,13 +1792,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2807"
+      - "2775"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"6d36958792b1534714f226ad2db1d6ce"
+      - W/"9297731612cd7875d7b32408e5e558bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1806,9 +1806,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "977"
       X-Request-Id:
-      - 0ec1be1b-78e7-4c55-818d-721b2ee0271c
+      - cc7fc7de-8e4c-4fd9-9050-9d3777a0e7ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1820,12 +1820,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1834,13 +1834,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "418"
+      - "411"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"9859472b89c06c30d1c8e6ca1a8fad4d"
+      - W/"386c478e52acacd362acbbf90c65f13e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1848,9 +1848,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "976"
       X-Request-Id:
-      - 9306b876-3951-49ec-af27-c708a10013c2
+      - aa37cb41-d446-4f11-ac62-aeda210557e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1862,12 +1862,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGwwzNt4lemXMJ5t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1876,13 +1876,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "539"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:55 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"eeca8360336ad568404d219a8407d118"
+      - W/"2216552cde0fe5c18c02619c4a7ca987"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1890,9 +1890,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "975"
       X-Request-Id:
-      - e4a0004f-785c-4a01-a938-4a9f603c75e1
+      - 25270731-c575-45fa-a502-0f046b12adfe
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,19 +1904,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1925,13 +1925,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2807"
+      - "2775"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:56 GMT
+      - Thu, 23 Mar 2023 10:55:01 GMT
       Etag:
-      - W/"6d36958792b1534714f226ad2db1d6ce"
+      - W/"9297731612cd7875d7b32408e5e558bd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1939,9 +1939,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "970"
       X-Request-Id:
-      - 5eb1482e-e1e5-4fe7-a2f8-c7471ffd5e6f
+      - dbdb293c-40e4-4246-b3ba-93c0ea18bc1e
     status: 200 OK
     code: 200
     duration: ""
@@ -1953,7 +1953,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: POST
   response:
     body: '{}'
@@ -1969,7 +1969,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:56 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1979,15 +1979,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "969"
       X-Request-Id:
-      - 4539ccab-b01e-404c-886b-5c97ce618e50
+      - 8b002f98-1443-499b-be1e-fb29242b9969
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_jmpKAarcgRvploVk"},"properties":{"tag_names":["lb","app","web"]}}
+      {"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ"},"properties":{"tag_names":["lb","app","web"]}}
     form: {}
     headers:
       Accept:
@@ -1999,14 +1999,14 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2015,13 +2015,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2492"
+      - "2466"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:56 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"282f51bdb9a8738d34553cfa31352efd"
+      - W/"72f3a308c87956953645f43c975feeba"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2029,9 +2029,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "966"
       X-Request-Id:
-      - a2b41f46-c228-439c-b6ee-ec6de63766ef
+      - 1deab044-27dc-486a-a9ad-051e0d512af0
     status: 200 OK
     code: 200
     duration: ""
@@ -2043,17 +2043,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2062,13 +2062,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2492"
+      - "2466"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:56 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"282f51bdb9a8738d34553cfa31352efd"
+      - W/"72f3a308c87956953645f43c975feeba"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2076,9 +2076,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "964"
       X-Request-Id:
-      - aa62e3ad-8385-4355-9efd-87c903d6d420
+      - fdb423bb-2ebd-43f1-8205-8480ca535b80
     status: 200 OK
     code: 200
     duration: ""
@@ -2090,12 +2090,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2104,13 +2104,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "361"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:56 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"17480b4ac032f1a1c2518883280c08e4"
+      - W/"c2dce1b7471f5535865fae591a236b34"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2118,9 +2118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "952"
+      - "963"
       X-Request-Id:
-      - d68cdc0d-802f-491e-b29a-97a2d8ecae6b
+      - 13b57965-21af-4203-a575-260145c61781
     status: 200 OK
     code: 200
     duration: ""
@@ -2132,12 +2132,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGwwzNt4lemXMJ5t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2146,13 +2146,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "495"
+      - "482"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:56 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      - W/"d3543a03dedd68a19b60bee1bcd15c7d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2160,9 +2160,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "951"
+      - "962"
       X-Request-Id:
-      - a2e73be3-8f4a-4861-8e37-d70c4e8eb1b2
+      - 5c70b078-c218-4d4b-9be8-3fe16830a7b4
     status: 200 OK
     code: 200
     duration: ""
@@ -2174,17 +2174,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2193,13 +2193,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2492"
+      - "2466"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:56 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"282f51bdb9a8738d34553cfa31352efd"
+      - W/"72f3a308c87956953645f43c975feeba"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2207,9 +2207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "950"
+      - "961"
       X-Request-Id:
-      - 125de940-d6c4-4869-9798-ca1300a193f2
+      - 56cd84f7-68f6-40dc-b95d-fda53bbea79e
     status: 200 OK
     code: 200
     duration: ""
@@ -2221,10 +2221,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"185-199-222-120.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -2239,9 +2239,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:57 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"40e4700975977b320d54253fe3bf4e3a"
+      - W/"c14477dd8b8d2d0e1dc18e3e514e0ad1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2249,9 +2249,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "949"
+      - "960"
       X-Request-Id:
-      - db6f4805-e168-498a-8c24-028777a06a00
+      - 732cc218-650d-4623-a11c-caa914074110
     status: 200 OK
     code: 200
     duration: ""
@@ -2263,12 +2263,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2277,13 +2277,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "718"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:57 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"79d932dcd6664ecec44e46d19267806d"
+      - W/"c459ba6fb15d6664455e29f55da102ec"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2291,9 +2291,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "960"
       X-Request-Id:
-      - 5eb64698-5933-4a3d-ad0b-73a2d7af84b3
+      - 6a978385-03f8-44b6-a10f-c84f6f7b5abc
     status: 200 OK
     code: 200
     duration: ""
@@ -2305,17 +2305,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2324,13 +2324,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2492"
+      - "2466"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:57 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"282f51bdb9a8738d34553cfa31352efd"
+      - W/"72f3a308c87956953645f43c975feeba"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2338,9 +2338,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "947"
+      - "958"
       X-Request-Id:
-      - 46c4f967-a55e-4670-b73c-2d2afac9dec8
+      - 2330c278-1a91-4f45-9d65-5058074ae682
     status: 200 OK
     code: 200
     duration: ""
@@ -2352,12 +2352,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGwwzNt4lemXMJ5t","name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2366,13 +2366,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "361"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:57 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"17480b4ac032f1a1c2518883280c08e4"
+      - W/"c2dce1b7471f5535865fae591a236b34"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2380,9 +2380,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "946"
+      - "957"
       X-Request-Id:
-      - 9794265a-3b40-4a4c-8c2a-041ee69834a8
+      - 54dd1a8e-e77a-4388-8559-29ea1d4a9788
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,12 +2394,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGwwzNt4lemXMJ5t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
-      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGwwzNt4lemXMJ5t","virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana"},"name":"Public
+      Network on tf-acc-test-fast-icy-banana","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:50:cb:af:4a:f4","state":"attached","ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2408,13 +2408,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "495"
+      - "482"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:57 GMT
+      - Thu, 23 Mar 2023 10:55:02 GMT
       Etag:
-      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      - W/"d3543a03dedd68a19b60bee1bcd15c7d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2422,9 +2422,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "945"
+      - "956"
       X-Request-Id:
-      - 6aa57a61-67ab-4397-9c99-5a509e98a815
+      - 283e4659-4ed7-4b8b-83eb-ceade3590420
     status: 200 OK
     code: 200
     duration: ""
@@ -2436,17 +2436,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2455,13 +2455,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2492"
+      - "2466"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:57 GMT
+      - Thu, 23 Mar 2023 10:55:03 GMT
       Etag:
-      - W/"282f51bdb9a8738d34553cfa31352efd"
+      - W/"72f3a308c87956953645f43c975feeba"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2469,9 +2469,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "943"
+      - "954"
       X-Request-Id:
-      - 83d13ad1-2f22-4fbd-9d82-294da7c306f9
+      - de038990-2e3a-400a-b73c-7b48e5f5ce44
     status: 200 OK
     code: 200
     duration: ""
@@ -2483,50 +2483,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:43:57 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "944"
-      X-Request-Id:
-      - 6597861f-888a-47c2-b402-bd8e1ed67fbe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: POST
   response:
-    body: '{"task":{"id":"task_wQhLLRcDpaBHWXLM","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_FJ3r9UbKQE1Vd0j4","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2539,9 +2499,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:57 GMT
+      - Thu, 23 Mar 2023 10:55:03 GMT
       Etag:
-      - W/"0a76465c4cc4a30aa9cfb392cde1cd5e"
+      - W/"024c9789d64bd75639a627229d05af3c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2549,9 +2509,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "942"
+      - "953"
       X-Request-Id:
-      - a6796012-d23c-4ff0-bbe9-5d2f1bef8e18
+      - 2c791b91-fff6-4085-9464-819ad6e61928
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,10 +2523,50 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_wQhLLRcDpaBHWXLM
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:03 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - f5efc723-94a2-40fa-9989-7c34fa6a48f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_FJ3r9UbKQE1Vd0j4
     method: GET
   response:
-    body: '{"task":{"id":"task_wQhLLRcDpaBHWXLM","name":"Stop virtual machine","status":"running","created_at":1679507037,"started_at":1679507038,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_FJ3r9UbKQE1Vd0j4","name":"Stop virtual machine","status":"running","created_at":1679568903,"started_at":1679568903,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2579,9 +2579,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:43:58 GMT
+      - Thu, 23 Mar 2023 10:55:04 GMT
       Etag:
-      - W/"c447402d217ba402d1f0fa5a7b20217f"
+      - W/"ec586eaa666d08932fa70880e0cfb134"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2589,9 +2589,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "952"
       X-Request-Id:
-      - 1c953e73-8708-4586-9ed4-4d89007bca9c
+      - b01591b8-3c6f-4c36-8cc6-4e399ccb7b8b
     status: 200 OK
     code: 200
     duration: ""
@@ -2603,10 +2603,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_wQhLLRcDpaBHWXLM
+    url: https://api.katapult.io/core/v1/tasks/task_FJ3r9UbKQE1Vd0j4
     method: GET
   response:
-    body: '{"task":{"id":"task_wQhLLRcDpaBHWXLM","name":"Stop virtual machine","status":"completed","created_at":1679507037,"started_at":1679507038,"finished_at":1679507040,"progress":100}}'
+    body: '{"task":{"id":"task_FJ3r9UbKQE1Vd0j4","name":"Stop virtual machine","status":"completed","created_at":1679568903,"started_at":1679568903,"finished_at":1679568906,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2619,9 +2619,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:03 GMT
+      - Thu, 23 Mar 2023 10:55:09 GMT
       Etag:
-      - W/"aac8030e132803fe58f0849fba08eeaa"
+      - W/"f6c019cdc4891da8bf6ce78d8d85750c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2629,9 +2629,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "933"
       X-Request-Id:
-      - 7d5e8567-f7e1-4ba9-b3bd-b2a7d7fa1872
+      - 660a1f1c-72da-4fa8-b6ee-9a6b977b7c33
     status: 200 OK
     code: 200
     duration: ""
@@ -2643,17 +2643,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_YVwrUDY3hvPQJ88v","keep_until":1679679843,"object_id":"vm_jmpKAarcgRvploVk","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_BhwJV0aQAQiURzRo","keep_until":1679741709,"object_id":"vm_lFIB5149CLl5vgKZ","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_lFIB5149CLl5vgKZ","name":"tf-acc-test-fast-icy-banana","hostname":"tf-acc-test-fast-icy-banana","fqdn":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568875,"initial_root_password":"CtSg8OKZ2kbsAf43","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_U9UlK0AeOdMthOJ5","address":"185.199.222.98","reverse_dns":"tf-acc-test-fast-icy-banana.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.98/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_lFIB5149CLl5vgKZ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2662,13 +2662,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2627"
+      - "2601"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:03 GMT
+      - Thu, 23 Mar 2023 10:55:09 GMT
       Etag:
-      - W/"2ef288782de65bf6913747d3405aa5f2"
+      - W/"3f5903ee8b37d6856ba6a4ec334021e7"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2676,9 +2676,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "932"
       X-Request-Id:
-      - 4619be9a-bbc5-4134-8a42-de960aba874c
+      - 57e3cec6-b548-41f0-84f5-71f05555bada
     status: 200 OK
     code: 200
     duration: ""
@@ -2690,7 +2690,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: POST
   response:
     body: '{}'
@@ -2706,7 +2706,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:04 GMT
+      - Thu, 23 Mar 2023 10:55:10 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2716,9 +2716,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "931"
       X-Request-Id:
-      - 2979e1c1-36d9-4a80-aa57-1738674c2094
+      - aa7d535c-382e-4e67-b294-88ecd4c687b3
     status: 200 OK
     code: 200
     duration: ""
@@ -2730,10 +2730,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YVwrUDY3hvPQJ88v
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_BhwJV0aQAQiURzRo
     method: DELETE
   response:
-    body: '{"task":{"id":"task_4NvUcQwmVGwUQHIM","name":"Purge items from trash","status":"pending","created_at":1679507044,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_skcVKYcrNkFPWFdN","name":"Purge items from trash","status":"pending","created_at":1679568910,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2746,9 +2746,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:04 GMT
+      - Thu, 23 Mar 2023 10:55:10 GMT
       Etag:
-      - W/"8ef0cb7aa38a285b93948b7df0875167"
+      - W/"a6ec111fc682dfcc59666112b94663b8"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2756,9 +2756,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "930"
       X-Request-Id:
-      - a69a28d6-4803-425c-98e5-06889567f60a
+      - 17c6fd48-1a02-4230-a5cf-b7f2b8c2e6dd
     status: 200 OK
     code: 200
     duration: ""
@@ -2770,10 +2770,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YVwrUDY3hvPQJ88v
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_BhwJV0aQAQiURzRo
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_YVwrUDY3hvPQJ88v","keep_until":1679679843,"object_id":"vm_jmpKAarcgRvploVk","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_BhwJV0aQAQiURzRo","keep_until":1679741709,"object_id":"vm_lFIB5149CLl5vgKZ","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2786,9 +2786,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:05 GMT
+      - Thu, 23 Mar 2023 10:55:11 GMT
       Etag:
-      - W/"19a531297700864a047d681e28a2f40d"
+      - W/"24f0e42af1024d1e423cc69776d9626a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2796,9 +2796,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "929"
       X-Request-Id:
-      - f67136da-5c70-4ad3-8cc3-c9f906a1fabf
+      - a7483957-e090-4bd2-b285-b367c2330374
     status: 200 OK
     code: 200
     duration: ""
@@ -2810,7 +2810,87 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YVwrUDY3hvPQJ88v
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_BhwJV0aQAQiURzRo
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_BhwJV0aQAQiURzRo","keep_until":1679741709,"object_id":"vm_lFIB5149CLl5vgKZ","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:16 GMT
+      Etag:
+      - W/"24f0e42af1024d1e423cc69776d9626a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "921"
+      X-Request-Id:
+      - f251b073-0fcf-4461-ab8f-57674f884450
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_BhwJV0aQAQiURzRo
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_BhwJV0aQAQiURzRo","keep_until":1679741709,"object_id":"vm_lFIB5149CLl5vgKZ","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:26 GMT
+      Etag:
+      - W/"24f0e42af1024d1e423cc69776d9626a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "904"
+      X-Request-Id:
+      - 7c132ffc-ef29-44f8-943e-dc44194b40a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_BhwJV0aQAQiURzRo
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2827,7 +2907,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:10 GMT
+      - Thu, 23 Mar 2023 10:55:36 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2837,9 +2917,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "899"
       X-Request-Id:
-      - 0c8b62c6-78a7-4182-bc67-015a39f4dc08
+      - d3834815-bb81-4a34-9f24-a0cd21ceaec2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2851,7 +2931,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: DELETE
   response:
     body: '{}'
@@ -2867,7 +2947,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:11 GMT
+      - Thu, 23 Mar 2023 10:55:36 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2877,9 +2957,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "898"
       X-Request-Id:
-      - c25fdab2-2363-4960-8935-95893c7c2f34
+      - d385b013-dd9f-4f5a-b347-060af96ed5b7
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,7 +2971,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_lFIB5149CLl5vgKZ
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2908,7 +2988,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:11 GMT
+      - Thu, 23 Mar 2023 10:55:36 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2918,9 +2998,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "897"
       X-Request-Id:
-      - eb1bb80d-b8e7-44a2-ad44-ca951c734f9d
+      - daa9ad32-3cf5-4114-9778-0f721ddffcf2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2932,7 +3012,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_lFIB5149CLl5vgKZ
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:36 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "896"
+      X-Request-Id:
+      - 370957b3-1fe2-4b41-9e9f-29a4b3094caa
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2949,7 +3070,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:11 GMT
+      - Thu, 23 Mar 2023 10:55:36 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2959,9 +3080,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "895"
       X-Request-Id:
-      - 88c4fa1d-aa24-4b48-b1e6-ef1db7d88e1c
+      - 20eb2b5b-6a5d-4016-9353-cc70b02225ac
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2973,7 +3094,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_U9UlK0AeOdMthOJ5
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2990,7 +3111,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:44:11 GMT
+      - Thu, 23 Mar 2023 10:55:36 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -3000,9 +3121,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "894"
       X-Request-Id:
-      - b9d4a99d-1c03-446a-aed9-6be2731e062e
+      - 69f0b096-26d3-49e8-b2d7-ba5036ef1416
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_ips.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_ips.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:43:27 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "800"
+      - "999"
       X-Request-Id:
-      - b8522c38-6ae3-4ad4-886a-b75954725f7f
+      - fc5bbc45-b1e5-4779-bac7-bf89e975bdcd
     status: 200 OK
     code: 200
     duration: ""
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"185-199-222-238.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"185-199-222-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -70,9 +70,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:43:30 GMT
       Etag:
-      - W/"da896ea2082a872e05ac7030f2151ede"
+      - W/"e0788f5c5041aa9d58b3366e98789623"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "799"
+      - "998"
       X-Request-Id:
-      - f517b3d6-3348-4b51-80cf-406b4950577b
+      - 01e0490b-f448-41ac-b2d0-affe0291d26c
     status: 200 OK
     code: 200
     duration: ""
@@ -94,10 +94,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"185-199-222-238.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"185-199-222-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -112,9 +112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:43:30 GMT
       Etag:
-      - W/"8af94df87e3760eb2c77da699d9a7007"
+      - W/"099ea7765f3a652616e2a40ad38ab29f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -122,9 +122,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "798"
+      - "997"
       X-Request-Id:
-      - 2d3e0a9a-7176-4114-84c8-0dfdee088152
+      - 18aa925c-064f-47f9-8500-34142016ff5e
     status: 200 OK
     code: 200
     duration: ""
@@ -136,10 +136,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"185-199-222-238.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"185-199-222-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -154,9 +154,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:43:30 GMT
       Etag:
-      - W/"8af94df87e3760eb2c77da699d9a7007"
+      - W/"099ea7765f3a652616e2a40ad38ab29f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -164,15 +164,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "797"
+      - "996"
       X-Request-Id:
-      - 241a05b3-f13b-431c-ab41-772f31a0cbe5
+      - a6914e89-8b74-4b1e-b5a6-d1f60b4f3e1c
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_lMARBMFBAmCoffcW</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-rapid-quiet-copper</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_RwFCDb3XqBvIb12H</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-salty-early-dandelion</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_f4cAckPFI7BkvUfs","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_J4oADyclZuULPY98","state":"pending"},"virtual_machine_build":{"id":"vmbuild_J4oADyclZuULPY98","state":"pending"},"hostname":"tf-acc-test-rapid-quiet-copper"}'
+    body: '{"task":{"id":"task_d0ndKQjlDe2m3wXg","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","state":"pending"},"virtual_machine_build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","state":"pending"},"hostname":"tf-acc-test-salty-early-dandelion"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -193,13 +193,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "269"
+      - "272"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:45 GMT
+      - Wed, 22 Mar 2023 17:43:30 GMT
       Etag:
-      - W/"4fda6ff9c07a3a86d9e77263c4dad974"
+      - W/"d3460af7a4c9784dc519e1a9d35e4517"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -207,9 +207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "796"
+      - "995"
       X-Request-Id:
-      - 9dc606e3-0bb0-445e-9120-dd2bc92bbf26
+      - ae19141d-f0da-47ce-a260-60b24a7a082f
     status: 201 Created
     code: 201
     duration: ""
@@ -221,17 +221,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_J4oADyclZuULPY98
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Wm2iVhorqYcAnTNF
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_J4oADyclZuULPY98","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.238\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-rapid-quiet-copper\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-salty-early-dandelion\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031225}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679507010}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -240,154 +240,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1581"
+      - "1384"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:13:47 GMT
+      - Wed, 22 Mar 2023 17:43:32 GMT
       Etag:
-      - W/"77dc24a67ab46b05d70763245ee51d64"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "792"
-      X-Request-Id:
-      - 2816aa7b-d35a-4cb0-ad2d-27757525ce81
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_J4oADyclZuULPY98
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_J4oADyclZuULPY98","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.238\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-rapid-quiet-copper\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1676031225}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1581"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:13:52 GMT
-      Etag:
-      - W/"77dc24a67ab46b05d70763245ee51d64"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "788"
-      X-Request-Id:
-      - a5ead60d-a282-4996-8678-55b476e62cf6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_J4oADyclZuULPY98
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_J4oADyclZuULPY98","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.238\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-rapid-quiet-copper\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1676031225}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1581"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:02 GMT
-      Etag:
-      - W/"b47aaca1f43aeb7c6c43822c7fe7300d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 9f4f7a36-6ddd-46b0-81a3-d2ac49de3ce4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2155"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:04 GMT
-      Etag:
-      - W/"4025bd0ceae9b6a89efa29cbf1652fc6"
+      - W/"9ceb13c5bf2db68e07c438d2a76cac2e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -397,7 +256,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "994"
       X-Request-Id:
-      - 676aedf3-52c8-4001-aea0-de23667c879f
+      - 347fa857-c5ab-48f1-9d55-024f1120cda5
     status: 200 OK
     code: 200
     duration: ""
@@ -409,17 +268,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Wm2iVhorqYcAnTNF
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-salty-early-dandelion\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679507010}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -428,13 +287,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2155"
+      - "1593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:04 GMT
+      - Wed, 22 Mar 2023 17:43:38 GMT
       Etag:
-      - W/"4025bd0ceae9b6a89efa29cbf1652fc6"
+      - W/"a5d5c04584f3f1b587a5e8c3c4f44884"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -444,7 +303,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "993"
       X-Request-Id:
-      - 39062b0b-733f-41ed-89ce-7b3ddc560a7a
+      - f4c98c7d-2908-491b-aa74-9b21a2ff87dc
     status: 200 OK
     code: 200
     duration: ""
@@ -456,12 +315,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Wm2iVhorqYcAnTNF
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_Wm2iVhorqYcAnTNF","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-salty-early-dandelion\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679507010}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -470,13 +334,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "358"
+      - "1593"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:04 GMT
+      - Wed, 22 Mar 2023 17:43:48 GMT
       Etag:
-      - W/"6652eecec9ae4d86bfaa14e6e81725af"
+      - W/"235ddc1a8a5d5e8b96ceaa306d97010b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -486,7 +350,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "992"
       X-Request-Id:
-      - 362ca2ec-f072-4cc0-9bee-ca3f32bb62fb
+      - fb7e1cf5-9a35-4e93-967d-01ac7f94a602
     status: 200 OK
     code: 200
     duration: ""
@@ -498,12 +362,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q1be3npOPebt6qJm
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -512,13 +381,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "489"
+      - "2208"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:04 GMT
+      - Wed, 22 Mar 2023 17:43:50 GMT
       Etag:
-      - W/"c42696504605e9ecfdca1c788f7cf325"
+      - W/"d4ffe09611b05b33badda32b1624d4f1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -528,7 +397,138 @@ interactions:
       X-Ratelimit-Remaining:
       - "991"
       X-Request-Id:
-      - 7f462a64-73fd-4ea5-a75a-7a1f0b4b0057
+      - d866d59f-5815-4197-9c33-7636e625c860
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2208"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:50 GMT
+      Etag:
+      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 7ef3b16e-b4aa-4460-bad6-f1f43c675663
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "361"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:50 GMT
+      Etag:
+      - W/"17480b4ac032f1a1c2518883280c08e4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 60dbdfb0-fd69-4cbe-b84c-1f36d29ecb9e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "495"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:50 GMT
+      Etag:
+      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 9cd84ac4-24db-4db0-81fc-6a318af5a863
     status: 200 OK
     code: 200
     duration: ""
@@ -540,17 +540,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -559,144 +559,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2155"
+      - "2208"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
+      - Wed, 22 Mar 2023 17:43:50 GMT
       Etag:
-      - W/"4025bd0ceae9b6a89efa29cbf1652fc6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - e2136ef3-f245-4bc4-84eb-e2b0591920e1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "726"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
-      Etag:
-      - W/"d6153c9c5d2b371f63473332842806d7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - 1b3a1e00-4596-489d-b67e-8cc7e4b14c64
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2155"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
-      Etag:
-      - W/"4025bd0ceae9b6a89efa29cbf1652fc6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - 4ca3827f-507b-4e64-a1b7-7be98d007743
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "358"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
-      Etag:
-      - W/"6652eecec9ae4d86bfaa14e6e81725af"
+      - W/"d4ffe09611b05b33badda32b1624d4f1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -706,7 +575,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - 6ccfc5a9-0e08-4f26-8036-246ef16aca4e
+      - e2843080-4846-499a-a430-84641c9d8e3f
     status: 200 OK
     code: 200
     duration: ""
@@ -718,12 +587,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q1be3npOPebt6qJm
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -732,13 +601,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "489"
+      - "732"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
+      - Wed, 22 Mar 2023 17:43:50 GMT
       Etag:
-      - W/"c42696504605e9ecfdca1c788f7cf325"
+      - W/"79d932dcd6664ecec44e46d19267806d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -748,7 +617,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - 9c643a1b-17f9-473a-b0b9-8b074e93782f
+      - 2be170a1-99d5-42ae-8775-7678fbc5876e
     status: 200 OK
     code: 200
     duration: ""
@@ -760,12 +629,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -774,13 +648,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "726"
+      - "2208"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
+      - Wed, 22 Mar 2023 17:43:50 GMT
       Etag:
-      - W/"d6153c9c5d2b371f63473332842806d7"
+      - W/"d4ffe09611b05b33badda32b1624d4f1"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -790,7 +664,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - d33f22b8-e679-4a67-9889-6d765c0085b4
+      - 460d5c1d-bc13-4761-97bb-41ef213a03a7
     status: 200 OK
     code: 200
     duration: ""
@@ -802,17 +676,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -821,13 +690,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2155"
+      - "361"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
+      - Wed, 22 Mar 2023 17:43:50 GMT
       Etag:
-      - W/"4025bd0ceae9b6a89efa29cbf1652fc6"
+      - W/"17480b4ac032f1a1c2518883280c08e4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -837,7 +706,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "984"
       X-Request-Id:
-      - 661f52ec-81d7-4b83-8e88-7886cacab23d
+      - e461ef57-623b-455e-b3ed-7d34f7f200ce
     status: 200 OK
     code: 200
     duration: ""
@@ -849,12 +718,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -863,13 +732,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "358"
+      - "495"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
+      - Wed, 22 Mar 2023 17:43:50 GMT
       Etag:
-      - W/"6652eecec9ae4d86bfaa14e6e81725af"
+      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -879,7 +748,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "983"
       X-Request-Id:
-      - fc290f6a-5e87-43b2-83cc-d61e927b55be
+      - 8381764d-192a-4bf1-9e72-bde463de8f2e
     status: 200 OK
     code: 200
     duration: ""
@@ -891,12 +760,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q1be3npOPebt6qJm
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -905,13 +774,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "489"
+      - "732"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:05 GMT
+      - Wed, 22 Mar 2023 17:43:50 GMT
       Etag:
-      - W/"c42696504605e9ecfdca1c788f7cf325"
+      - W/"79d932dcd6664ecec44e46d19267806d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -921,7 +790,138 @@ interactions:
       X-Ratelimit-Remaining:
       - "982"
       X-Request-Id:
-      - 35437183-4567-4aff-9a93-f1703aeb2704
+      - cc1fe2b2-78a3-472b-8579-8201a4d08829
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2208"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:50 GMT
+      Etag:
+      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 0a24c1c7-1720-41d5-aef9-97f068f7a997
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "361"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:50 GMT
+      Etag:
+      - W/"17480b4ac032f1a1c2518883280c08e4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - 38d029af-0b64-4770-82ee-b7444bf64781
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "495"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:50 GMT
+      Etag:
+      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 547368b1-57db-430f-9020-5eeb9d8cac98
     status: 200 OK
     code: 200
     duration: ""
@@ -949,7 +949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
+      - Wed, 22 Mar 2023 17:43:51 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -959,9 +959,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "981"
+      - "978"
       X-Request-Id:
-      - 76bb5f21-a024-4ea3-ad5a-923a3efda9ab
+      - b2941369-328d-4cf7-b4ef-8cda6bec3977
     status: 200 OK
     code: 200
     duration: ""
@@ -979,7 +979,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"185-199-222-20.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"185-199-222-120.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -990,144 +990,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "552"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
+      - Wed, 22 Mar 2023 17:43:54 GMT
       Etag:
-      - W/"24e9f3fdf3002e0fc99e72783589e420"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - dcfdf758-f9a7-4a3e-8bbb-0f9b0245ed1a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_c6xuC4Qqvwk3oz5j
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"185-199-222-20.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
-      Etag:
-      - W/"ec62ecf63b5f5b5f70d25bffcab34d7c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - d3641bfc-d16e-4a63-9b10-ee6942444ce6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2155"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
-      Etag:
-      - W/"4025bd0ceae9b6a89efa29cbf1652fc6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "978"
-      X-Request-Id:
-      - 77f78314-3bd7-4b8b-b50e-e2a174d1c35f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "359"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
-      Etag:
-      - W/"49f3c46ca3f60eb576a77ec085ccbb46"
+      - W/"3ce3da3a89230c900adcf68ea917e465"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1137,7 +1006,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "977"
       X-Request-Id:
-      - 9b32c852-87ef-45bc-952c-4fbe256c2108
+      - 0d78fcde-9894-42b8-8019-903bb0f6f125
     status: 200 OK
     code: 200
     duration: ""
@@ -1149,10 +1018,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_c6xuC4Qqvwk3oz5j
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"185-199-222-20.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"185-199-222-120.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -1163,13 +1032,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
+      - Wed, 22 Mar 2023 17:43:54 GMT
       Etag:
-      - W/"ec62ecf63b5f5b5f70d25bffcab34d7c"
+      - W/"40e4700975977b320d54253fe3bf4e3a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1179,13 +1048,144 @@ interactions:
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - 857a6764-4bec-4daa-8798-055e5644a4e6
+      - 21d79be8-b60a-4083-bafa-1a22fdbcf1ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2208"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:54 GMT
+      Etag:
+      - W/"d4ffe09611b05b33badda32b1624d4f1"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 590bf8fb-d2ec-46ca-a7d2-430a9e4f8776
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "362"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:54 GMT
+      Etag:
+      - W/"fda32f205223e39c51aff171653e47bd"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 06bc5074-90a8-4359-a4ff-20de1d8d120a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"185-199-222-120.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:54 GMT
+      Etag:
+      - W/"40e4700975977b320d54253fe3bf4e3a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 0454a3c8-74fb-4624-818f-ee85ab683c0e
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm"},"ip_address":{"id":"ip_c6xuC4Qqvwk3oz5j"}}
+      {"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV"},"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW"}}
     form: {}
     headers:
       Accept:
@@ -1197,9 +1197,9 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/allocate_ip
     method: POST
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1208,13 +1208,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "462"
+      - "469"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
+      - Wed, 22 Mar 2023 17:43:54 GMT
       Etag:
-      - W/"48c73dafab2b215ee1c538643c31c8ef"
+      - W/"e39c03531c2015e429ca15d430ee9b03"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1222,15 +1222,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "972"
       X-Request-Id:
-      - c69f90f5-d2a5-47f5-ada0-03b993e5bfdd
+      - 0dbfebf3-3caf-4e1c-adc3-a6773dc8810d
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj"},"properties":{}}
+      {"virtual_machine":{"id":"vm_jmpKAarcgRvploVk"},"properties":{}}
     form: {}
     headers:
       Accept:
@@ -1242,16 +1242,16 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1260,146 +1260,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2749"
+      - "2807"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
+      - Wed, 22 Mar 2023 17:43:54 GMT
       Etag:
-      - W/"be2bb7a32888f9738dd51e90b3a93373"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - 4815defa-d306-49fc-a543-f480e1290876
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2749"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
-      Etag:
-      - W/"be2bb7a32888f9738dd51e90b3a93373"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "973"
-      X-Request-Id:
-      - 2a8595eb-2381-4c2a-b306-0dd1ac763d34
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "414"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
-      Etag:
-      - W/"bc53795daf0441afbd26b0b107933c1c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "972"
-      X-Request-Id:
-      - fc6223e9-af19-480e-a2ba-9609fb26f4c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q1be3npOPebt6qJm
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "545"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:06 GMT
-      Etag:
-      - W/"ab0f7d713d16e81ed18daa2b9611d246"
+      - W/"6d36958792b1534714f226ad2db1d6ce"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1409,7 +1276,140 @@ interactions:
       X-Ratelimit-Remaining:
       - "971"
       X-Request-Id:
-      - b1b9dbf9-2894-4da6-9e49-fc5350d0f1a6
+      - bbed7bfd-8e5a-4eb6-95ca-5a744545be3e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2807"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:54 GMT
+      Etag:
+      - W/"6d36958792b1534714f226ad2db1d6ce"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - 7ecbe8bc-6e71-47fd-8eb9-bcd1b7654139
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "418"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:54 GMT
+      Etag:
+      - W/"9859472b89c06c30d1c8e6ca1a8fad4d"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 6e9a0dc6-cc96-4021-968e-0726f6ce50b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "552"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:55 GMT
+      Etag:
+      - W/"eeca8360336ad568404d219a8407d118"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - 70d0acdb-9452-4a4d-af15-c13786b0b888
     status: 200 OK
     code: 200
     duration: ""
@@ -1421,19 +1421,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1442,146 +1442,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2749"
+      - "2807"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"be2bb7a32888f9738dd51e90b3a93373"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "970"
-      X-Request-Id:
-      - bbb5c85c-1be2-4537-ac5f-2ad751a8b5b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_c6xuC4Qqvwk3oz5j
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "724"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
-      Etag:
-      - W/"3b4491ae89de05f19d6bc1f10b47e924"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - 7aa1783b-9ace-41c1-8f2f-2b478fb510a9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "726"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
-      Etag:
-      - W/"d6153c9c5d2b371f63473332842806d7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "968"
-      X-Request-Id:
-      - fa019b1e-867c-4a77-a7c1-54b5e946f61e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2749"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
-      Etag:
-      - W/"be2bb7a32888f9738dd51e90b3a93373"
+      - W/"6d36958792b1534714f226ad2db1d6ce"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1591,7 +1458,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "967"
       X-Request-Id:
-      - 0b4ed636-104c-4e74-81d2-281205e835de
+      - 1efa6b2c-d63a-4bad-b867-378e599d29bc
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,12 +1470,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
+    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1617,13 +1484,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "414"
+      - "732"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"bc53795daf0441afbd26b0b107933c1c"
+      - W/"c308c320c02d50fd46d6c50b0ed276cb"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1633,7 +1500,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "966"
       X-Request-Id:
-      - b511f933-919b-4a67-b3b3-26b0d959dc32
+      - fc4820b0-12f9-4bf0-8b3e-4215dd17ab4b
     status: 200 OK
     code: 200
     duration: ""
@@ -1645,12 +1512,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q1be3npOPebt6qJm
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1659,13 +1526,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "545"
+      - "732"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"ab0f7d713d16e81ed18daa2b9611d246"
+      - W/"79d932dcd6664ecec44e46d19267806d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1673,9 +1540,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "966"
       X-Request-Id:
-      - 6749680c-fffc-4b91-b0cf-93b280895b21
+      - b5725b14-27ce-4d91-94e8-4a779dc791fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1687,12 +1554,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1701,13 +1575,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "726"
+      - "2807"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"d6153c9c5d2b371f63473332842806d7"
+      - W/"6d36958792b1534714f226ad2db1d6ce"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1717,7 +1591,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "964"
       X-Request-Id:
-      - f51644fb-ba03-4a3a-bbb0-7b8b661d82a3
+      - ead9ddbc-bbbf-4509-9002-01d6b53e44ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,12 +1603,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_c6xuC4Qqvwk3oz5j
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1743,13 +1617,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "724"
+      - "418"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"3b4491ae89de05f19d6bc1f10b47e924"
+      - W/"9859472b89c06c30d1c8e6ca1a8fad4d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1759,7 +1633,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "963"
       X-Request-Id:
-      - 8f71b542-6f0d-4c2d-b131-e48cc62c316c
+      - 66e2c569-14b3-42cf-aee1-ee683316fba3
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,19 +1645,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1792,13 +1659,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2749"
+      - "552"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"be2bb7a32888f9738dd51e90b3a93373"
+      - W/"eeca8360336ad568404d219a8407d118"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1808,7 +1675,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "962"
       X-Request-Id:
-      - d62bc66d-0ac7-482e-9f75-f2782fed1e78
+      - 4f924719-5f3f-4896-bdb3-dc6c67ac008d
     status: 200 OK
     code: 200
     duration: ""
@@ -1820,12 +1687,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
+    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1834,13 +1701,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "414"
+      - "732"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"bc53795daf0441afbd26b0b107933c1c"
+      - W/"c308c320c02d50fd46d6c50b0ed276cb"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1850,7 +1717,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "961"
       X-Request-Id:
-      - 52161a76-c26d-40d8-8fcb-2c5577f73957
+      - 84d53785-2f01-45f8-ae55-11f114a05b7e
     status: 200 OK
     code: 200
     duration: ""
@@ -1862,12 +1729,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q1be3npOPebt6qJm
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1876,13 +1743,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "545"
+      - "732"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:07 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"ab0f7d713d16e81ed18daa2b9611d246"
+      - W/"79d932dcd6664ecec44e46d19267806d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1890,9 +1757,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "961"
       X-Request-Id:
-      - 579dc1fe-4daf-48d7-85d1-441f00648d07
+      - 185f6712-938f-4261-856b-137db4ab6aa9
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,19 +1771,19 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1925,13 +1792,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2749"
+      - "2807"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:08 GMT
+      - Wed, 22 Mar 2023 17:43:55 GMT
       Etag:
-      - W/"be2bb7a32888f9738dd51e90b3a93373"
+      - W/"6d36958792b1534714f226ad2db1d6ce"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1941,7 +1808,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "959"
       X-Request-Id:
-      - 22ccb9a5-db6d-4a9e-835a-e543a8637c79
+      - 0ec1be1b-78e7-4c55-818d-721b2ee0271c
     status: 200 OK
     code: 200
     duration: ""
@@ -1953,7 +1820,140 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_c6xuC4Qqvwk3oz5j
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "418"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:55 GMT
+      Etag:
+      - W/"9859472b89c06c30d1c8e6ca1a8fad4d"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - 9306b876-3951-49ec-af27-c708a10013c2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "552"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:55 GMT
+      Etag:
+      - W/"eeca8360336ad568404d219a8407d118"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - e4a0004f-785c-4a01-a938-4a9f603c75e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2807"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:56 GMT
+      Etag:
+      - W/"6d36958792b1534714f226ad2db1d6ce"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 5eb1482e-e1e5-4fe7-a2f8-c7471ffd5e6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
     method: POST
   response:
     body: '{}'
@@ -1969,7 +1969,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:08 GMT
+      - Wed, 22 Mar 2023 17:43:56 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -1979,15 +1979,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "955"
       X-Request-Id:
-      - 71a1c2a6-d914-490b-93f2-b71303881147
+      - 4539ccab-b01e-404c-886b-5c97ce618e50
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj"},"properties":{"tag_names":["lb","app","web"]}}
+      {"virtual_machine":{"id":"vm_jmpKAarcgRvploVk"},"properties":{"tag_names":["lb","app","web"]}}
     form: {}
     headers:
       Accept:
@@ -1999,14 +1999,14 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2015,144 +2015,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2439"
+      - "2492"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:08 GMT
+      - Wed, 22 Mar 2023 17:43:56 GMT
       Etag:
-      - W/"24122186e572bcaf45a0f414ed88659e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "957"
-      X-Request-Id:
-      - 205ab450-a0bc-4951-a16d-dd93e5779362
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2439"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:08 GMT
-      Etag:
-      - W/"24122186e572bcaf45a0f414ed88659e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "956"
-      X-Request-Id:
-      - caa1f899-8cd0-4808-8a31-10ed7fcb56b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "358"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:08 GMT
-      Etag:
-      - W/"6652eecec9ae4d86bfaa14e6e81725af"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "955"
-      X-Request-Id:
-      - 08e4d803-a96d-4d6c-b6e9-92c8462cc2ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q1be3npOPebt6qJm
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "489"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:08 GMT
-      Etag:
-      - W/"c42696504605e9ecfdca1c788f7cf325"
+      - W/"282f51bdb9a8738d34553cfa31352efd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2162,7 +2031,138 @@ interactions:
       X-Ratelimit-Remaining:
       - "954"
       X-Request-Id:
-      - 89c77807-2ab4-4fb3-bd49-04c91d1b7219
+      - a2b41f46-c228-439c-b6ee-ec6de63766ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2492"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:56 GMT
+      Etag:
+      - W/"282f51bdb9a8738d34553cfa31352efd"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "953"
+      X-Request-Id:
+      - aa62e3ad-8385-4355-9efd-87c903d6d420
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "361"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:56 GMT
+      Etag:
+      - W/"17480b4ac032f1a1c2518883280c08e4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - d68cdc0d-802f-491e-b29a-97a2d8ecae6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "495"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:56 GMT
+      Etag:
+      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "951"
+      X-Request-Id:
+      - a2e73be3-8f4a-4861-8e37-d70c4e8eb1b2
     status: 200 OK
     code: 200
     duration: ""
@@ -2174,17 +2174,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2193,13 +2193,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2439"
+      - "2492"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:08 GMT
+      - Wed, 22 Mar 2023 17:43:56 GMT
       Etag:
-      - W/"24122186e572bcaf45a0f414ed88659e"
+      - W/"282f51bdb9a8738d34553cfa31352efd"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2207,9 +2207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "950"
       X-Request-Id:
-      - 01dacd09-fb7c-45ff-b128-1b9a6da84f15
+      - 125de940-d6c4-4869-9798-ca1300a193f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2221,10 +2221,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_c6xuC4Qqvwk3oz5j
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_c6xuC4Qqvwk3oz5j","address":"185.199.222.20","reverse_dns":"185-199-222-20.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.20/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_gulJ8ggq8JhG1ksW","address":"185.199.222.120","reverse_dns":"185-199-222-120.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.120/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -2235,144 +2235,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:09 GMT
+      - Wed, 22 Mar 2023 17:43:57 GMT
       Etag:
-      - W/"ec62ecf63b5f5b5f70d25bffcab34d7c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - 65fb4db8-2328-40df-9403-e5f0538ad67e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "726"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:09 GMT
-      Etag:
-      - W/"d6153c9c5d2b371f63473332842806d7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - 9571448b-e8d2-4212-88ef-6019e23b79f5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2439"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:09 GMT
-      Etag:
-      - W/"24122186e572bcaf45a0f414ed88659e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - 9488d435-6ef1-4253-a718-eb51b37faee7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Q1be3npOPebt6qJm","name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "358"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:09 GMT
-      Etag:
-      - W/"6652eecec9ae4d86bfaa14e6e81725af"
+      - W/"40e4700975977b320d54253fe3bf4e3a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2382,7 +2251,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "949"
       X-Request-Id:
-      - e7b5e27c-b36e-4a8d-ab65-fdf8eb1a2f46
+      - db6f4805-e168-498a-8c24-028777a06a00
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,12 +2263,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Q1be3npOPebt6qJm
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_Q1be3npOPebt6qJm","virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper"},"name":"Public
-      Network on tf-acc-test-rapid-quiet-copper","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:6e:82:dc:5f:22","state":"attached","ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2408,13 +2277,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "489"
+      - "732"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:09 GMT
+      - Wed, 22 Mar 2023 17:43:57 GMT
       Etag:
-      - W/"c42696504605e9ecfdca1c788f7cf325"
+      - W/"79d932dcd6664ecec44e46d19267806d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2424,7 +2293,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "948"
       X-Request-Id:
-      - 752b92c9-822a-4aff-b03e-c60416937ff9
+      - 5eb64698-5933-4a3d-ad0b-73a2d7af84b3
     status: 200 OK
     code: 200
     duration: ""
@@ -2436,17 +2305,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2455,13 +2324,55 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2439"
+      - "2492"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:09 GMT
+      - Wed, 22 Mar 2023 17:43:57 GMT
       Etag:
-      - W/"24122186e572bcaf45a0f414ed88659e"
+      - W/"282f51bdb9a8738d34553cfa31352efd"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - 46c4f967-a55e-4670-b73c-2d2afac9dec8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_KOj2SHT5s3LaUvGV","name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "361"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:57 GMT
+      Etag:
+      - W/"17480b4ac032f1a1c2518883280c08e4"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2471,7 +2382,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "946"
       X-Request-Id:
-      - a58f564f-1734-4276-a216-f9baa5228c80
+      - 9794265a-3b40-4a4c-8c2a-041ee69834a8
     status: 200 OK
     code: 200
     duration: ""
@@ -2483,10 +2394,139 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_KOj2SHT5s3LaUvGV
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_KOj2SHT5s3LaUvGV","virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion"},"name":"Public
+      Network on tf-acc-test-salty-early-dandelion","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:59:18:50:5a:1d","state":"attached","ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "495"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:57 GMT
+      Etag:
+      - W/"1b1aca15e5b2ec1d2b32ff6ccbe01144"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 6aa57a61-67ab-4397-9c99-5a509e98a815
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2492"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:57 GMT
+      Etag:
+      - W/"282f51bdb9a8738d34553cfa31352efd"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - 83d13ad1-2f22-4fbd-9d82-294da7c306f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:43:57 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - 6597861f-888a-47c2-b402-bd8e1ed67fbe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: POST
   response:
-    body: '{"task":{"id":"task_ljJ0sOeROYM3jWZ5","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_wQhLLRcDpaBHWXLM","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2499,9 +2539,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:09 GMT
+      - Wed, 22 Mar 2023 17:43:57 GMT
       Etag:
-      - W/"76c0a60e59cc31de5681024ab148f129"
+      - W/"0a76465c4cc4a30aa9cfb392cde1cd5e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2509,9 +2549,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "943"
+      - "942"
       X-Request-Id:
-      - e4af75c3-67d4-4a53-a63e-cd6cfd84f111
+      - a6796012-d23c-4ff0-bbe9-5d2f1bef8e18
     status: 200 OK
     code: 200
     duration: ""
@@ -2523,10 +2563,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_ljJ0sOeROYM3jWZ5
+    url: https://api.katapult.io/core/v1/tasks/task_wQhLLRcDpaBHWXLM
     method: GET
   response:
-    body: '{"task":{"id":"task_ljJ0sOeROYM3jWZ5","name":"Stop virtual machine","status":"pending","created_at":1676031249,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_wQhLLRcDpaBHWXLM","name":"Stop virtual machine","status":"running","created_at":1679507037,"started_at":1679507038,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2535,13 +2575,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "162"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:10 GMT
+      - Wed, 22 Mar 2023 17:43:58 GMT
       Etag:
-      - W/"f6c92eff798bb11f05492cf82d230ca7"
+      - W/"c447402d217ba402d1f0fa5a7b20217f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2549,9 +2589,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "931"
+      - "941"
       X-Request-Id:
-      - c8ab0860-2f5f-409d-916c-41e31a0fe7c8
+      - 1c953e73-8708-4586-9ed4-4d89007bca9c
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,130 +2603,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_c6xuC4Qqvwk3oz5j
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:11 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "947"
-      X-Request-Id:
-      - ea750599-b37a-4f24-b4d9-35aee6785b57
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_ljJ0sOeROYM3jWZ5
+    url: https://api.katapult.io/core/v1/tasks/task_wQhLLRcDpaBHWXLM
     method: GET
   response:
-    body: '{"task":{"id":"task_ljJ0sOeROYM3jWZ5","name":"Stop virtual machine","status":"pending","created_at":1676031249,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:15 GMT
-      Etag:
-      - W/"f6c92eff798bb11f05492cf82d230ca7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "889"
-      X-Request-Id:
-      - 0eaaceff-dcde-47f2-9b08-b3efee7b0158
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_ljJ0sOeROYM3jWZ5
-    method: GET
-  response:
-    body: '{"task":{"id":"task_ljJ0sOeROYM3jWZ5","name":"Stop virtual machine","status":"running","created_at":1676031249,"started_at":1676031264,"finished_at":null,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "170"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:25 GMT
-      Etag:
-      - W/"9f8a1c2afd55316840c9ea693ad58544"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "835"
-      X-Request-Id:
-      - 29e0c944-b0f2-4e19-a326-af4f33026211
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_ljJ0sOeROYM3jWZ5
-    method: GET
-  response:
-    body: '{"task":{"id":"task_ljJ0sOeROYM3jWZ5","name":"Stop virtual machine","status":"completed","created_at":1676031249,"started_at":1676031264,"finished_at":1676031266,"progress":100}}'
+    body: '{"task":{"id":"task_wQhLLRcDpaBHWXLM","name":"Stop virtual machine","status":"completed","created_at":1679507037,"started_at":1679507038,"finished_at":1679507040,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2699,9 +2619,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:35 GMT
+      - Wed, 22 Mar 2023 17:44:03 GMT
       Etag:
-      - W/"4d48efbf65b57a41ae936ee98014f6b2"
+      - W/"aac8030e132803fe58f0849fba08eeaa"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2709,9 +2629,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "820"
+      - "999"
       X-Request-Id:
-      - 0c1fed52-b75d-490d-809f-3c3a77daf336
+      - 7d5e8567-f7e1-4ba9-b3bd-b2a7d7fa1872
     status: 200 OK
     code: 200
     duration: ""
@@ -2723,17 +2643,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_fkxrzRBRvTNyh13X","keep_until":1676204075,"object_id":"vm_TxqF5aTawY5VNrmj","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_TxqF5aTawY5VNrmj","name":"tf-acc-test-rapid-quiet-copper","hostname":"tf-acc-test-rapid-quiet-copper","fqdn":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","description":null,"created_at":1676031226,"initial_root_password":"icfZ7OLnmQUX4nZY","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_YVwrUDY3hvPQJ88v","keep_until":1679679843,"object_id":"vm_jmpKAarcgRvploVk","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_jmpKAarcgRvploVk","name":"tf-acc-test-salty-early-dandelion","hostname":"tf-acc-test-salty-early-dandelion","fqdn":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","description":null,"created_at":1679507012,"initial_root_password":"5s10wJeWKkUCM47r","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_lMARBMFBAmCoffcW","address":"185.199.222.238","reverse_dns":"tf-acc-test-rapid-quiet-copper.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.238/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_RwFCDb3XqBvIb12H","address":"185.199.222.172","reverse_dns":"tf-acc-test-salty-early-dandelion.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TxqF5aTawY5VNrmj","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_jmpKAarcgRvploVk","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2742,13 +2662,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2574"
+      - "2627"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:35 GMT
+      - Wed, 22 Mar 2023 17:44:03 GMT
       Etag:
-      - W/"ba0b2d6578cd95438ecb27290731faf0"
+      - W/"2ef288782de65bf6913747d3405aa5f2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2756,9 +2676,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "819"
+      - "998"
       X-Request-Id:
-      - 524d72ed-4c1a-40d7-91e7-66f565f78543
+      - 4619be9a-bbc5-4134-8a42-de960aba874c
     status: 200 OK
     code: 200
     duration: ""
@@ -2770,7 +2690,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: POST
   response:
     body: '{}'
@@ -2786,7 +2706,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:36 GMT
+      - Wed, 22 Mar 2023 17:44:04 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2796,9 +2716,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "818"
+      - "997"
       X-Request-Id:
-      - cced7e5e-3bca-43a7-8aba-ba6dd6fa8c7f
+      - 2979e1c1-36d9-4a80-aa57-1738674c2094
     status: 200 OK
     code: 200
     duration: ""
@@ -2810,10 +2730,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_fkxrzRBRvTNyh13X
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YVwrUDY3hvPQJ88v
     method: DELETE
   response:
-    body: '{"task":{"id":"task_v3UfnPaHcKouFeMq","name":"Purge items from trash","status":"pending","created_at":1676031276,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_4NvUcQwmVGwUQHIM","name":"Purge items from trash","status":"pending","created_at":1679507044,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2826,9 +2746,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:36 GMT
+      - Wed, 22 Mar 2023 17:44:04 GMT
       Etag:
-      - W/"8ee1d08e988b5a2432088f2b9ed6f76d"
+      - W/"8ef0cb7aa38a285b93948b7df0875167"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2836,9 +2756,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "817"
+      - "996"
       X-Request-Id:
-      - 030f033f-2415-4a22-b22f-f153d3c80ef9
+      - a69a28d6-4803-425c-98e5-06889567f60a
     status: 200 OK
     code: 200
     duration: ""
@@ -2850,10 +2770,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_v3UfnPaHcKouFeMq
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YVwrUDY3hvPQJ88v
     method: GET
   response:
-    body: '{"task":{"id":"task_v3UfnPaHcKouFeMq","name":"Purge items from trash","status":"pending","created_at":1676031276,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"trash_object":{"id":"trsh_YVwrUDY3hvPQJ88v","keep_until":1679679843,"object_id":"vm_jmpKAarcgRvploVk","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2862,13 +2782,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "164"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:37 GMT
+      - Wed, 22 Mar 2023 17:44:05 GMT
       Etag:
-      - W/"8ee1d08e988b5a2432088f2b9ed6f76d"
+      - W/"19a531297700864a047d681e28a2f40d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2876,9 +2796,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "816"
+      - "995"
       X-Request-Id:
-      - 952d472a-ef6f-4951-842e-dd026a111922
+      - f67136da-5c70-4ad3-8cc3-c9f906a1fabf
     status: 200 OK
     code: 200
     duration: ""
@@ -2890,37 +2810,38 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_v3UfnPaHcKouFeMq
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_YVwrUDY3hvPQJ88v
     method: GET
   response:
-    body: '{"task":{"id":"task_v3UfnPaHcKouFeMq","name":"Purge items from trash","status":"pending","created_at":1676031276,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "164"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:14:42 GMT
-      Etag:
-      - W/"8ee1d08e988b5a2432088f2b9ed6f76d"
+      - Wed, 22 Mar 2023 17:44:10 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "810"
+      - "994"
       X-Request-Id:
-      - a4d42533-b86c-4d06-a299-0ea709e45273
-    status: 200 OK
-    code: 200
+      - 0c8b62c6-78a7-4182-bc67-015a39f4dc08
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -2930,87 +2851,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_v3UfnPaHcKouFeMq
-    method: GET
-  response:
-    body: '{"task":{"id":"task_v3UfnPaHcKouFeMq","name":"Purge items from trash","status":"running","created_at":1676031276,"started_at":1676031291,"finished_at":null,"progress":5}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "170"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:14:52 GMT
-      Etag:
-      - W/"b625ec524d0ceaad96bd301435ea1e5f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "779"
-      X-Request-Id:
-      - c8397b5a-ab03-4972-8b04-afbf4dc6e04f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_v3UfnPaHcKouFeMq
-    method: GET
-  response:
-    body: '{"task":{"id":"task_v3UfnPaHcKouFeMq","name":"Purge items from trash","status":"completed","created_at":1676031276,"started_at":1676031291,"finished_at":1676031295,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "180"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 10 Feb 2023 12:15:02 GMT
-      Etag:
-      - W/"328959b0d176a118e94312a05eec775d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - 04253bca-ab94-48ac-a3d4-d9612443b998
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: DELETE
   response:
     body: '{}'
@@ -3026,7 +2867,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:02 GMT
+      - Wed, 22 Mar 2023 17:44:11 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -3036,9 +2877,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "993"
       X-Request-Id:
-      - 4778bf5d-eedd-4348-a109-cc9165bc5820
+      - c25fdab2-2363-4960-8935-95893c7c2f34
     status: 200 OK
     code: 200
     duration: ""
@@ -3050,7 +2891,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TxqF5aTawY5VNrmj
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_jmpKAarcgRvploVk
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -3067,7 +2908,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:02 GMT
+      - Wed, 22 Mar 2023 17:44:11 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -3077,9 +2918,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "992"
       X-Request-Id:
-      - f26cf537-c3ef-4c0d-8bae-f1b5a4f58cb7
+      - eb1bb80d-b8e7-44a2-ad44-ca951c734f9d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3091,7 +2932,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_c6xuC4Qqvwk3oz5j
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_gulJ8ggq8JhG1ksW
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -3108,7 +2949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:02 GMT
+      - Wed, 22 Mar 2023 17:44:11 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -3118,9 +2959,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "991"
       X-Request-Id:
-      - fdc0822d-dc61-4ac9-928c-7bd39c389ee2
+      - 88c4fa1d-aa24-4b48-b1e6-ef1db7d88e1c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3132,7 +2973,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_lMARBMFBAmCoffcW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_RwFCDb3XqBvIb12H
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -3149,7 +2990,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 10 Feb 2023 12:15:02 GMT
+      - Wed, 22 Mar 2023 17:44:11 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -3159,9 +3000,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "990"
       X-Request-Id:
-      - 39aaa311-d8c7-47c9-bf1c-dcf2c028b26c
+      - b9d4a99d-1c03-446a-aed9-6be2731e062e
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.rand_id
@@ -1,1 +1,1 @@
-gnj2p4sib0lk
+m1q3srynyxqi

--- a/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.rand_id
@@ -1,1 +1,1 @@
-vh7nvao069pa
+gnj2p4sib0lk

--- a/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:10 GMT
+      - Thu, 23 Mar 2023 10:54:31 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "995"
       X-Request-Id:
-      - f30f7098-bbad-48c4-88a6-0e3d6f738097
+      - 80271c7f-e0fd-41e0-9b10-bbe2e3c8c3a3
     status: 200 OK
     code: 200
     duration: ""
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -70,9 +70,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:19 GMT
+      - Thu, 23 Mar 2023 10:54:38 GMT
       Etag:
-      - W/"5392ee9f0c9d9fecfd13399b97019a7d"
+      - W/"83ea4f34a8ce0d2edaa0f1a799893caa"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "990"
       X-Request-Id:
-      - cd1cbc48-7643-4663-a34e-8f349432ab41
+      - 7969fd6b-4cbb-4dc5-a54a-745906f58315
     status: 200 OK
     code: 200
     duration: ""
@@ -94,10 +94,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -112,9 +112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:19 GMT
+      - Thu, 23 Mar 2023 10:54:38 GMT
       Etag:
-      - W/"c14477dd8b8d2d0e1dc18e3e514e0ad1"
+      - W/"64dd313fd865984b592937218047f068"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -122,9 +122,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "977"
       X-Request-Id:
-      - cf797a22-9867-4389-98c9-79eb1619dfa1
+      - 0918346a-f214-475a-83b8-25b755fde7c6
     status: 200 OK
     code: 200
     duration: ""
@@ -136,10 +136,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"185-199-222-102.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -154,9 +154,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:19 GMT
+      - Thu, 23 Mar 2023 10:54:38 GMT
       Etag:
-      - W/"c14477dd8b8d2d0e1dc18e3e514e0ad1"
+      - W/"64dd313fd865984b592937218047f068"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -164,15 +164,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "982"
+      - "975"
       X-Request-Id:
-      - 3c159598-bdfa-402a-b97d-326a10938069
+      - 18a01235-6fcd-4c4e-b539-039db64d0534
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_3BDhWnR6wcxRtkfv</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-ashy-lunar-woodpecker</Hostname></Hostname><Name>tf-acc-test-update-network-speed-profile-gnj2p4sib0lk</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_Z5FLGs1qY5Mhtbwz</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-vast-gentle-leopard</Hostname></Hostname><Name>tf-acc-test-update-network-speed-profile-m1q3srynyxqi</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Sn0LreXjDXC74Mnm","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_rjR8PtMf6c6nZls1","state":"pending"},"virtual_machine_build":{"id":"vmbuild_rjR8PtMf6c6nZls1","state":"pending"},"hostname":"tf-acc-test-ashy-lunar-woodpecker"}'
+    body: '{"task":{"id":"task_a8ccEjrIEuEkhrvg","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_2g38wAbqWtXkEL9t","state":"pending"},"virtual_machine_build":{"id":"vmbuild_2g38wAbqWtXkEL9t","state":"pending"},"hostname":"tf-acc-test-vast-gentle-leopard"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -193,13 +193,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "272"
+      - "270"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:19 GMT
+      - Thu, 23 Mar 2023 10:54:38 GMT
       Etag:
-      - W/"5603d531486ffbb5b58b5ea591596b9d"
+      - W/"30c2078d1f722bda60969a045568f877"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -207,9 +207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "981"
+      - "974"
       X-Request-Id:
-      - d9936119-b5d7-4b9d-897f-7ebd2317dbf6
+      - f6caea60-c697-4607-9655-1b2885f72da9
     status: 201 Created
     code: 201
     duration: ""
@@ -221,17 +221,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rjR8PtMf6c6nZls1
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_2g38wAbqWtXkEL9t
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_rjR8PtMf6c6nZls1","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_2g38wAbqWtXkEL9t","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.216\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-ashy-lunar-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-gnj2p4sib0lk\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-vast-gentle-leopard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-m1q3srynyxqi\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506699}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568878}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -240,13 +240,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1703"
+      - "1697"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:22 GMT
+      - Thu, 23 Mar 2023 10:54:40 GMT
       Etag:
-      - W/"d54598eec320d4bdc0ee012d92a56f38"
+      - W/"cfbac8b6462ebfea38924302abd20e9c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -254,9 +254,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "979"
+      - "972"
       X-Request-Id:
-      - 548f3634-e64f-4318-892c-c3e9190bfbdc
+      - f36d8b9a-ddd2-4183-8df8-ad6105e8154f
     status: 200 OK
     code: 200
     duration: ""
@@ -268,17 +268,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rjR8PtMf6c6nZls1
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_2g38wAbqWtXkEL9t
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_rjR8PtMf6c6nZls1","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_2g38wAbqWtXkEL9t","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.216\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-ashy-lunar-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-gnj2p4sib0lk\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-vast-gentle-leopard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-m1q3srynyxqi\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506699}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679568878}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -287,13 +287,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1703"
+      - "1697"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:27 GMT
+      - Thu, 23 Mar 2023 10:54:45 GMT
       Etag:
-      - W/"d54598eec320d4bdc0ee012d92a56f38"
+      - W/"cfbac8b6462ebfea38924302abd20e9c"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -301,9 +301,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "977"
+      - "970"
       X-Request-Id:
-      - f17628b3-e30a-495a-937d-fe0028e33099
+      - d1974a49-a003-4a31-8518-72c2b60aa496
     status: 200 OK
     code: 200
     duration: ""
@@ -315,17 +315,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rjR8PtMf6c6nZls1
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_2g38wAbqWtXkEL9t
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_rjR8PtMf6c6nZls1","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_2g38wAbqWtXkEL9t","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.216\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-ashy-lunar-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-gnj2p4sib0lk\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.102\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-vast-gentle-leopard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-m1q3srynyxqi\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679506699}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679568878}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -334,369 +334,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1704"
+      - "1697"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:37 GMT
+      - Thu, 23 Mar 2023 10:54:55 GMT
       Etag:
-      - W/"9e0ef82450d226634a150e4d788df6fb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "954"
-      X-Request-Id:
-      - e9456c64-f834-4048-b7f9-e5c1e838ec1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2228"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - dfd57503-fabd-4a52-bbf6-6e8a9663bdb8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2228"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "951"
-      X-Request-Id:
-      - 4e47127c-f72a-45a0-87b4-42ba6d2aa39c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "381"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"d59211dc265af79795b74e38dc63311a"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - 04b4508c-71b0-4f85-9c92-aefc8369c5ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "535"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "949"
-      X-Request-Id:
-      - 3338d24d-29c7-4175-88b1-90c0a57d8678
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2228"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "948"
-      X-Request-Id:
-      - 9f2f579b-8cd2-47aa-a292-a63c5a84f3cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "752"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"82e66b226d29c4cc79f588a80e89e331"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "947"
-      X-Request-Id:
-      - 5b84e238-a729-4d71-842b-38ec1cd1825d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2228"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "946"
-      X-Request-Id:
-      - 0c1380c7-a754-4eaf-a484-5ed523f4d3a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "381"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"d59211dc265af79795b74e38dc63311a"
+      - W/"a9fa596bfb1e836e5de584b3767f770f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -706,7 +350,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "945"
       X-Request-Id:
-      - b35ed39f-db50-4f88-842b-b1d1babd7d64
+      - ff5b7e35-f5d1-405b-8260-a60749d07fdb
     status: 200 OK
     code: 200
     duration: ""
@@ -718,101 +362,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "535"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:39 GMT
-      Etag:
-      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "944"
-      X-Request-Id:
-      - a37fd33b-6946-4211-af55-65a3c469e04a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "752"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
-      Etag:
-      - W/"82e66b226d29c4cc79f588a80e89e331"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "943"
-      X-Request-Id:
-      - bdf27eac-eba6-44fc-b42b-e2ccc5965b67
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -821,13 +381,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -835,9 +395,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "942"
+      - "920"
       X-Request-Id:
-      - ff1185aa-87c3-42cd-8bde-85763717d516
+      - 347b3db0-57de-4434-972d-76726f5008f7
     status: 200 OK
     code: 200
     duration: ""
@@ -849,12 +409,59 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2222"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:57 GMT
+      Etag:
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "919"
+      X-Request-Id:
+      - bba4a290-2a3d-4750-8abe-aac4b3b75199
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_P7e1fuhqetZ9O4cA","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -867,9 +474,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"d59211dc265af79795b74e38dc63311a"
+      - W/"cdcc4b0c868f0a9cf5fe849af594a50e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -877,9 +484,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "918"
       X-Request-Id:
-      - 0f94a0ac-fbe2-40cd-bb04-6f6b4a3aa246
+      - 4bd747df-42f6-42da-9db2-dfccd0493f17
     status: 200 OK
     code: 200
     duration: ""
@@ -891,12 +498,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_P7e1fuhqetZ9O4cA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_P7e1fuhqetZ9O4cA","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ba:48:af:84:82","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -909,9 +516,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
+      - W/"47227e79827d9ef1e5364337d52dcdc0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -919,9 +526,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "940"
+      - "917"
       X-Request-Id:
-      - 00ccd0cf-ed9b-4b3b-a811-c4fa857b6b96
+      - 1e6df159-e1db-4481-ba91-d0d955f626ef
     status: 200 OK
     code: 200
     duration: ""
@@ -933,17 +540,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -952,13 +559,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:54:57 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -966,9 +573,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "939"
+      - "916"
       X-Request-Id:
-      - 8839332b-37fc-4a8d-9926-d6c7168a8003
+      - 023a9e9d-8a3f-4f0b-8a17-de13e3e839f4
     status: 200 OK
     code: 200
     duration: ""
@@ -980,12 +587,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -994,13 +601,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "752"
+      - "750"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"82e66b226d29c4cc79f588a80e89e331"
+      - W/"5e1afb4cbf9a76e9b15ac01b6625c5e5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1008,9 +615,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "938"
+      - "911"
       X-Request-Id:
-      - 95b0edd6-dbe3-488c-a0f6-e9aa60bc66b7
+      - 3bdf1e41-5bbe-4b78-bbeb-02c32ca1636c
     status: 200 OK
     code: 200
     duration: ""
@@ -1022,17 +629,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1041,13 +648,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1055,9 +662,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "937"
+      - "910"
       X-Request-Id:
-      - 7d2ac060-a98e-4430-ba2c-d8f1c8d14a64
+      - f05c0d39-907e-4a92-9b46-2e61b1df7056
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,12 +676,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_P7e1fuhqetZ9O4cA","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1087,9 +694,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"d59211dc265af79795b74e38dc63311a"
+      - W/"cdcc4b0c868f0a9cf5fe849af594a50e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1097,9 +704,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "936"
+      - "909"
       X-Request-Id:
-      - ebf35424-9da3-4c28-8cbf-f3de05b873d5
+      - 5970d45f-798b-4d27-b4e0-c2d7d60ae3bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,12 +718,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_P7e1fuhqetZ9O4cA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_P7e1fuhqetZ9O4cA","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ba:48:af:84:82","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1129,9 +736,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:40 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
+      - W/"47227e79827d9ef1e5364337d52dcdc0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1139,9 +746,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "935"
+      - "908"
       X-Request-Id:
-      - 1f9a3341-a2c5-4ce4-a41d-8033088ccde6
+      - 0695c4ac-5cf9-422e-b3d1-84d7ecd7a5ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1153,12 +760,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1167,13 +774,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "752"
+      - "750"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:41 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"82e66b226d29c4cc79f588a80e89e331"
+      - W/"5e1afb4cbf9a76e9b15ac01b6625c5e5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1181,9 +788,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "933"
+      - "902"
       X-Request-Id:
-      - 91631938-87f3-498c-9927-7e3c75fe4035
+      - 3a001dbf-fedd-4564-b217-936516bf3dd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1195,17 +802,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1214,13 +821,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:41 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1228,9 +835,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "932"
+      - "901"
       X-Request-Id:
-      - 616f93ca-9ec8-4665-8a2a-e2b7a283c07b
+      - c7c2c419-6c34-46cf-aa42-e0f193a0237b
     status: 200 OK
     code: 200
     duration: ""
@@ -1242,12 +849,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_P7e1fuhqetZ9O4cA","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1260,9 +867,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:41 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"d59211dc265af79795b74e38dc63311a"
+      - W/"cdcc4b0c868f0a9cf5fe849af594a50e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1270,9 +877,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "931"
+      - "900"
       X-Request-Id:
-      - ec03bf8a-ba54-4666-a0ee-804220efcdd1
+      - 51b07eea-ac46-4186-9b48-2194a2c612e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1284,12 +891,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_P7e1fuhqetZ9O4cA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_P7e1fuhqetZ9O4cA","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ba:48:af:84:82","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1302,9 +909,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:41 GMT
+      - Thu, 23 Mar 2023 10:54:58 GMT
       Etag:
-      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
+      - W/"47227e79827d9ef1e5364337d52dcdc0"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1312,9 +919,56 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "930"
+      - "898"
       X-Request-Id:
-      - ed333589-7143-4eeb-9062-071c02e01e83
+      - 58570cc8-5d6f-49b2-9e96-8ed7f1051b89
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2222"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:54:59 GMT
+      Etag:
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "888"
+      X-Request-Id:
+      - 0cb20988-c920-4b0e-83d4-1c50b095a48a
     status: 200 OK
     code: 200
     duration: ""
@@ -1326,12 +980,358 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "750"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"5e1afb4cbf9a76e9b15ac01b6625c5e5"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "880"
+      X-Request-Id:
+      - ddc06ed2-7cb3-48bd-96af-4dc725d09cac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2222"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - b2728538-3ef8-47dd-97d6-af4c11625662
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_P7e1fuhqetZ9O4cA","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "381"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"cdcc4b0c868f0a9cf5fe849af594a50e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 76958ebf-294b-4b47-b2b5-4221578183fa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_P7e1fuhqetZ9O4cA
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_P7e1fuhqetZ9O4cA","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ba:48:af:84:82","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "535"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"47227e79827d9ef1e5364337d52dcdc0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - aa387540-379b-4703-9287-556c25ca3210
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "750"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"5e1afb4cbf9a76e9b15ac01b6625c5e5"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 2a73fee3-7579-4249-9e37-fb1e3b97aa52
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2222"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 56c90a97-a1b4-4672-93f0-040a0f77d1f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_P7e1fuhqetZ9O4cA","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "381"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"cdcc4b0c868f0a9cf5fe849af594a50e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - fc29d15a-1a2d-4c10-85c6-3c473e5d8f23
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_P7e1fuhqetZ9O4cA
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_P7e1fuhqetZ9O4cA","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ba:48:af:84:82","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "535"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:00 GMT
+      Etag:
+      - W/"47227e79827d9ef1e5364337d52dcdc0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 725da08f-8dcd-414b-a180-05f07e2fc754
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_P7e1fuhqetZ9O4cA","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1344,9 +1344,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:41 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"a1d84ddf75fbd59486b26e46256ced0c"
+      - W/"595a300823af09d713dd4ea4b8cff535"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1354,15 +1354,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "929"
+      - "974"
       X-Request-Id:
-      - 9fbcd02a-6704-4592-a433-e8bb89eaa62b
+      - 096ba30b-fe60-47b9-8e8f-6d2525106c66
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN"},"speed_profile":{"permalink":"1gbps"}}
+      {"virtual_machine_network_interface":{"id":"vmnet_P7e1fuhqetZ9O4cA"},"speed_profile":{"permalink":"1gbps"}}
     form: {}
     headers:
       Accept:
@@ -1374,8 +1374,8 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/update_speed_profile
     method: PATCH
   response:
-    body: '{"task":{"id":"task_PHKU4HpBWF22kYFY","name":"Change network interface
-      speed profile","status":"pending","created_at":1679506721,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_s3EMAWhf6B59MqeL","name":"Change network interface
+      speed profile","status":"pending","created_at":1679568900,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1388,9 +1388,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:41 GMT
+      - Thu, 23 Mar 2023 10:55:00 GMT
       Etag:
-      - W/"56b6d0327863751f0e173bdc2080bace"
+      - W/"dff4039b666dbf17e3b443873c192cad"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1398,9 +1398,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "928"
+      - "973"
       X-Request-Id:
-      - c4cd0b81-02f6-4f90-998c-f3e84445de2e
+      - a129343b-552d-400f-b7bc-9d9c5dbbe07a
     status: 200 OK
     code: 200
     duration: ""
@@ -1412,11 +1412,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_PHKU4HpBWF22kYFY
+    url: https://api.katapult.io/core/v1/tasks/task_s3EMAWhf6B59MqeL
     method: GET
   response:
-    body: '{"task":{"id":"task_PHKU4HpBWF22kYFY","name":"Change network interface
-      speed profile","status":"running","created_at":1679506721,"started_at":1679506722,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_s3EMAWhf6B59MqeL","name":"Change network interface
+      speed profile","status":"running","created_at":1679568900,"started_at":1679568901,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1429,9 +1429,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:42 GMT
+      - Thu, 23 Mar 2023 10:55:01 GMT
       Etag:
-      - W/"55d807f7111805c9bd2392c8eef07cb4"
+      - W/"230e259a7b772df80a768852bfff337f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1439,9 +1439,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "927"
+      - "968"
       X-Request-Id:
-      - 43eef81b-6bf0-4f04-80e3-150c8379e6b5
+      - 992c6fa2-56fd-404b-9223-c3891610798f
     status: 200 OK
     code: 200
     duration: ""
@@ -1453,11 +1453,11 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_PHKU4HpBWF22kYFY
+    url: https://api.katapult.io/core/v1/tasks/task_s3EMAWhf6B59MqeL
     method: GET
   response:
-    body: '{"task":{"id":"task_PHKU4HpBWF22kYFY","name":"Change network interface
-      speed profile","status":"completed","created_at":1679506721,"started_at":1679506722,"finished_at":1679506723,"progress":100}}'
+    body: '{"task":{"id":"task_s3EMAWhf6B59MqeL","name":"Change network interface
+      speed profile","status":"completed","created_at":1679568900,"started_at":1679568901,"finished_at":1679568903,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1470,9 +1470,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:47 GMT
+      - Thu, 23 Mar 2023 10:55:06 GMT
       Etag:
-      - W/"65cb181823519540bb7b611775546933"
+      - W/"1fffb3c15b859e7083ade1a35e63705a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1480,15 +1480,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "924"
+      - "951"
       X-Request-Id:
-      - cfe329c1-5f0b-4b90-be7a-beeb03e9d3e6
+      - 574a028b-63a3-4dba-ad50-f46f954c789e
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21"},"properties":{}}
+      {"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy"},"properties":{}}
     form: {}
     headers:
       Accept:
@@ -1500,14 +1500,14 @@ interactions:
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1516,13 +1516,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:47 GMT
+      - Thu, 23 Mar 2023 10:55:06 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1530,9 +1530,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "923"
+      - "950"
       X-Request-Id:
-      - fa9005fb-68a7-411c-8f17-37b75f96c502
+      - 841b8349-a0ad-4ad5-a65b-71149c286dcb
     status: 200 OK
     code: 200
     duration: ""
@@ -1544,17 +1544,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1563,13 +1563,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:47 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1577,9 +1577,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "922"
+      - "949"
       X-Request-Id:
-      - a52147f9-d7bb-4fd2-b14e-6a1e7ee07a4a
+      - 4645b6ee-d334-4c17-b438-e86a83a72ff0
     status: 200 OK
     code: 200
     duration: ""
@@ -1591,12 +1591,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_P7e1fuhqetZ9O4cA","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1609,9 +1609,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:47 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"d59211dc265af79795b74e38dc63311a"
+      - W/"cdcc4b0c868f0a9cf5fe849af594a50e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1619,9 +1619,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "947"
       X-Request-Id:
-      - 646d8be1-b8c9-47c9-84ab-d621937cbba5
+      - 550f35b9-92f9-4a1f-94a4-8f33f4672dcc
     status: 200 OK
     code: 200
     duration: ""
@@ -1633,12 +1633,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_P7e1fuhqetZ9O4cA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:83:b8:00:49","state":"attached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_P7e1fuhqetZ9O4cA","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ba:48:af:84:82","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1651,9 +1651,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:47 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"c3ec417afddedc48786d0fcc19694e07"
+      - W/"58ad5fdf834f26af32aea47b266b7357"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1661,9 +1661,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "920"
+      - "945"
       X-Request-Id:
-      - 063f3372-342f-41b6-9f15-4f6ded50e487
+      - 3f5d4fe3-b417-4ac6-8a10-73b5e58d29d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1675,17 +1675,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1694,13 +1694,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:47 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1708,9 +1708,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "919"
+      - "943"
       X-Request-Id:
-      - b3457cc4-a29b-4daa-9f87-e41b681ced78
+      - 94ef44b3-d2ed-4c83-9eb4-083e711ba8de
     status: 200 OK
     code: 200
     duration: ""
@@ -1722,12 +1722,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1736,13 +1736,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "752"
+      - "750"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:48 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"82e66b226d29c4cc79f588a80e89e331"
+      - W/"5e1afb4cbf9a76e9b15ac01b6625c5e5"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1750,9 +1750,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "918"
+      - "942"
       X-Request-Id:
-      - 1e338f80-4930-43ec-8c75-5bc09ecef4a8
+      - 61b23096-ae38-492d-a25f-66edb9835aca
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,17 +1764,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1783,13 +1783,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:48 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1797,9 +1797,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "941"
       X-Request-Id:
-      - 1e92ecfc-3366-4702-8081-f2717c472b97
+      - 55d55d5e-e90d-48b9-8fc7-53c3a77eef4a
     status: 200 OK
     code: 200
     duration: ""
@@ -1811,12 +1811,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_P7e1fuhqetZ9O4cA","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1829,9 +1829,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:48 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"d59211dc265af79795b74e38dc63311a"
+      - W/"cdcc4b0c868f0a9cf5fe849af594a50e"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1839,9 +1839,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "916"
+      - "940"
       X-Request-Id:
-      - 42a8a355-1151-4abd-b74a-6cb1df811d4f
+      - 8bb4fbd1-1bba-4524-a551-19b1399ca586
     status: 200 OK
     code: 200
     duration: ""
@@ -1853,12 +1853,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_P7e1fuhqetZ9O4cA
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:70:83:b8:00:49","state":"attached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_P7e1fuhqetZ9O4cA","virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-m1q3srynyxqi","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:ba:48:af:84:82","state":"attached","ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1871,9 +1871,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:48 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"c3ec417afddedc48786d0fcc19694e07"
+      - W/"58ad5fdf834f26af32aea47b266b7357"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1881,9 +1881,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "915"
+      - "939"
       X-Request-Id:
-      - e8cbeab4-a2d3-413b-9fa9-d2c00288c711
+      - 820cef1f-b69b-46dc-b355-85db1dbd21c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1895,17 +1895,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1914,13 +1914,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2228"
+      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:48 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"59d3313f48044c90db5a6f0282abb89b"
+      - W/"958fd73e70e7ae66c996a73630c24fe2"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1928,9 +1928,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "914"
+      - "938"
       X-Request-Id:
-      - afaab44a-37ac-4f24-bd90-0361ef2544ef
+      - badeed4e-8183-44d0-8a8a-b85e34b53085
     status: 200 OK
     code: 200
     duration: ""
@@ -1942,10 +1942,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: POST
   response:
-    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_ojSbcYCPSSrTpt3V","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1958,9 +1958,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:38:48 GMT
+      - Thu, 23 Mar 2023 10:55:07 GMT
       Etag:
-      - W/"7f7aa6fe826db0c2d9422a85ed9f7bed"
+      - W/"15e94b59b675670bda57ab2dcc71540f"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1968,9 +1968,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "913"
+      - "936"
       X-Request-Id:
-      - 5c4b131f-3036-4bf9-a576-026e64696a22
+      - 9e3be6ab-fa42-4421-9bb8-ae39731b279f
     status: 200 OK
     code: 200
     duration: ""
@@ -1982,90 +1982,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_jWfLrcdlfoZi030j
+    url: https://api.katapult.io/core/v1/tasks/task_ojSbcYCPSSrTpt3V
     method: GET
   response:
-    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"pending","created_at":1679506728,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:49 GMT
-      Etag:
-      - W/"0d2dae7c4a33d549eea1dc39d0a612f4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "912"
-      X-Request-Id:
-      - 48d79773-bf50-49c4-91a6-b72da872b477
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_jWfLrcdlfoZi030j
-    method: GET
-  response:
-    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"pending","created_at":1679506728,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Mar 2023 17:38:54 GMT
-      Etag:
-      - W/"0d2dae7c4a33d549eea1dc39d0a612f4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "909"
-      X-Request-Id:
-      - 12381f96-c03c-417e-a97f-afece592626b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_jWfLrcdlfoZi030j
-    method: GET
-  response:
-    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"running","created_at":1679506728,"started_at":1679506744,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_ojSbcYCPSSrTpt3V","name":"Stop virtual machine","status":"running","created_at":1679568907,"started_at":1679568908,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2078,9 +1998,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:04 GMT
+      - Thu, 23 Mar 2023 10:55:08 GMT
       Etag:
-      - W/"70c81fcbed8d5ed2d3b58b6c487abbd6"
+      - W/"215afd989fc5977865ffdd4771825736"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2088,9 +2008,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "978"
+      - "934"
       X-Request-Id:
-      - 582a7fb6-3ff7-4e1f-a390-9f4ed614038e
+      - 946fd99f-4197-463f-98ab-d4421c29d03c
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,10 +2022,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_jWfLrcdlfoZi030j
+    url: https://api.katapult.io/core/v1/tasks/task_ojSbcYCPSSrTpt3V
     method: GET
   response:
-    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"completed","created_at":1679506728,"started_at":1679506744,"finished_at":1679506746,"progress":100}}'
+    body: '{"task":{"id":"task_ojSbcYCPSSrTpt3V","name":"Stop virtual machine","status":"completed","created_at":1679568907,"started_at":1679568908,"finished_at":1679568911,"progress":100}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2118,9 +2038,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:14 GMT
+      - Thu, 23 Mar 2023 10:55:13 GMT
       Etag:
-      - W/"9c2367d07a96e4ef7a6917badc0f4401"
+      - W/"1417ad856c6220c9587ddc219e4bac52"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2128,9 +2048,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "930"
+      - "926"
       X-Request-Id:
-      - 08798d4d-f1b0-408c-b95b-1f15bdc2e7d0
+      - 3a39a490-0787-4001-94ce-c416c8e9ca97
     status: 200 OK
     code: 200
     duration: ""
@@ -2142,17 +2062,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_huvibuDYsguvMlaR","keep_until":1679679554,"object_id":"vm_GtdWxZwhN4dJ4J21","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_UH8HeaPikWGNBvAh","keep_until":1679741713,"object_id":"vm_PCOknlXDOQFCCjTy","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_PCOknlXDOQFCCjTy","name":"tf-acc-test-update-network-speed-profile-m1q3srynyxqi","hostname":"tf-acc-test-vast-gentle-leopard","fqdn":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679568879,"initial_root_password":"1lZaiMk0tDc3L7IG","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Z5FLGs1qY5Mhtbwz","address":"185.199.222.102","reverse_dns":"tf-acc-test-vast-gentle-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.102/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_PCOknlXDOQFCCjTy","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2161,13 +2081,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2363"
+      - "2357"
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:14 GMT
+      - Thu, 23 Mar 2023 10:55:13 GMT
       Etag:
-      - W/"b47a8c86445da5f00a8f23be0f8609d8"
+      - W/"04fa6621772c250036af2f88d2f22812"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2175,9 +2095,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "929"
+      - "925"
       X-Request-Id:
-      - 797502bf-d143-45f2-a401-9ceaba55b758
+      - 8010affc-f695-4ce7-a080-7c22f7d2b1cf
     status: 200 OK
     code: 200
     duration: ""
@@ -2189,7 +2109,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: POST
   response:
     body: '{}'
@@ -2205,7 +2125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:15 GMT
+      - Thu, 23 Mar 2023 10:55:14 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2215,9 +2135,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "928"
+      - "924"
       X-Request-Id:
-      - 843ddad0-4e1f-47c5-8572-71c29e0ae1bb
+      - 203e1f5e-e780-4d5b-9449-0b0e60c2d1b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,10 +2149,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_huvibuDYsguvMlaR
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_UH8HeaPikWGNBvAh
     method: DELETE
   response:
-    body: '{"task":{"id":"task_djBcErfRcrs3QHco","name":"Purge items from trash","status":"pending","created_at":1679506755,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_lBP3SG0qoynp9hPR","name":"Purge items from trash","status":"pending","created_at":1679568914,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2245,9 +2165,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:15 GMT
+      - Thu, 23 Mar 2023 10:55:14 GMT
       Etag:
-      - W/"c8b44e15ace147615ff94ed83c70c1c0"
+      - W/"40f8fea6b686a0e6599990e406504607"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2255,9 +2175,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "924"
+      - "923"
       X-Request-Id:
-      - 0c370854-4d3e-4ab9-94d3-bf4d8093df70
+      - 088cec59-3322-4575-8858-5ca72e277c2f
     status: 200 OK
     code: 200
     duration: ""
@@ -2269,10 +2189,10 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_huvibuDYsguvMlaR
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_UH8HeaPikWGNBvAh
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_huvibuDYsguvMlaR","keep_until":1679679554,"object_id":"vm_GtdWxZwhN4dJ4J21","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_UH8HeaPikWGNBvAh","keep_until":1679741713,"object_id":"vm_PCOknlXDOQFCCjTy","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2285,9 +2205,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:16 GMT
+      - Thu, 23 Mar 2023 10:55:15 GMT
       Etag:
-      - W/"6dfae61a12447bc193505ddbaf62fedb"
+      - W/"ac0571c9e4c98e8996d95e7f805d663d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2295,9 +2215,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "922"
       X-Request-Id:
-      - 36b13a6d-53b1-4c21-a677-d0a6cb203756
+      - b6bc29a0-b5be-4f90-a956-d846e3913c59
     status: 200 OK
     code: 200
     duration: ""
@@ -2309,7 +2229,87 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_huvibuDYsguvMlaR
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_UH8HeaPikWGNBvAh
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_UH8HeaPikWGNBvAh","keep_until":1679741713,"object_id":"vm_PCOknlXDOQFCCjTy","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:20 GMT
+      Etag:
+      - W/"ac0571c9e4c98e8996d95e7f805d663d"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "920"
+      X-Request-Id:
+      - afcbdeef-616b-46a4-a664-32c40b4841fe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_UH8HeaPikWGNBvAh
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_UH8HeaPikWGNBvAh","keep_until":1679741713,"object_id":"vm_PCOknlXDOQFCCjTy","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:30 GMT
+      Etag:
+      - W/"ac0571c9e4c98e8996d95e7f805d663d"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "901"
+      X-Request-Id:
+      - 138487e0-5036-4907-ae25-60563b4b476b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_UH8HeaPikWGNBvAh
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2326,7 +2326,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:21 GMT
+      - Thu, 23 Mar 2023 10:55:40 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2336,9 +2336,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "918"
+      - "886"
       X-Request-Id:
-      - 6c224374-afe8-440f-b192-a132423410b0
+      - 64d727d1-7e1f-4654-87f9-6cbccb0a395b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2350,7 +2350,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: DELETE
   response:
     body: '{}'
@@ -2366,7 +2366,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:21 GMT
+      - Thu, 23 Mar 2023 10:55:40 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2376,9 +2376,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "885"
       X-Request-Id:
-      - 82af8b50-d074-463c-b753-4128e8cc5c23
+      - 26b78607-f818-445e-a1f9-f47570ce996a
     status: 200 OK
     code: 200
     duration: ""
@@ -2390,7 +2390,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_PCOknlXDOQFCCjTy
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2407,7 +2407,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:21 GMT
+      - Thu, 23 Mar 2023 10:55:40 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2417,9 +2417,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "916"
+      - "884"
       X-Request-Id:
-      - f8578b34-1a47-40d1-91ef-1872dbbb1d1b
+      - cb383f1a-c04b-4415-8c47-1eaa65805c70
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2431,7 +2431,48 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_PCOknlXDOQFCCjTy
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Mar 2023 10:55:40 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "883"
+      X-Request-Id:
+      - 406163e2-6bc6-428b-86e5-d2af1c10529e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Z5FLGs1qY5Mhtbwz
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2448,7 +2489,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Mar 2023 17:39:21 GMT
+      - Thu, 23 Mar 2023 10:55:40 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2458,9 +2499,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "915"
+      - "882"
       X-Request-Id:
-      - a11814e0-7d14-4f73-9288-15e2411bed47
+      - e8f2e77c-eae1-4458-bd90-d34ac0ade040
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:32 GMT
+      - Wed, 22 Mar 2023 17:38:10 GMT
       Etag:
       - W/"d60d47b2ba0b179327bb89a97b1c0e77"
       Server:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "998"
       X-Request-Id:
-      - ba66cc69-6b29-4e15-9b98-f3042ef26e29
+      - f30f7098-bbad-48c4-88a6-0e3d6f738097
     status: 200 OK
     code: 200
     duration: ""
@@ -55,7 +55,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"185-199-221-30.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -66,97 +66,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "552"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:32 GMT
+      - Wed, 22 Mar 2023 17:38:19 GMT
       Etag:
-      - W/"261e718304dce69017df6c7013909306"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - 96b61168-3dcf-4597-b332-d64c9eeafcb2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"185-199-221-30.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:32 GMT
-      Etag:
-      - W/"b3e0cdf61916ce6a065c79b1247c7c14"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - ea40fcb3-48c6-49b1-ac9a-da2d2771948d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"185-199-221-30.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:32 GMT
-      Etag:
-      - W/"b3e0cdf61916ce6a065c79b1247c7c14"
+      - W/"5392ee9f0c9d9fecfd13399b97019a7d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -166,13 +82,97 @@ interactions:
       X-Ratelimit-Remaining:
       - "996"
       X-Request-Id:
-      - dfbae4dd-45e2-4375-9185-9646b92dc5d3
+      - cd1cbc48-7643-4663-a34e-8f349432ab41
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:19 GMT
+      Etag:
+      - W/"c14477dd8b8d2d0e1dc18e3e514e0ad1"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - cf797a22-9867-4389-98c9-79eb1619dfa1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"185-199-222-216.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:19 GMT
+      Etag:
+      - W/"c14477dd8b8d2d0e1dc18e3e514e0ad1"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 3c159598-bdfa-402a-b97d-326a10938069
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_Y1mpdmngnrGaqNde</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-faithful-polar-tungsten</Hostname></Hostname><Name>tf-acc-test-update-network-speed-profile-vh7nvao069pa</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_3BDhWnR6wcxRtkfv</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-ashy-lunar-woodpecker</Hostname></Hostname><Name>tf-acc-test-update-network-speed-profile-gnj2p4sib0lk</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -184,7 +184,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_LVL3LQC8fmHzW6j2","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_zPZLKMdozINJIK3H","state":"pending"},"virtual_machine_build":{"id":"vmbuild_zPZLKMdozINJIK3H","state":"pending"},"hostname":"tf-acc-test-faithful-polar-tungsten"}'
+    body: '{"task":{"id":"task_Sn0LreXjDXC74Mnm","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_rjR8PtMf6c6nZls1","state":"pending"},"virtual_machine_build":{"id":"vmbuild_rjR8PtMf6c6nZls1","state":"pending"},"hostname":"tf-acc-test-ashy-lunar-woodpecker"}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -193,13 +193,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "274"
+      - "272"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:32 GMT
+      - Wed, 22 Mar 2023 17:38:19 GMT
       Etag:
-      - W/"8a872694e90a94e824895d1dc8830461"
+      - W/"5603d531486ffbb5b58b5ea591596b9d"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -207,9 +207,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "981"
       X-Request-Id:
-      - 378498ef-6402-4365-a1ac-e3d2f92bdb1d
+      - d9936119-b5d7-4b9d-897f-7ebd2317dbf6
     status: 201 Created
     code: 201
     duration: ""
@@ -221,17 +221,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_zPZLKMdozINJIK3H
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rjR8PtMf6c6nZls1
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_zPZLKMdozINJIK3H","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_rjR8PtMf6c6nZls1","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.30\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-faithful-polar-tungsten\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-vh7nvao069pa\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.216\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-ashy-lunar-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-gnj2p4sib0lk\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1678291352}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506699}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -240,678 +240,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "1708"
+      - "1703"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:35 GMT
+      - Wed, 22 Mar 2023 17:38:22 GMT
       Etag:
-      - W/"f581235841920c9de939c9206f9588b4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - 34415eb9-f8f1-4515-baae-b39bd3b3cc44
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_zPZLKMdozINJIK3H
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_zPZLKMdozINJIK3H","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.30\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-faithful-polar-tungsten\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-vh7nvao069pa\u003c/Name\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1678291352}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1708"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:40 GMT
-      Etag:
-      - W/"f581235841920c9de939c9206f9588b4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - e0ea4bae-9e5a-43b9-bba3-a122a432c8c8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_zPZLKMdozINJIK3H
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_zPZLKMdozINJIK3H","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.30\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-faithful-polar-tungsten\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-vh7nvao069pa\u003c/Name\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1678291352}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1708"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:50 GMT
-      Etag:
-      - W/"92f1f5a4c03dbebce2571c1502be20fd"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - caac66ad-a8a5-4be3-898e-3681cdc76263
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2191"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "991"
-      X-Request-Id:
-      - 851e538b-ffc3-45c7-9598-0dbb01a79b93
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2191"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - 9e8d7de9-069a-45e3-bef5-cb505b7358bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VxYSS2XmJwMbwryn","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"9f2ee7060ef11fafec50faa719639e30"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - b7ef1814-22ef-45ff-9398-8d92a8281900
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VxYSS2XmJwMbwryn
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_VxYSS2XmJwMbwryn","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:e0:d2:76:bd","state":"attached","ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"46d4faeb8a1eefa61782a2dbf9d820e6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - 68250fce-b03d-47bf-bb1d-037ac6a81dde
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2191"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - 048a5251-875c-4b11-8a1a-8016304939ce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "752"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"7c98884a7cfb307358293475725d99fb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - 28b92f96-0bbd-407a-8682-ec798c0ef4c9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2191"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "985"
-      X-Request-Id:
-      - c3cccba9-2dd4-4f62-8b6e-2502ff099651
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VxYSS2XmJwMbwryn","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"9f2ee7060ef11fafec50faa719639e30"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 3a522a91-356d-4578-b1c6-3b14db8db35e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VxYSS2XmJwMbwryn
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_VxYSS2XmJwMbwryn","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:e0:d2:76:bd","state":"attached","ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"46d4faeb8a1eefa61782a2dbf9d820e6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - f85e933e-a1f4-47a3-91fe-c8e403c1668f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "752"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"7c98884a7cfb307358293475725d99fb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "982"
-      X-Request-Id:
-      - 73d6eef8-6a36-4571-97ec-fe9e09637ec3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2191"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "981"
-      X-Request-Id:
-      - 8ff93c0e-afde-43da-a9fc-d8c85e26e4b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VxYSS2XmJwMbwryn","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"9f2ee7060ef11fafec50faa719639e30"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - c78686f2-5327-4a7c-8405-73b4cdc0758e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VxYSS2XmJwMbwryn
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_VxYSS2XmJwMbwryn","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:e0:d2:76:bd","state":"attached","ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:52 GMT
-      Etag:
-      - W/"46d4faeb8a1eefa61782a2dbf9d820e6"
+      - W/"d54598eec320d4bdc0ee012d92a56f38"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -921,54 +256,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - e2ab2df6-3dcc-43b6-a539-06acdbcb25bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2191"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
-      Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "978"
-      X-Request-Id:
-      - 799e50ca-a969-4425-9b63-760bfce828d5
+      - 548f3634-e64f-4318-892c-c3e9190bfbdc
     status: 200 OK
     code: 200
     duration: ""
@@ -980,12 +268,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rjR8PtMf6c6nZls1
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"}}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_rjR8PtMf6c6nZls1","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.216\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-ashy-lunar-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-gnj2p4sib0lk\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679506699}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -994,13 +287,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "752"
+      - "1703"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
+      - Wed, 22 Mar 2023 17:38:27 GMT
       Etag:
-      - W/"7c98884a7cfb307358293475725d99fb"
+      - W/"d54598eec320d4bdc0ee012d92a56f38"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1010,7 +303,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "977"
       X-Request-Id:
-      - cdead58e-a526-415b-8f95-36f8ea91c487
+      - f17628b3-e30a-495a-937d-fe0028e33099
     status: 200 OK
     code: 200
     duration: ""
@@ -1022,17 +315,64 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rjR8PtMf6c6nZls1
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine_build":{"id":"vmbuild_rjR8PtMf6c6nZls1","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.216\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-ashy-lunar-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-gnj2p4sib0lk\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679506699}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "1704"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:37 GMT
+      Etag:
+      - W/"9e0ef82450d226634a150e4d788df6fb"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - e9456c64-f834-4048-b7f9-e5c1e838ec1f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1041,13 +381,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2191"
+      - "2228"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
+      - W/"59d3313f48044c90db5a6f0282abb89b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1055,9 +395,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "976"
+      - "952"
       X-Request-Id:
-      - 82f5601e-a4b2-4f3c-80b7-80de9cf614f2
+      - dfd57503-fabd-4a52-bbf6-6e8a9663bdb8
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,143 +409,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VxYSS2XmJwMbwryn","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
-      Etag:
-      - W/"9f2ee7060ef11fafec50faa719639e30"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "975"
-      X-Request-Id:
-      - a615e2b7-abf0-45d5-9a79-ae434e216e08
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VxYSS2XmJwMbwryn
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_VxYSS2XmJwMbwryn","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:e0:d2:76:bd","state":"attached","ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
-      Etag:
-      - W/"46d4faeb8a1eefa61782a2dbf9d820e6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - cdec3d0b-c061-46c2-9490-e0bbe87aae30
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "752"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
-      Etag:
-      - W/"7c98884a7cfb307358293475725d99fb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "973"
-      X-Request-Id:
-      - d77d1f79-2fd8-49ac-b55b-022f28ef3334
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1214,13 +428,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2191"
+      - "2228"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
+      - W/"59d3313f48044c90db5a6f0282abb89b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1228,9 +442,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "972"
+      - "951"
       X-Request-Id:
-      - d2963f1e-66d3-4beb-9b70-204ba8e93567
+      - 4e47127c-f72a-45a0-87b4-42ba6d2aa39c
     status: 200 OK
     code: 200
     duration: ""
@@ -1242,96 +456,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VxYSS2XmJwMbwryn","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
-      Etag:
-      - W/"9f2ee7060ef11fafec50faa719639e30"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - 24da393e-b747-4624-b085-1740c13a74a1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VxYSS2XmJwMbwryn
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_VxYSS2XmJwMbwryn","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:e0:d2:76:bd","state":"attached","ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:53 GMT
-      Etag:
-      - W/"46d4faeb8a1eefa61782a2dbf9d820e6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "970"
-      X-Request-Id:
-      - 04018ee3-99c9-4912-908a-280e654411f3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VxYSS2XmJwMbwryn","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1344,9 +474,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:54 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"f6e9a94381f8b66d7a7a6980086faaf3"
+      - W/"d59211dc265af79795b74e38dc63311a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1354,53 +484,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "969"
+      - "950"
       X-Request-Id:
-      - 1dd2c438-0cc1-40c4-b352-e92580cc0385
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_VxYSS2XmJwMbwryn"},"speed_profile":{"permalink":"1gbps"}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/update_speed_profile
-    method: PATCH
-  response:
-    body: '{"task":{"id":"task_5wmP3XV4psMXACDg","name":"Change network interface
-      speed profile","status":"pending","created_at":1678291374,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "180"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:02:54 GMT
-      Etag:
-      - W/"08a9ea6d702aad755bfc4edbd131aeb3"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "968"
-      X-Request-Id:
-      - 251913c7-12e3-4b1a-bf36-70594bec5091
+      - 04b4508c-71b0-4f85-9c92-aefc8369c5ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1412,11 +498,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_5wmP3XV4psMXACDg
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
     method: GET
   response:
-    body: '{"task":{"id":"task_5wmP3XV4psMXACDg","name":"Change network interface
-      speed profile","status":"running","created_at":1678291374,"started_at":1678291374,"finished_at":null,"progress":5}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1425,13 +512,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "186"
+      - "535"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:02:55 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"b8bea92bdccc2de7e87bbc8dd499b3c6"
+      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1439,231 +526,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "949"
       X-Request-Id:
-      - 1cfdde7b-efaf-4b7f-9eae-c59bd5a0bf7f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_5wmP3XV4psMXACDg
-    method: GET
-  response:
-    body: '{"task":{"id":"task_5wmP3XV4psMXACDg","name":"Change network interface
-      speed profile","status":"completed","created_at":1678291374,"started_at":1678291374,"finished_at":1678291376,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "196"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:03:00 GMT
-      Etag:
-      - W/"70d724cb11c70136413ec0cd0e6ca2a4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - bc77bf81-f85b-4553-bad4-427f9e9ed3cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3"},"properties":{}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2191"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:03:00 GMT
-      Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - ed38130a-2ca1-42fe-97df-3fb53e3589a0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2191"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:03:00 GMT
-      Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - bfd6d10f-0088-479a-b65b-5d356c8ef1dc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VxYSS2XmJwMbwryn","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:03:00 GMT
-      Etag:
-      - W/"9f2ee7060ef11fafec50faa719639e30"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 6ee07252-a6cb-4875-adab-ab27b0769cb0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VxYSS2XmJwMbwryn
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_VxYSS2XmJwMbwryn","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:e0:d2:76:bd","state":"attached","ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "532"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:03:00 GMT
-      Etag:
-      - W/"417e3fd87f4603602384ffe38a1e84bc"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - d78af1fb-bbbf-4147-a51c-a983f7ad62be
+      - 3338d24d-29c7-4175-88b1-90c0a57d8678
     status: 200 OK
     code: 200
     duration: ""
@@ -1675,17 +540,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1694,13 +559,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2191"
+      - "2228"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:00 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
+      - W/"59d3313f48044c90db5a6f0282abb89b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1708,9 +573,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "948"
       X-Request-Id:
-      - fd76e6bd-d83c-4e27-960b-05af0c2219cc
+      - 9f2f579b-8cd2-47aa-a292-a63c5a84f3cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1722,12 +587,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1740,9 +605,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:01 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"7c98884a7cfb307358293475725d99fb"
+      - W/"82e66b226d29c4cc79f588a80e89e331"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1750,9 +615,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "947"
       X-Request-Id:
-      - 243c9f10-482f-47e2-adf2-da51f1838b07
+      - 5b84e238-a729-4d71-842b-38ec1cd1825d
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,17 +629,17 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1783,13 +648,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2191"
+      - "2228"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:01 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
+      - W/"59d3313f48044c90db5a6f0282abb89b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1797,9 +662,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "946"
       X-Request-Id:
-      - 849bf2f4-c35e-4b7e-b8ac-fe4f40c100ad
+      - 0c1380c7-a754-4eaf-a484-5ed523f4d3a8
     status: 200 OK
     code: 200
     duration: ""
@@ -1811,12 +676,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VxYSS2XmJwMbwryn","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1825,13 +690,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "381"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:01 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"9f2ee7060ef11fafec50faa719639e30"
+      - W/"d59211dc265af79795b74e38dc63311a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1839,9 +704,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "945"
       X-Request-Id:
-      - cf38c876-f803-4599-aa6c-b8babd710258
+      - b35ed39f-db50-4f88-842b-b1d1babd7d64
     status: 200 OK
     code: 200
     duration: ""
@@ -1853,12 +718,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VxYSS2XmJwMbwryn
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_VxYSS2XmJwMbwryn","virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-vh7nvao069pa","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c2:e0:d2:76:bd","state":"attached","ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1867,13 +732,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "532"
+      - "535"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:01 GMT
+      - Wed, 22 Mar 2023 17:38:39 GMT
       Etag:
-      - W/"417e3fd87f4603602384ffe38a1e84bc"
+      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1881,9 +746,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "944"
       X-Request-Id:
-      - 8a019fdc-e509-4a52-9d5b-bd0a614c5c62
+      - a37fd33b-6946-4211-af55-65a3c469e04a
     status: 200 OK
     code: 200
     duration: ""
@@ -1895,17 +760,59 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "752"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:40 GMT
+      Etag:
+      - W/"82e66b226d29c4cc79f588a80e89e331"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - bdf27eac-eba6-44fc-b42b-e2ccc5965b67
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1914,13 +821,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2191"
+      - "2228"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:01 GMT
+      - Wed, 22 Mar 2023 17:38:40 GMT
       Etag:
-      - W/"7749467c8a22ac163a051737668d1ae6"
+      - W/"59d3313f48044c90db5a6f0282abb89b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -1928,9 +835,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "942"
       X-Request-Id:
-      - 288481f3-8e0d-4928-865c-3fcf7766e134
+      - ff1185aa-87c3-42cd-8bde-85763717d516
     status: 200 OK
     code: 200
     duration: ""
@@ -1942,50 +849,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: POST
-  response:
-    body: '{"task":{"id":"task_zO4wWeJyf1aP8Wkq","name":"Stop virtual machine","status":"pending"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "88"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:03:01 GMT
-      Etag:
-      - W/"1c8d665d0082c99bda38f82b6193ab3d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - c48c30a1-801d-49f7-89b5-a9cc45767b8d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_zO4wWeJyf1aP8Wkq
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
     method: GET
   response:
-    body: '{"task":{"id":"task_zO4wWeJyf1aP8Wkq","name":"Stop virtual machine","status":"running","created_at":1678291381,"started_at":1678291382,"finished_at":null,"progress":5}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -1994,13 +863,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "381"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:02 GMT
+      - Wed, 22 Mar 2023 17:38:40 GMT
       Etag:
-      - W/"3dc5eddb88cfb8ad8729247e885e6efa"
+      - W/"d59211dc265af79795b74e38dc63311a"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2008,9 +877,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "941"
       X-Request-Id:
-      - 03644147-c262-46f5-b8e3-63f1c1a5f33c
+      - 0f94a0ac-fbe2-40cd-bb04-6f6b4a3aa246
     status: 200 OK
     code: 200
     duration: ""
@@ -2022,10 +891,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_zO4wWeJyf1aP8Wkq
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
     method: GET
   response:
-    body: '{"task":{"id":"task_zO4wWeJyf1aP8Wkq","name":"Stop virtual machine","status":"completed","created_at":1678291381,"started_at":1678291382,"finished_at":1678291384,"progress":100}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2034,13 +905,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "178"
+      - "535"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:07 GMT
+      - Wed, 22 Mar 2023 17:38:40 GMT
       Etag:
-      - W/"d69fab78b82e40099d85e22d2cd3a105"
+      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2048,9 +919,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "940"
       X-Request-Id:
-      - 8e3d3694-9cf5-4d07-8ee4-fa3ad8e26f07
+      - 00ccd0cf-ed9b-4b3b-a811-c4fa857b6b96
     status: 200 OK
     code: 200
     duration: ""
@@ -2061,18 +932,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
-    method: DELETE
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_h20tKlYNJSQHGVCP","keep_until":1678464187,"object_id":"vm_w22OsLLcl5vxlgX3","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_w22OsLLcl5vxlgX3","name":"tf-acc-test-update-network-speed-profile-vh7nvao069pa","hostname":"tf-acc-test-faithful-polar-tungsten","fqdn":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1678291354,"initial_root_password":"js0idTpxLFFIUz4y","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Y1mpdmngnrGaqNde","address":"185.199.221.30","reverse_dns":"tf-acc-test-faithful-polar-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.30/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_w22OsLLcl5vxlgX3","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2081,13 +952,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2326"
+      - "2228"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:07 GMT
+      - Wed, 22 Mar 2023 17:38:40 GMT
       Etag:
-      - W/"c679952af31859fe9038562a76525c91"
+      - W/"59d3313f48044c90db5a6f0282abb89b"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2095,9 +966,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "939"
       X-Request-Id:
-      - 859c4689-6055-40eb-b100-3ff54bb8709f
+      - 8839332b-37fc-4a8d-9926-d6c7168a8003
     status: 200 OK
     code: 200
     duration: ""
@@ -2109,90 +980,12 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
-    method: POST
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:03:08 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 4e3a663a-afac-4993-8786-6b98f19900bc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_h20tKlYNJSQHGVCP
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_wj9zIUXW9jROzsuW","name":"Purge items from trash","status":"pending","created_at":1678291388,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 08 Mar 2023 16:03:08 GMT
-      Etag:
-      - W/"6390bb057af8bfc693652641989a3eb6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - 91b4a437-8bf4-4090-b9de-5d495b7e3353
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_wj9zIUXW9jROzsuW
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
-    body: '{"task":{"id":"task_wj9zIUXW9jROzsuW","name":"Purge items from trash","status":"running","created_at":1678291388,"started_at":1678291388,"finished_at":null,"progress":5}}'
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2201,13 +994,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "752"
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:09 GMT
+      - Wed, 22 Mar 2023 17:38:40 GMT
       Etag:
-      - W/"9945a67f7473c3550dc45c719c1cf1e0"
+      - W/"82e66b226d29c4cc79f588a80e89e331"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2215,9 +1008,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "982"
+      - "938"
       X-Request-Id:
-      - aa819685-bc79-40fa-ba1a-7f3368665b13
+      - 95b0edd6-dbe3-488c-a0f6-e9aa60bc66b7
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,10 +1022,360 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_wj9zIUXW9jROzsuW
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
     method: GET
   response:
-    body: '{"task":{"id":"task_wj9zIUXW9jROzsuW","name":"Purge items from trash","status":"completed","created_at":1678291388,"started_at":1678291388,"finished_at":1678291391,"progress":100}}'
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2228"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:40 GMT
+      Etag:
+      - W/"59d3313f48044c90db5a6f0282abb89b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "937"
+      X-Request-Id:
+      - 7d2ac060-a98e-4430-ba2c-d8f1c8d14a64
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "381"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:40 GMT
+      Etag:
+      - W/"d59211dc265af79795b74e38dc63311a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "936"
+      X-Request-Id:
+      - ebf35424-9da3-4c28-8cbf-f3de05b873d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "535"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:40 GMT
+      Etag:
+      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "935"
+      X-Request-Id:
+      - 1f9a3341-a2c5-4ce4-a41d-8033088ccde6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "752"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:41 GMT
+      Etag:
+      - W/"82e66b226d29c4cc79f588a80e89e331"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "933"
+      X-Request-Id:
+      - 91631938-87f3-498c-9927-7e3c75fe4035
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2228"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:41 GMT
+      Etag:
+      - W/"59d3313f48044c90db5a6f0282abb89b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "932"
+      X-Request-Id:
+      - 616f93ca-9ec8-4665-8a2a-e2b7a283c07b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "381"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:41 GMT
+      Etag:
+      - W/"d59211dc265af79795b74e38dc63311a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "931"
+      X-Request-Id:
+      - ec03bf8a-ba54-4666-a0ee-804220efcdd1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:70:83:b8:00:49","state":"detached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "535"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:41 GMT
+      Etag:
+      - W/"8afbc2b9a3e81c1fbef81cfe60693f97"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "930"
+      X-Request-Id:
+      - ed333589-7143-4eeb-9062-071c02e01e83
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "382"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:41 GMT
+      Etag:
+      - W/"a1d84ddf75fbd59486b26e46256ced0c"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "929"
+      X-Request-Id:
+      - 9fbcd02a-6704-4592-a433-e8bb89eaa62b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN"},"speed_profile":{"permalink":"1gbps"}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/update_speed_profile
+    method: PATCH
+  response:
+    body: '{"task":{"id":"task_PHKU4HpBWF22kYFY","name":"Change network interface
+      speed profile","status":"pending","created_at":1679506721,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Methods:
       - '*'
@@ -2245,9 +1388,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:14 GMT
+      - Wed, 22 Mar 2023 17:38:41 GMT
       Etag:
-      - W/"1c851f8a6c04712d80269fb05209f057"
+      - W/"56b6d0327863751f0e173bdc2080bace"
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2255,9 +1398,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "981"
+      - "928"
       X-Request-Id:
-      - 041dd2d2-8e02-4334-a704-ce6a6fce80dc
+      - c4cd0b81-02f6-4f90-998c-f3e84445de2e
     status: 200 OK
     code: 200
     duration: ""
@@ -2269,7 +1412,945 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
+    url: https://api.katapult.io/core/v1/tasks/task_PHKU4HpBWF22kYFY
+    method: GET
+  response:
+    body: '{"task":{"id":"task_PHKU4HpBWF22kYFY","name":"Change network interface
+      speed profile","status":"running","created_at":1679506721,"started_at":1679506722,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "186"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:42 GMT
+      Etag:
+      - W/"55d807f7111805c9bd2392c8eef07cb4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "927"
+      X-Request-Id:
+      - 43eef81b-6bf0-4f04-80e3-150c8379e6b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_PHKU4HpBWF22kYFY
+    method: GET
+  response:
+    body: '{"task":{"id":"task_PHKU4HpBWF22kYFY","name":"Change network interface
+      speed profile","status":"completed","created_at":1679506721,"started_at":1679506722,"finished_at":1679506723,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "196"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:47 GMT
+      Etag:
+      - W/"65cb181823519540bb7b611775546933"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "924"
+      X-Request-Id:
+      - cfe329c1-5f0b-4b90-be7a-beeb03e9d3e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21"},"properties":{}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
+  response:
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2228"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:47 GMT
+      Etag:
+      - W/"59d3313f48044c90db5a6f0282abb89b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "923"
+      X-Request-Id:
+      - fa9005fb-68a7-411c-8f17-37b75f96c502
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2228"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:47 GMT
+      Etag:
+      - W/"59d3313f48044c90db5a6f0282abb89b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "922"
+      X-Request-Id:
+      - a52147f9-d7bb-4fd2-b14e-6a1e7ee07a4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "381"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:47 GMT
+      Etag:
+      - W/"d59211dc265af79795b74e38dc63311a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "921"
+      X-Request-Id:
+      - 646d8be1-b8c9-47c9-84ab-d621937cbba5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:70:83:b8:00:49","state":"attached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "533"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:47 GMT
+      Etag:
+      - W/"c3ec417afddedc48786d0fcc19694e07"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "920"
+      X-Request-Id:
+      - 063f3372-342f-41b6-9f15-4f6ded50e487
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2228"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:47 GMT
+      Etag:
+      - W/"59d3313f48044c90db5a6f0282abb89b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "919"
+      X-Request-Id:
+      - b3457cc4-a29b-4daa-9f87-e41b681ced78
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "752"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:48 GMT
+      Etag:
+      - W/"82e66b226d29c4cc79f588a80e89e331"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "918"
+      X-Request-Id:
+      - 1e338f80-4930-43ec-8c75-5bc09ecef4a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2228"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:48 GMT
+      Etag:
+      - W/"59d3313f48044c90db5a6f0282abb89b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "917"
+      X-Request-Id:
+      - 1e92ecfc-3366-4702-8081-f2717c472b97
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_e3KTVU08EIjFqCuN","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}]}]}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "381"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:48 GMT
+      Etag:
+      - W/"d59211dc265af79795b74e38dc63311a"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "916"
+      X-Request-Id:
+      - 42a8a355-1151-4abd-b74a-6cb1df811d4f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_e3KTVU08EIjFqCuN
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_e3KTVU08EIjFqCuN","virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"mac_address":"3a:70:83:b8:00:49","state":"attached","ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "533"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:48 GMT
+      Etag:
+      - W/"c3ec417afddedc48786d0fcc19694e07"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "915"
+      X-Request-Id:
+      - e8cbeab4-a2d3-413b-9fa9-d2c00288c711
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2228"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:48 GMT
+      Etag:
+      - W/"59d3313f48044c90db5a6f0282abb89b"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "914"
+      X-Request-Id:
+      - afaab44a-37ac-4f24-bd90-0361ef2544ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: POST
+  response:
+    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:48 GMT
+      Etag:
+      - W/"7f7aa6fe826db0c2d9422a85ed9f7bed"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "913"
+      X-Request-Id:
+      - 5c4b131f-3036-4bf9-a576-026e64696a22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_jWfLrcdlfoZi030j
+    method: GET
+  response:
+    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"pending","created_at":1679506728,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:49 GMT
+      Etag:
+      - W/"0d2dae7c4a33d549eea1dc39d0a612f4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "912"
+      X-Request-Id:
+      - 48d79773-bf50-49c4-91a6-b72da872b477
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_jWfLrcdlfoZi030j
+    method: GET
+  response:
+    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"pending","created_at":1679506728,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:38:54 GMT
+      Etag:
+      - W/"0d2dae7c4a33d549eea1dc39d0a612f4"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "909"
+      X-Request-Id:
+      - 12381f96-c03c-417e-a97f-afece592626b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_jWfLrcdlfoZi030j
+    method: GET
+  response:
+    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"running","created_at":1679506728,"started_at":1679506744,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:04 GMT
+      Etag:
+      - W/"70c81fcbed8d5ed2d3b58b6c487abbd6"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 582a7fb6-3ff7-4e1f-a390-9f4ed614038e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_jWfLrcdlfoZi030j
+    method: GET
+  response:
+    body: '{"task":{"id":"task_jWfLrcdlfoZi030j","name":"Stop virtual machine","status":"completed","created_at":1679506728,"started_at":1679506744,"finished_at":1679506746,"progress":100}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:14 GMT
+      Etag:
+      - W/"9c2367d07a96e4ef7a6917badc0f4401"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "930"
+      X-Request-Id:
+      - 08798d4d-f1b0-408c-b95b-1f15bdc2e7d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_huvibuDYsguvMlaR","keep_until":1679679554,"object_id":"vm_GtdWxZwhN4dJ4J21","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_GtdWxZwhN4dJ4J21","name":"tf-acc-test-update-network-speed-profile-gnj2p4sib0lk","hostname":"tf-acc-test-ashy-lunar-woodpecker","fqdn":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679506700,"initial_root_password":"lbbwBOC710C5DfdH","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_3BDhWnR6wcxRtkfv","address":"185.199.222.216","reverse_dns":"tf-acc-test-ashy-lunar-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.216/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GtdWxZwhN4dJ4J21","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2363"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:14 GMT
+      Etag:
+      - W/"b47a8c86445da5f00a8f23be0f8609d8"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "929"
+      X-Request-Id:
+      - 797502bf-d143-45f2-a401-9ceaba55b758
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:15 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "928"
+      X-Request-Id:
+      - 843ddad0-4e1f-47c5-8572-71c29e0ae1bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_huvibuDYsguvMlaR
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_djBcErfRcrs3QHco","name":"Purge items from trash","status":"pending","created_at":1679506755,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:15 GMT
+      Etag:
+      - W/"c8b44e15ace147615ff94ed83c70c1c0"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "924"
+      X-Request-Id:
+      - 0c370854-4d3e-4ab9-94d3-bf4d8093df70
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_huvibuDYsguvMlaR
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_huvibuDYsguvMlaR","keep_until":1679679554,"object_id":"vm_GtdWxZwhN4dJ4J21","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:16 GMT
+      Etag:
+      - W/"6dfae61a12447bc193505ddbaf62fedb"
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "921"
+      X-Request-Id:
+      - 36b13a6d-53b1-4c21-a677-d0a6cb203756
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bid%5D=trsh_huvibuDYsguvMlaR
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Methods:
+      - '*'
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 22 Mar 2023 17:39:21 GMT
+      Server:
+      - Caddy
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "918"
+      X-Request-Id:
+      - 6c224374-afe8-440f-b192-a132423410b0
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: DELETE
   response:
     body: '{}'
@@ -2285,7 +2366,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:15 GMT
+      - Wed, 22 Mar 2023 17:39:21 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Server:
@@ -2295,9 +2376,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "980"
+      - "917"
       X-Request-Id:
-      - 7bddf90c-42f6-4732-b59f-34abc3c51d56
+      - 82af8b50-d074-463c-b753-4128e8cc5c23
     status: 200 OK
     code: 200
     duration: ""
@@ -2309,7 +2390,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_w22OsLLcl5vxlgX3
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GtdWxZwhN4dJ4J21
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
@@ -2326,7 +2407,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:15 GMT
+      - Wed, 22 Mar 2023 17:39:21 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2336,9 +2417,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "979"
+      - "916"
       X-Request-Id:
-      - 58a682cd-57a1-4177-bad4-2147128419d7
+      - f8578b34-1a47-40d1-91ef-1872dbbb1d1b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2350,7 +2431,7 @@ interactions:
       - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Y1mpdmngnrGaqNde
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BDhWnR6wcxRtkfv
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
@@ -2367,7 +2448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Mar 2023 16:03:15 GMT
+      - Wed, 22 Mar 2023 17:39:21 GMT
       Server:
       - Caddy
       Strict-Transport-Security:
@@ -2377,9 +2458,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "978"
+      - "915"
       X-Request-Id:
-      - d428a224-271d-47ef-b968-0db3b699a9e5
+      - a11814e0-7d14-4f73-9288-15e2411bed47
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
Check trash objects directly, and wait for them to disappear. Instead of
simply waiting for the purge task we triggered to complete.

Some purge operations need to run as separate background tasks in
Katapult, meaning the main task for the purge trash object request may
finish before the object itself is fully deleted.

---

Also enhance VM destroyed check test helper to verify there's no trash object left, and fix a issue with the Security Group sweeper.