### PR TITLE
chore(deps): update minimum supported Terraform version to 1.4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,13 @@ jobs:
       matrix:
         terraform_version:
           - "" # latest
+          - "1.10.0"
           - "1.9.8"
           - "1.8.5"
           - "1.7.5"
           - "1.6.6"
           - "1.5.7"
           - "1.4.7"
-          - "1.3.10"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ listed in the release notes and changelog.
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) 1.3 or later.
+- [Terraform](https://www.terraform.io/downloads.html) 1.4 or later. Earlier
+  versions may work, but are untested.
 
 ## Using the Provider
 
@@ -75,7 +76,7 @@ make build
 ### Requirements
 
 - [Go](https://golang.org/dl/) 1.23 or later.
-- [Terraform](https://www.terraform.io/downloads.html) 1.3 or later.
+- [Terraform](https://www.terraform.io/downloads.html) 1.4 or later.
 
 ### Rules
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.23"
-terraform = "1.8"
+terraform = "1.10"
 
 [env]
 # DO NOT put local environment variables here. Use mise.local.toml instead.


### PR DESCRIPTION
Earlier versions may still work, but are not officially supported, nor tested.