### PR TITLE
ci: update test matrix versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
       matrix:
         terraform_version:
           - "" # latest
-          - "1.3.7"
-          - "1.2.9"
-          - "1.1.9"
-          - "1.0.11"
+          - "1.6.6"
+          - "1.5.7"
+          - "1.4.7"
+          - "1.3.10"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ listed in the release notes and changelog.
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) 1.0 or later.
+- [Terraform](https://www.terraform.io/downloads.html) 1.3 or later.
 
 ## Using the Provider
 
@@ -75,7 +75,7 @@ make build
 ### Requirements
 
 - [Go](https://golang.org/dl/) 1.19 or later.
-- [Terraform](https://www.terraform.io/downloads.html) 1.0 or later.
+- [Terraform](https://www.terraform.io/downloads.html) 1.3 or later.
 
 ### Rules
 


### PR DESCRIPTION
Drops `1.0.x`, `1.1.x` and `1.2.x` from our test matrix. 
Adds `1.4.x` , `1.5.x` and `1.6.x` to our test matrix