### PR TITLE
ci(check/pr): add semantic-pr workflow to check PR titles

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,50 @@
+name: "Semantic PR"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: write
+  statuses: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Post a comment when the PR title is invalid
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            ### Pull Request Title Check Failure
+
+            The pull request title is not formatted according to [Conventional Commits](https://www.conventionalcommits.org/).
+
+            Please update the pull request title to following the format:
+
+            ```
+            <type>[optional scope]: <description>
+            ```
+
+            ### Check Failure Details:
+
+            ${{ steps.lint_pr_title.outputs.error_message }}
+
+      # Delete a previous comment when the issue has been resolved
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
This ensures that all PR titles follow conventional commit formatting, which is
needed for our release process to automatically pick up changes, update the
changelog and propose a new release version.