### PR TITLE
feat(katapult_virtual_machine): add virtual network management support

### DIFF
--- a/docs/data-sources/virtual_machine.md
+++ b/docs/data-sources/virtual_machine.md
@@ -42,7 +42,20 @@ data "katapult_virtual_machine" "web-1" {
 - `ip_address_ids` (Set of String) One or more IP IDs.
 - `ip_addresses` (Set of String)
 - `name` (String)
+- `network_interfaces` (List of Object) Network interface details for the virtual machine. (see [below for nested schema](#nestedatt--network_interfaces))
 - `network_speed_profile` (String) Permalink of a Network Speed Profile.
 - `package` (String) Permalink or ID of a Virtual Machine Package.
 - `state` (String)
 - `tags` (Set of String)
+- `virtual_network_ids` (Set of String) Virtual Networks attached to the VM.
+
+<a id="nestedatt--network_interfaces"></a>
+### Nested Schema for `network_interfaces`
+
+Read-Only:
+
+- `id` (String)
+- `ip_addresses` (Set of String)
+- `mac_address` (String)
+- `network_id` (String)
+- `virtual_network_id` (String)

--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -92,12 +92,14 @@ resource "katapult_virtual_machine" "base" {
 - `network_speed_profile` (String) Permalink of a Network Speed Profile.
 - `tags` (Set of String)
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `virtual_network_ids` (Set of String) Virtual Networks attached to the VM.
 
 ### Read-Only
 
 - `fqdn` (String)
 - `id` (String) The ID of this resource.
 - `ip_addresses` (Set of String)
+- `network_interfaces` (List of Object) Network interface details for the virtual machine. (see [below for nested schema](#nestedatt--network_interfaces))
 - `state` (String)
 
 <a id="nestedblock--disk"></a>
@@ -120,3 +122,15 @@ Optional:
 - `create` (String)
 - `delete` (String)
 - `update` (String)
+
+
+<a id="nestedatt--network_interfaces"></a>
+### Nested Schema for `network_interfaces`
+
+Read-Only:
+
+- `id` (String)
+- `ip_addresses` (Set of String)
+- `mac_address` (String)
+- `network_id` (String)
+- `virtual_network_id` (String)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/jimeh/undent v1.1.1
 	github.com/krystal/go-katapult v0.2.13
 	github.com/stretchr/testify v1.9.0
+	github.com/tidwall/gjson v1.18.0
 )
 
 require (
@@ -62,6 +63,8 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,12 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/generic_api_error.go
+++ b/internal/provider/generic_api_error.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+type GenericAPIError struct {
+	Code        string
+	Description string
+	Detail      string
+}
+
+func (e *GenericAPIError) Error() string {
+	r := e.Code
+
+	if e.Description != "" {
+		r += ": " + e.Description
+	}
+
+	if e.Detail != "" {
+		r += ": " + e.Detail
+	}
+
+	return r
+}
+
+func genericAPIError(err error, body []byte) error {
+	apiErr := parseGenericAPIError(body)
+	if apiErr != nil {
+		return apiErr
+	}
+
+	return err
+}
+
+func parseGenericAPIError(body []byte) *GenericAPIError {
+	gj := gjson.ParseBytes(body)
+
+	code := gj.Get("error.code").String()
+	if code == "" {
+		return nil
+	}
+
+	err := &GenericAPIError{
+		Code:        code,
+		Description: gj.Get("error.description").String(),
+	}
+
+	if detail := gj.Get("error.detail"); detail.Exists() {
+		var values []string
+		switch {
+		case detail.IsArray():
+			detail.ForEach(func(_, v gjson.Result) bool {
+				values = append(values, v.String())
+
+				return true
+			})
+		case detail.IsObject():
+			for k, v := range detail.Map() {
+				values = append(values, k+"="+v.String())
+			}
+			sort.Strings(values)
+		default:
+			values = append(values, detail.String())
+		}
+
+		err.Detail = strings.Join(values, ", ")
+	}
+
+	return err
+}

--- a/internal/provider/generic_api_error_test.go
+++ b/internal/provider/generic_api_error_test.go
@@ -1,0 +1,140 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseGenericAPIError(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		want *GenericAPIError
+	}{
+		{
+			name: "valid error response",
+			body: []byte(`{
+				"error": {
+					"code": "not_found",
+					"description": "Resource not found"
+				}
+			}`),
+			want: &GenericAPIError{
+				Code:        "not_found",
+				Description: "Resource not found",
+			},
+		},
+		{
+			name: "error with detail array",
+			body: []byte(`{
+				"error": {
+					"code": "not_found",
+					"description": "Resource not found",
+					"detail": ["this is", "an array"]
+				}
+			}`),
+			want: &GenericAPIError{
+				Code:        "not_found",
+				Description: "Resource not found",
+				Detail:      "this is, an array",
+			},
+		},
+		{
+			name: "error with detail object",
+			body: []byte(`{
+				"error": {
+					"code": "not_found",
+					"description": "Resource not found",
+					"detail": {"scope": "global", "data": "none"}
+				}
+			}`),
+			want: &GenericAPIError{
+				Code:        "not_found",
+				Description: "Resource not found",
+				Detail:      "data=none, scope=global",
+			},
+		},
+		{
+			name: "missing error code",
+			body: []byte(`{
+				"error": {
+					"description": "Something went wrong"
+				}
+			}`),
+			want: nil,
+		},
+		{
+			name: "invalid json",
+			body: []byte(`not json`),
+			want: nil,
+		},
+		{
+			name: "empty response",
+			body: []byte(``),
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGenericAPIError(tt.body)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_genericAPIError(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		body    []byte
+		wantErr error
+	}{
+		{
+			name: "valid API error",
+			err:  errors.New("original error"),
+			body: []byte(`{
+				"error": {
+					"code": "not_found",
+					"description": "Resource not found"
+				}
+			}`),
+			wantErr: &GenericAPIError{
+				Code:        "not_found",
+				Description: "Resource not found",
+			},
+		},
+		{
+			name:    "no API error returns original error",
+			err:     errors.New("original error"),
+			body:    []byte(`{}`),
+			wantErr: errors.New("original error"),
+		},
+		{
+			name:    "empty body returns original error",
+			err:     errors.New("original error"),
+			body:    []byte(``),
+			wantErr: errors.New("original error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := genericAPIError(tt.err, tt.body)
+
+			if tt.wantErr == nil {
+				assert.NoError(t, got)
+			} else {
+				var apiErr *GenericAPIError
+				if errors.As(tt.wantErr, &apiErr) {
+					assert.Equal(t, apiErr, got)
+				} else {
+					assert.Equal(t, tt.wantErr.Error(), got.Error())
+				}
+			}
+		})
+	}
+}

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -101,7 +102,7 @@ func waitForTaskCompletion(
 	ctx context.Context,
 	m *Meta,
 	timeout time.Duration,
-	task *core.Task,
+	taskID string,
 ) error {
 	taskWaiter := &retry.StateChangeConf{
 		Pending: []string{
@@ -112,7 +113,7 @@ func waitForTaskCompletion(
 			string(core.TaskCompleted),
 		},
 		Refresh: func() (interface{}, string, error) {
-			t, _, e := m.Core.Tasks.Get(ctx, task.ID)
+			t, _, e := m.Core.Tasks.Get(ctx, taskID)
 			if e != nil {
 				return t, "", e
 			}
@@ -137,26 +138,12 @@ func stringsDiff(a, b []string) []string {
 	r := []string{}
 
 	for _, v := range a {
-		if !stringsContain(b, v) {
+		if !slices.Contains(b, v) {
 			r = append(r, v)
 		}
 	}
 
 	return r
-}
-
-func stringsContain(strs []string, s string) bool {
-	if len(strs) == 0 || s == "" {
-		return false
-	}
-
-	for _, v := range strs {
-		if v == s {
-			return true
-		}
-	}
-
-	return false
 }
 
 func stringsEqual(a, b []string) bool {

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -80,47 +80,6 @@ func Benchmark_stringsDiff(b *testing.B) {
 	}
 }
 
-func Test_stringsContain(t *testing.T) {
-	tests := []struct {
-		name string
-		strs []string
-		s    string
-		want bool
-	}{
-		{
-			name: "empty slice",
-			strs: []string{},
-			s:    "pompano",
-			want: false,
-		},
-		{
-			name: "empty string",
-			strs: []string{"roster", "wish", "pompano", "upscale", "pelf"},
-			s:    "",
-			want: false,
-		},
-		{
-			name: "present",
-			strs: []string{"roster", "wish", "pompano", "upscale", "pelf"},
-			s:    "pompano",
-			want: true,
-		},
-		{
-			name: "missing",
-			strs: []string{"roster", "wish", "pompano", "upscale", "pelf"},
-			s:    "bale",
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := stringsContain(tt.strs, tt.s)
-
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func Test_stringsEqual(t *testing.T) {
 	tests := []struct {
 		name string
@@ -170,6 +129,55 @@ func Test_stringsEqual(t *testing.T) {
 			got := stringsEqual(tt.a, tt.b)
 
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_mapKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]any
+		want []string
+	}{
+		{
+			name: "empty map",
+			m:    map[string]any{},
+			want: []string{},
+		},
+		{
+			name: "map with string values",
+			m: map[string]any{
+				"name":     "John",
+				"age":      "30",
+				"location": "NY",
+			},
+			want: []string{"name", "age", "location"},
+		},
+		{
+			name: "map with mixed value types",
+			m: map[string]any{
+				"name":    "John",
+				"age":     42,
+				"active":  true,
+				"hobbies": []string{"reading", "coding"},
+				"address": map[string]string{"city": "NY"},
+				"nothing": nil,
+			},
+			want: []string{
+				"name",
+				"age",
+				"active",
+				"hobbies",
+				"address",
+				"nothing",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapKeys(tt.m)
+			assert.ElementsMatch(t, tt.want, got)
 		})
 	}
 }

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -5,12 +5,14 @@ import (
 	"github.com/krystal/go-katapult"
 	"github.com/krystal/go-katapult/core"
 	"github.com/krystal/go-katapult/namegenerator"
+	corenext "github.com/krystal/go-katapult/next/core"
 )
 
 type Meta struct {
-	Client *katapult.Client
-	Core   *core.Client
-	Logger hclog.Logger
+	Client   *katapult.Client
+	Core     *core.Client
+	CoreNext corenext.ClientWithResponsesInterface
+	Logger   hclog.Logger
 
 	GeneratedNamePrefix  string
 	SkipTrashObjectPurge bool

--- a/internal/provider/testdata/DataSourceFileStorageVolume_associations.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceFileStorageVolume_associations.cassette.rand_id
@@ -1,1 +1,1 @@
-jcmon00bkgg1
+1i9qkof7v9ph

--- a/internal/provider/testdata/DataSourceFileStorageVolume_associations.cassette.yaml
+++ b/internal/provider/testdata/DataSourceFileStorageVolume_associations.cassette.yaml
@@ -8,36 +8,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:47 GMT
+      - Thu, 06 Feb 2025 16:47:48 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "641"
+      - "988"
       X-Request-Id:
-      - e889c02b-4651-4a89-a716-e832c1556483
+      - a70e1cd1-e588-4ca3-9829-5980f0d97169
     status: 200 OK
     code: 200
     duration: ""
@@ -51,306 +53,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"185-44-252-217.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:50 GMT
+      - Thu, 06 Feb 2025 16:47:48 GMT
       Etag:
-      - W/"bca869113d81fc0901f92a0d7516e299"
-      Server:
-      - Caddy
+      - W/"edf83e158d45d4aaf900b16be42fea42"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "640"
-      X-Request-Id:
-      - 0b87c8c2-7a1e-4ff9-81a9-0b2991ccba03
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:50 GMT
-      Etag:
-      - W/"e885820193fa788a5a81f9194c9217d1"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "638"
-      X-Request-Id:
-      - 525d491f-4d2f-465d-9369-6c6641c4eb94
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:50 GMT
-      Etag:
-      - W/"e885820193fa788a5a81f9194c9217d1"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "637"
-      X-Request-Id:
-      - 408c463f-d728-466c-ad50-3031cfad4e28
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_Ntu5DTZickqN6c9T</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-associations-jcmon00bkgg1-web</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
-    method: POST
-  response:
-    body: '{"task":{"id":"task_BAk7Mdn462ki7hxh","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_nmBRRJckx4oUm5IB","state":"pending"},"virtual_machine_build":{"id":"vmbuild_nmBRRJckx4oUm5IB","state":"pending"},"hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web"}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "292"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
-      Etag:
-      - W/"96c31de3d49fe353506948247adbfeb9"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "636"
-      X-Request-Id:
-      - 88c180ff-d060-4c3c-a35d-2dc3d3618605
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_nmBRRJckx4oUm5IB
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_nmBRRJckx4oUm5IB","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-jcmon00bkgg1-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679595291}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1403"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:53 GMT
-      Etag:
-      - W/"82a109b8bc51f503d239e2b9b21faa53"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "620"
-      X-Request-Id:
-      - 3fe2607d-1d5f-46e3-a863-645f5d5d629c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_nmBRRJckx4oUm5IB
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_nmBRRJckx4oUm5IB","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-jcmon00bkgg1-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595291}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1672"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:58 GMT
-      Etag:
-      - W/"247266c2a443c132480c639ecbd61cf8"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "594"
-      X-Request-Id:
-      - 60b9841d-7849-4a2e-ad2b-edf1a356b5fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_nmBRRJckx4oUm5IB
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_nmBRRJckx4oUm5IB","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-jcmon00bkgg1-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679595291}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1673"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:08 GMT
-      Etag:
-      - W/"4a615113deb8c4c023eaf808589cf6c4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - d65445e7-df71-4265-a432-7fce021041ec
+      - 99458b74-45d1-4bcc-80ac-45c82e06d5d8
     status: 200 OK
     code: 200
     duration: ""
@@ -361,180 +97,90 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_PmbvFzngYirSA6Cy
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595292,"initial_root_password":"1mg1VhGMlsExeVyY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"}]}}'
+    body: '{"ip_address":{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"185-44-252-217.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2286"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:10 GMT
+      - Thu, 06 Feb 2025 16:47:48 GMT
       Etag:
-      - W/"2427d460f1d66c145b1f512964b326ad"
-      Server:
-      - Caddy
+      - W/"1f4faa9fb41caca7ee670edc5a7eeb2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 6fd3fb49-99c5-4ca3-b422-16a95ef14921
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_PmbvFzngYirSA6Cy
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"185-44-252-217.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "579"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:48 GMT
+      Etag:
+      - W/"1f4faa9fb41caca7ee670edc5a7eeb2e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - 66312d5e-e6fa-402f-b521-86e0982b701d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595292,"initial_root_password":"1mg1VhGMlsExeVyY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2286"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:10 GMT
-      Etag:
-      - W/"2427d460f1d66c145b1f512964b326ad"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - a92c2275-8e2c-46b4-90f5-d472e2eb75de
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_loFY4HzoOxzlOaOe","name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:10 GMT
-      Etag:
-      - W/"3b2e79dd35df5e8b874093573179fcc8"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - c4e1c544-2b86-4ec6-a52d-9d9e971c4941
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_loFY4HzoOxzlOaOe
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_loFY4HzoOxzlOaOe","virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web"},"name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:38:6b:26:88:bc","state":"attached","ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:10 GMT
-      Etag:
-      - W/"ec0bcf12b172b6498be7d78bda4befe3"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "982"
-      X-Request-Id:
-      - e86d4bef-6306-4040-90fd-936a0fab9c91
+      - 17f7ec22-8d40-40d7-bcea-39708860149e
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"]}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_PmbvFzngYirSA6Cy</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-associations-1i9qkof7v9ph-web</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -542,36 +188,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/file_storage_volumes
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"pending","nfs_location":null,"size":0}}'
+    body: '{"task":{"id":"task_4GlrWu2RnNFX54Eh","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_ht7oNb7emUi3PfPs","state":"pending"},"virtual_machine_build":{"id":"vmbuild_ht7oNb7emUi3PfPs","state":"pending"},"hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "282"
+      - "309"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:10 GMT
+      - Thu, 06 Feb 2025 16:47:48 GMT
       Etag:
-      - W/"456f04a2f5aae2c97209a6d3fc5efb7c"
-      Server:
-      - Caddy
+      - W/"dd6dcb72dc9a8f9b703fc687b44c5c76"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "981"
+      - "984"
       X-Request-Id:
-      - c9ed9f84-e016-434d-bad5-004020d69c80
+      - 57193c4b-2103-4006-8571-25d2c4236a56
     status: 201 Created
     code: 201
     duration: ""
@@ -582,36 +230,967 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ht7oNb7emUi3PfPs
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"configuring","nfs_location":null,"size":0}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_ht7oNb7emUi3PfPs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.217\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-1i9qkof7v9ph-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860468},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:50 GMT
+      Etag:
+      - W/"009dde6f9b2f67f296a3b16fa9f22470"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 6202eada-2c6f-4e48-a2fe-2d55fe0929ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ht7oNb7emUi3PfPs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_ht7oNb7emUi3PfPs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.217\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-1i9qkof7v9ph-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860468},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:56 GMT
+      Etag:
+      - W/"b395d15f4ae6f788ddd3cc6610eb13a0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 71cc8758-1c88-493c-bd13-40130753dd8a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ht7oNb7emUi3PfPs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_ht7oNb7emUi3PfPs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.217\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-1i9qkof7v9ph-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860468},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:06 GMT
+      Etag:
+      - W/"b395d15f4ae6f788ddd3cc6610eb13a0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - b9862b23-b1ec-469b-b336-9ded93f3d29b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ht7oNb7emUi3PfPs
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_ht7oNb7emUi3PfPs","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.217\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-1i9qkof7v9ph-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738860468},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:16 GMT
+      Etag:
+      - W/"bdfd682cf3b64947b0ad7bbd9db800e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 224936ed-0175-4cf4-a2c3-b6f9e86972d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860474,"initial_root_password":"1aKktBLbIORKToDk","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:18 GMT
+      Etag:
+      - W/"9e29bd6285daa55ccc9789c08db307cb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 81999eae-faa7-4569-b27c-9076e3c0f7e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860474,"initial_root_password":"1aKktBLbIORKToDk","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:18 GMT
+      Etag:
+      - W/"9e29bd6285daa55ccc9789c08db307cb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - cbf9b12f-0bf3-466f-ba31-2326985f2e8d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Jh0j5cwOMnZl3SrG","name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "286"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:12 GMT
+      - Thu, 06 Feb 2025 16:48:18 GMT
       Etag:
-      - W/"8e5add3d228e7f5edd0ac2838354a981"
-      Server:
-      - Caddy
+      - W/"ff76abb22a59cb8db47a3e93d26f70cf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 9dfbab98-6ff0-4d49-a89a-1a3f1b898926
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Jh0j5cwOMnZl3SrG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Jh0j5cwOMnZl3SrG","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:8e:88:70:b4:f1","state":"attached","ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:18 GMT
+      Etag:
+      - W/"bbaf7459bfa00c82ded3062d5a4ae87e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 46473eec-7bff-4564-80cc-81f60b68aa52
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Jh0j5cwOMnZl3SrG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Jh0j5cwOMnZl3SrG","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:8e:88:70:b4:f1","state":"attached","ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:18 GMT
+      Etag:
+      - W/"bbaf7459bfa00c82ded3062d5a4ae87e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 4dd23f15-7d1b-43b5-8fe3-c6f53cab327d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"]}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/file_storage_volumes
+    method: POST
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "299"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:18 GMT
+      Etag:
+      - W/"f2f829c65057a1ee2dffc9e3041239f4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 91076959-7e1d-4c91-b265-8c2f5ce8ca8a
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "303"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:20 GMT
+      Etag:
+      - W/"e75755180cd2c8e9fae949f01b672fde"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 56e317d0-dad9-403a-99f7-224f329adcfd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "303"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:25 GMT
+      Etag:
+      - W/"e75755180cd2c8e9fae949f01b672fde"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - e8304b7b-0f1e-49ab-8c10-949041dcd959
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:35 GMT
+      Etag:
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 4c913e5e-a085-4a4a-ab06-b1fe23aaf1e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - f2df4b21-a691-486d-a367-972c05d7b417
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - f9737fd6-dd79-4449-8c5a-e2fc7bcec146
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 69af050d-17a4-4d13-9c3e-23ac953684e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - ae07773b-4c0c-4436-bf8a-b877faa1bd61
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_PmbvFzngYirSA6Cy
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "785"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"cc02d3544224fc361edcac697f873788"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 2ad258eb-f769-41a7-be94-11a0cca3e509
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860474,"initial_root_password":"1aKktBLbIORKToDk","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"9e29bd6285daa55ccc9789c08db307cb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 46b302f6-fa80-4b1b-9aff-c0631059c542
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Jh0j5cwOMnZl3SrG","name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "404"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"ff76abb22a59cb8db47a3e93d26f70cf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 1ad24a1e-6ae1-4be9-8ae8-1b7ca62e2e93
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Jh0j5cwOMnZl3SrG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Jh0j5cwOMnZl3SrG","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:8e:88:70:b4:f1","state":"attached","ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"bbaf7459bfa00c82ded3062d5a4ae87e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 6e70ac5e-78f4-46bd-a119-175bcd4c1115
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Jh0j5cwOMnZl3SrG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Jh0j5cwOMnZl3SrG","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:8e:88:70:b4:f1","state":"attached","ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"bbaf7459bfa00c82ded3062d5a4ae87e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "980"
       X-Request-Id:
-      - 8bf6e16e-fecd-4f30-b2e9-259f46797871
+      - 1a41d2a2-5f0e-41e1-bac8-3e6679fb7adf
     status: 200 OK
     code: 200
     duration: ""
@@ -622,36 +1201,80 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "337"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:36 GMT
       Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 18456d73-5301-490f-8f30-55612bc3453a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:48:36 GMT
+      Etag:
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "978"
       X-Request-Id:
-      - 915abd84-a456-4688-8757-9ca0cd2cbdd0
+      - 1c1588ab-bdec-4815-86a5-e1f2de0b8d9d
     status: 200 OK
     code: 200
     duration: ""
@@ -662,36 +1285,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "337"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:36 GMT
       Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "977"
       X-Request-Id:
-      - 98aa81d1-ebb7-4e9d-80dc-83bf0866ada6
+      - 63ba52e6-265a-4116-a5c7-4995b8edeff5
     status: 200 OK
     code: 200
     duration: ""
@@ -702,36 +1327,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_PmbvFzngYirSA6Cy
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"ip_address":{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "337"
+      - "785"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:36 GMT
       Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
+      - W/"cc02d3544224fc361edcac697f873788"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - 722275e6-e014-414f-89ef-fcd193470476
+      - 60cfcb20-ab85-49b8-a23b-561b8d3ba2c0
     status: 200 OK
     code: 200
     duration: ""
@@ -742,36 +1371,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860474,"initial_root_password":"1aKktBLbIORKToDk","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "337"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:36 GMT
       Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
+      - W/"9e29bd6285daa55ccc9789c08db307cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "975"
       X-Request-Id:
-      - cd341096-bfee-49a9-a478-623d34cbed93
+      - 1035e642-9e4e-4488-98ec-35fc8a02a95f
     status: 200 OK
     code: 200
     duration: ""
@@ -779,39 +1416,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Jh0j5cwOMnZl3SrG","name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "337"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:36 GMT
       Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
+      - W/"ff76abb22a59cb8db47a3e93d26f70cf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "974"
       X-Request-Id:
-      - 86b8b00a-b124-433e-aff4-d4f4b2461acc
+      - bf853188-2ac8-46ec-ac3c-a3098167e6b0
     status: 200 OK
     code: 200
     duration: ""
@@ -819,41 +1458,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Jh0j5cwOMnZl3SrG
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Jh0j5cwOMnZl3SrG","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:8e:88:70:b4:f1","state":"attached","ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "770"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:36 GMT
       Etag:
-      - W/"bdb14e559ba8d8b708597b71e8e25cd6"
-      Server:
-      - Caddy
+      - W/"bbaf7459bfa00c82ded3062d5a4ae87e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "973"
       X-Request-Id:
-      - c763d8c2-aea1-4945-a436-83717dc0812c
+      - 5e9dfacf-0dda-40ac-ab97-0c8eb6e896e0
     status: 200 OK
     code: 200
     duration: ""
@@ -864,43 +1503,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Jh0j5cwOMnZl3SrG
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595292,"initial_root_password":"1mg1VhGMlsExeVyY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Jh0j5cwOMnZl3SrG","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:8e:88:70:b4:f1","state":"attached","ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2286"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:36 GMT
       Etag:
-      - W/"2427d460f1d66c145b1f512964b326ad"
-      Server:
-      - Caddy
+      - W/"bbaf7459bfa00c82ded3062d5a4ae87e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "972"
       X-Request-Id:
-      - 656a6f4e-ef39-4814-b07b-0a7ca8de0d0f
+      - d6f42eac-4a93-44f3-96b5-a9f371f7b3fc
     status: 200 OK
     code: 200
     duration: ""
@@ -911,38 +1547,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_loFY4HzoOxzlOaOe","name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"}]}]}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:36 GMT
       Etag:
-      - W/"3b2e79dd35df5e8b874093573179fcc8"
-      Server:
-      - Caddy
+      - W/"17fa1f5b18d5f4f28edc906d01f1b129"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "971"
       X-Request-Id:
-      - 64d3fe9b-18f0-49d2-8237-f16cc341c78c
+      - ea59e7ff-1635-480d-8f80-5db91289a891
     status: 200 OK
     code: 200
     duration: ""
@@ -953,411 +1589,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_loFY4HzoOxzlOaOe
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_loFY4HzoOxzlOaOe","virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web"},"name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:38:6b:26:88:bc","state":"attached","ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "534"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
+      - Thu, 06 Feb 2025 16:48:37 GMT
       Etag:
-      - W/"ec0bcf12b172b6498be7d78bda4befe3"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "970"
       X-Request-Id:
-      - d829d7ed-e11e-40ad-838f-98fbfef92ef7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:17 GMT
-      Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - 94522e04-c1c6-4bba-8723-aa0eda5417e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
-      Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "968"
-      X-Request-Id:
-      - 0db90426-af5b-4e10-8835-553efc30bb15
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
-      Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "967"
-      X-Request-Id:
-      - 6f19078e-2260-42c3-a04a-2c9c3db657b6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "770"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
-      Etag:
-      - W/"bdb14e559ba8d8b708597b71e8e25cd6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "966"
-      X-Request-Id:
-      - 4e87a2e3-9101-41c6-9b32-36805f01ed69
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595292,"initial_root_password":"1mg1VhGMlsExeVyY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2286"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
-      Etag:
-      - W/"2427d460f1d66c145b1f512964b326ad"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "965"
-      X-Request-Id:
-      - 7f2d1ed1-3369-485f-abb5-a2e4bea3b9f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_loFY4HzoOxzlOaOe","name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
-      Etag:
-      - W/"3b2e79dd35df5e8b874093573179fcc8"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "964"
-      X-Request-Id:
-      - bff07f79-c93b-4555-acf7-1f5e7765678a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_loFY4HzoOxzlOaOe
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_loFY4HzoOxzlOaOe","virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web"},"name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:38:6b:26:88:bc","state":"attached","ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
-      Etag:
-      - W/"ec0bcf12b172b6498be7d78bda4befe3"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "963"
-      X-Request-Id:
-      - 5b2b3220-d46d-48e1-b91c-33ba1be78669
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
-      Etag:
-      - W/"9da5eb6f7224f7261e7c06eed8c4aa75"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "962"
-      X-Request-Id:
-      - fd416840-1593-47b3-a38b-7efa4e9d0df1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
-    method: GET
-  response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "181"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
-      Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "961"
-      X-Request-Id:
-      - 7746da02-18fc-4576-83dd-d37085ef55b7
+      - 0d4e8420-429e-4d22-a61e-cca82bcca903
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,38 +1634,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"185-44-253-94.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
+      - Thu, 06 Feb 2025 16:48:37 GMT
       Etag:
-      - W/"137b10129b421fd5b21a6014fed1266d"
-      Server:
-      - Caddy
+      - W/"47eee63e832576d21541cecb3fffc601"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "969"
       X-Request-Id:
-      - 62a33760-d2e6-4e75-bdbd-864a211d1991
+      - 65b25dd8-5c1b-42c5-894d-a854964900bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1413,38 +1678,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8tA3BEBUDKsioZXp
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"185-44-253-94.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
+      - Thu, 06 Feb 2025 16:48:37 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"aa4df1d0a5823416224daa8c058a8d60"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "968"
       X-Request-Id:
-      - 411d87e8-eb51-400f-b104-074ada1592a2
+      - 24166103-f1e0-4462-a76f-e03fe981b25a
     status: 200 OK
     code: 200
     duration: ""
@@ -1455,44 +1722,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8tA3BEBUDKsioZXp
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"185-44-253-94.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:18 GMT
+      - Thu, 06 Feb 2025 16:48:37 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"aa4df1d0a5823416224daa8c058a8d60"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "967"
       X-Request-Id:
-      - 37dae8d7-79bf-494b-8cbd-a47e96db15f1
+      - b3a8b5b0-bbf9-43a5-ba77-e43868c3de4c
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_hc3GUyhBe6toov2e</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-associations-jcmon00bkgg1-db</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_8tA3BEBUDKsioZXp</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-associations-1i9qkof7v9ph-db</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -1500,36 +1769,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_IXXaQfp7iQAxkBwg","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_khg24h2qE5jwe0Fg","state":"pending"},"virtual_machine_build":{"id":"vmbuild_khg24h2qE5jwe0Fg","state":"pending"},"hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db"}'
+    body: '{"task":{"id":"task_xUJ658rJ9jTjRiau","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_Tt4BDGWGKrxC1oTz","state":"pending"},"virtual_machine_build":{"id":"vmbuild_Tt4BDGWGKrxC1oTz","state":"pending"},"hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "291"
+      - "308"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:19 GMT
+      - Thu, 06 Feb 2025 16:48:37 GMT
       Etag:
-      - W/"0edac8f48d20d98f896e959ae1fd8c34"
-      Server:
-      - Caddy
+      - W/"fc7c7eadb4e110d0782fbb92ff3851d2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "966"
       X-Request-Id:
-      - d5c390fb-b892-417e-9ae4-71a12bb6e81e
+      - 7418a5eb-40ac-407e-a27d-310813b0566e
     status: 201 Created
     code: 201
     duration: ""
@@ -1540,43 +1811,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_khg24h2qE5jwe0Fg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Tt4BDGWGKrxC1oTz
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_khg24h2qE5jwe0Fg","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Tt4BDGWGKrxC1oTz","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-jcmon00bkgg1-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.94\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-1i9qkof7v9ph-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595318}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860517},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1668"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:21 GMT
+      - Thu, 06 Feb 2025 16:48:39 GMT
       Etag:
-      - W/"f64df982cac5392c2da1dc63e8cf4dc3"
-      Server:
-      - Caddy
+      - W/"740f97217cb8bd58edab78dcbdd2f08c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "965"
       X-Request-Id:
-      - 21f4c26e-de92-4f39-b870-cb99ed42a250
+      - 7e88d559-7578-45cc-b69d-b168aa331bd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1587,43 +1858,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_khg24h2qE5jwe0Fg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Tt4BDGWGKrxC1oTz
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_khg24h2qE5jwe0Fg","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Tt4BDGWGKrxC1oTz","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-jcmon00bkgg1-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.94\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-1i9qkof7v9ph-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595318}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860517},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1668"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:26 GMT
+      - Thu, 06 Feb 2025 16:48:44 GMT
       Etag:
-      - W/"f64df982cac5392c2da1dc63e8cf4dc3"
-      Server:
-      - Caddy
+      - W/"11d6fb2d125d97ac19ef5bc301ce8a19"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "964"
       X-Request-Id:
-      - 610124b4-bd46-4d9c-95e0-b6e6ee3aa619
+      - a158bd15-f0e6-48df-a3c8-d3bcf238b6d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,43 +1905,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_khg24h2qE5jwe0Fg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Tt4BDGWGKrxC1oTz
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_khg24h2qE5jwe0Fg","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Tt4BDGWGKrxC1oTz","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-jcmon00bkgg1-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.94\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-1i9qkof7v9ph-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595318}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860517},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1668"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:36 GMT
+      - Thu, 06 Feb 2025 16:48:54 GMT
       Etag:
-      - W/"08a8dd4839438dc7738d03a0fedcdf30"
-      Server:
-      - Caddy
+      - W/"11d6fb2d125d97ac19ef5bc301ce8a19"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "963"
       X-Request-Id:
-      - 67d63808-b0d0-43ca-8bf1-e6e689e924c6
+      - 2cfae9b1-1ad7-470a-87be-87577f727993
     status: 200 OK
     code: 200
     duration: ""
@@ -1681,43 +1952,91 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Tt4BDGWGKrxC1oTz
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595320,"initial_root_password":"R9lLNLmV5h9LVWlH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine_build":{"id":"vmbuild_Tt4BDGWGKrxC1oTz","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.94\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-1i9qkof7v9ph-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1738860517},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:04 GMT
+      Etag:
+      - W/"df68ca33f256935d7ce8aed9253c25c8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 585985b4-b1a6-40f7-898c-2f7e19abf65a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860521,"initial_root_password":"6EkjEtqsdc72jXWE","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f54N6F0QQlJbWS6Y","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_neKtoLxPoYff62Uk","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2282"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:38 GMT
+      - Thu, 06 Feb 2025 16:49:06 GMT
       Etag:
-      - W/"2ace8206454eea6f54860e8036f217a4"
-      Server:
-      - Caddy
+      - W/"1b10ddbbdd2b08c3d53601964f7ee304"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "947"
+      - "998"
       X-Request-Id:
-      - 069fc2b9-bd9c-4e71-a508-ccd9c8225d7c
+      - c0980355-cb7e-47fa-8c3d-4e684dcdc890
     status: 200 OK
     code: 200
     duration: ""
@@ -1728,43 +2047,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595320,"initial_root_password":"R9lLNLmV5h9LVWlH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860521,"initial_root_password":"6EkjEtqsdc72jXWE","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f54N6F0QQlJbWS6Y","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_neKtoLxPoYff62Uk","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:06 GMT
+      Etag:
+      - W/"1b10ddbbdd2b08c3d53601964f7ee304"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 045a5b88-2206-4b5f-9a8a-4ef690f21193
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_LqUXVQSAqAG9tK0g","name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2282"
+      - "402"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:38 GMT
+      - Thu, 06 Feb 2025 16:49:06 GMT
       Etag:
-      - W/"2ace8206454eea6f54860e8036f217a4"
-      Server:
-      - Caddy
+      - W/"2bf43d9eb63bcb6591d86466b108f822"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "946"
+      - "996"
       X-Request-Id:
-      - 6c78d4a7-e107-49a2-b8f8-e6e9e9ec3600
+      - bdcc9cf6-54d6-4a04-82da-1169778a5f99
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_LqUXVQSAqAG9tK0g
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_LqUXVQSAqAG9tK0g","virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:bf:69:40:11:40","state":"attached","ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "554"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:06 GMT
+      Etag:
+      - W/"14cb85c9fd1bcea10ea320500c9e9d30"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - cd727805-0c9e-411d-8fd5-fe8880de84f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1775,86 +2179,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_LqUXVQSAqAG9tK0g
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_HahU83rH6irNr8MI","name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_LqUXVQSAqAG9tK0g","virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:bf:69:40:11:40","state":"attached","ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "379"
+      - "554"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:38 GMT
+      - Thu, 06 Feb 2025 16:49:06 GMT
       Etag:
-      - W/"9d8b88841c64e3d281b18a73a9c0f869"
-      Server:
-      - Caddy
+      - W/"14cb85c9fd1bcea10ea320500c9e9d30"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "945"
+      - "994"
       X-Request-Id:
-      - e9ea3146-63b6-4641-92b7-2138578b9981
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_HahU83rH6irNr8MI
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_HahU83rH6irNr8MI","virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db"},"name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:f9:c4:89:8d:8e","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "532"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:38 GMT
-      Etag:
-      - W/"816467e9b8c39d247b41cae8a2d21167"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "944"
-      X-Request-Id:
-      - 891fda6c-85a4-4ab1-9c19-e0c7117fc0c8
+      - b2244a89-eee4-4c99-99b5-a1ee49a3d1a2
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12"},"properties":{"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"]}}
+      {"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq"},"properties":{"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"]}}
     form: {}
     headers:
       Accept:
@@ -1862,36 +2226,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/file_storage_volumes/_
     method: PATCH
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "376"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:38 GMT
+      - Thu, 06 Feb 2025 16:49:06 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"627d32e9e53d332d9094194fb66f899d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "943"
+      - "993"
       X-Request-Id:
-      - cbfb81e8-475f-4996-82e0-05cd54cbb4de
+      - 0e1cf377-1993-44c6-bff3-f51b9a528bc8
     status: 200 OK
     code: 200
     duration: ""
@@ -1902,36 +2268,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "365"
+      - "382"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:43 GMT
+      - Thu, 06 Feb 2025 16:49:11 GMT
       Etag:
-      - W/"cad45f247d4599deba578305a57e68a2"
-      Server:
-      - Caddy
+      - W/"b65263d43b8362fb781d9391902ea30e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "942"
+      - "992"
       X-Request-Id:
-      - 4baa7f14-be89-4822-bc98-08de2a46df27
+      - 71ad72e2-65fb-4183-8576-ecef564f46cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1942,36 +2310,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "382"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
+      - Thu, 06 Feb 2025 16:49:16 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"b65263d43b8362fb781d9391902ea30e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "991"
       X-Request-Id:
-      - fdee5c3a-8c34-49e2-9d3d-83ff6a3beec4
+      - e90a670d-0e10-43a1-92d5-2d4437be353e
     status: 200 OK
     code: 200
     duration: ""
@@ -1982,36 +2352,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "376"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"627d32e9e53d332d9094194fb66f899d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "940"
+      - "990"
       X-Request-Id:
-      - a9e3b9db-2eb9-450d-a9b2-93acf1bf38d1
+      - 637b5bd2-e6bb-412f-8339-3bd4f8890473
     status: 200 OK
     code: 200
     duration: ""
@@ -2022,36 +2394,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "376"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"627d32e9e53d332d9094194fb66f899d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "939"
+      - "989"
       X-Request-Id:
-      - 210161d0-c7c8-492c-9fd8-41da3c488d10
+      - 6419fca2-34b8-4f2b-b77e-99388bdff32e
     status: 200 OK
     code: 200
     duration: ""
@@ -2062,36 +2436,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "376"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"627d32e9e53d332d9094194fb66f899d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "938"
+      - "988"
       X-Request-Id:
-      - d9021845-d2a7-4ad7-a093-2d882f7b75f3
+      - 4fee4e18-52b1-4440-926c-fa21f9ccdc82
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,36 +2478,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "376"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"627d32e9e53d332d9094194fb66f899d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "937"
+      - "987"
       X-Request-Id:
-      - 73f02176-37d5-4d98-a9a5-39d65115ead2
+      - 46e8110f-1ac1-4fe7-82c7-2e5d0d2f35d0
     status: 200 OK
     code: 200
     duration: ""
@@ -2142,38 +2520,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f54N6F0QQlJbWS6Y","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "768"
+      - "376"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"b2766747f5540fa4b5881d622c6d4f78"
-      Server:
-      - Caddy
+      - W/"627d32e9e53d332d9094194fb66f899d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "936"
+      - "986"
       X-Request-Id:
-      - faeab73d-3662-490f-ba8f-d826b74699e7
+      - 1892cc71-9e06-4aef-a873-3fbac966b70e
     status: 200 OK
     code: 200
     duration: ""
@@ -2184,43 +2562,132 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8tA3BEBUDKsioZXp
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595320,"initial_root_password":"R9lLNLmV5h9LVWlH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_neKtoLxPoYff62Uk","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "781"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:27 GMT
+      Etag:
+      - W/"fd7cc8f53b785ce39636f277e9a48bcf"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 561809c6-695f-4444-8ba6-a9dbb9ab3a4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_PmbvFzngYirSA6Cy
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "785"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:27 GMT
+      Etag:
+      - W/"cc02d3544224fc361edcac697f873788"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - c629a7c3-09ea-4f88-8fb7-6f9639733f3a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860521,"initial_root_password":"6EkjEtqsdc72jXWE","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f54N6F0QQlJbWS6Y","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_neKtoLxPoYff62Uk","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2282"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"2ace8206454eea6f54860e8036f217a4"
-      Server:
-      - Caddy
+      - W/"1b10ddbbdd2b08c3d53601964f7ee304"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "935"
+      - "983"
       X-Request-Id:
-      - 2ac1496e-2ca4-4187-8945-371f7646fdef
+      - 210cb36b-7d67-4bb7-b196-c610c31ce517
     status: 200 OK
     code: 200
     duration: ""
@@ -2231,169 +2698,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_HahU83rH6irNr8MI","name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "379"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
-      Etag:
-      - W/"9d8b88841c64e3d281b18a73a9c0f869"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "934"
-      X-Request-Id:
-      - 81554dfb-d977-46ce-a519-7112a1138d96
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "770"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
-      Etag:
-      - W/"bdb14e559ba8d8b708597b71e8e25cd6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "933"
-      X-Request-Id:
-      - a06655f8-f2fe-4312-8a3d-53f129521cc3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_HahU83rH6irNr8MI
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_HahU83rH6irNr8MI","virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db"},"name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:f9:c4:89:8d:8e","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "532"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
-      Etag:
-      - W/"816467e9b8c39d247b41cae8a2d21167"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "932"
-      X-Request-Id:
-      - 81841ed0-1c45-41fe-8f48-4944be3cb7fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595292,"initial_root_password":"1mg1VhGMlsExeVyY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860474,"initial_root_password":"1aKktBLbIORKToDk","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2286"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:48 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"2427d460f1d66c145b1f512964b326ad"
-      Server:
-      - Caddy
+      - W/"9e29bd6285daa55ccc9789c08db307cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "931"
+      - "983"
       X-Request-Id:
-      - b002fb16-c500-4832-91d2-fc6b82d9636a
+      - b8f279d5-0448-49a5-b47b-819c0c2db133
     status: 200 OK
     code: 200
     duration: ""
@@ -2401,41 +2743,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_loFY4HzoOxzlOaOe","name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_LqUXVQSAqAG9tK0g","name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "402"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:49 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"3b2e79dd35df5e8b874093573179fcc8"
-      Server:
-      - Caddy
+      - W/"2bf43d9eb63bcb6591d86466b108f822"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "930"
+      - "981"
       X-Request-Id:
-      - b0eac38e-4251-4022-bb2b-aded49ccd7a4
+      - e17da80a-792d-4a64-91c0-e30579458ee2
     status: 200 OK
     code: 200
     duration: ""
@@ -2443,41 +2785,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_loFY4HzoOxzlOaOe
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_loFY4HzoOxzlOaOe","virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web"},"name":"Public
-      Network on tf-acc-test-data-source-associations-jcmon00bkgg1-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:38:6b:26:88:bc","state":"attached","ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Jh0j5cwOMnZl3SrG","name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "534"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:49 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"ec0bcf12b172b6498be7d78bda4befe3"
-      Server:
-      - Caddy
+      - W/"ff76abb22a59cb8db47a3e93d26f70cf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "929"
+      - "980"
       X-Request-Id:
-      - 902e2b41-f7e3-4341-b940-5009cd3489e5
+      - f2c00092-f756-4c0b-8ebb-89e97d8666ea
     status: 200 OK
     code: 200
     duration: ""
@@ -2485,39 +2827,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Jh0j5cwOMnZl3SrG
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Jh0j5cwOMnZl3SrG","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:8e:88:70:b4:f1","state":"attached","ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:49 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"bbaf7459bfa00c82ded3062d5a4ae87e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "928"
+      - "978"
       X-Request-Id:
-      - 48576fe0-9270-4f8e-8416-b84e814500c4
+      - 0bd1d1e2-6aed-46f3-abf5-a988f41c9bf0
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,39 +2869,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_LqUXVQSAqAG9tK0g
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_LqUXVQSAqAG9tK0g","virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:bf:69:40:11:40","state":"attached","ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "554"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:49 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"14cb85c9fd1bcea10ea320500c9e9d30"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "927"
+      - "979"
       X-Request-Id:
-      - 1b7c8be1-b4d4-4d6f-a1a5-444ffc9dee41
+      - 3fc5ad31-bf8c-4744-b390-24e27b82fcf7
     status: 200 OK
     code: 200
     duration: ""
@@ -2568,36 +2914,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_LqUXVQSAqAG9tK0g
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_LqUXVQSAqAG9tK0g","virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:bf:69:40:11:40","state":"attached","ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "554"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:49 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"14cb85c9fd1bcea10ea320500c9e9d30"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "926"
+      - "977"
       X-Request-Id:
-      - 9b40a428-bff7-4afd-84bc-4f574cd98792
+      - 04fda810-1bd9-4ab8-bb63-9a641be5f8e8
     status: 200 OK
     code: 200
     duration: ""
@@ -2608,36 +2958,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Jh0j5cwOMnZl3SrG
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Jh0j5cwOMnZl3SrG","virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-1i9qkof7v9ph-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:8e:88:70:b4:f1","state":"attached","ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:49 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"c8c29886eb131a2bc387a7a5dea69428"
-      Server:
-      - Caddy
+      - W/"bbaf7459bfa00c82ded3062d5a4ae87e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "925"
+      - "977"
       X-Request-Id:
-      - f1b5e6be-97f3-4a87-951c-4b6ca06fa8cd
+      - 56692b86-9f37-40b0-b2fc-3367bfaa6355
     status: 200 OK
     code: 200
     duration: ""
@@ -2648,14 +3002,184 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:27 GMT
+      Etag:
+      - W/"627d32e9e53d332d9094194fb66f899d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 44315acb-8383-4654-b164-02fcdf1695bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:27 GMT
+      Etag:
+      - W/"627d32e9e53d332d9094194fb66f899d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - bc18e3de-2ccf-48b3-9cf9-88517bde3bb0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:27 GMT
+      Etag:
+      - W/"627d32e9e53d332d9094194fb66f899d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 1c2e70b8-6f68-4c93-8d8d-ddd633d58131
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:27 GMT
+      Etag:
+      - W/"627d32e9e53d332d9094194fb66f899d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - bc1d3b9a-9d07-4948-b169-d6a8522f9d24
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_cjlBUADxp92FRBhX","keep_until":1679768149,"object_id":"fsv_iktUEeiwYPQUTX12","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_iktUEeiwYPQUTX12","name":"tf-acc-test-data-source-associations-jcmon00bkgg1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_qQs6VbAQDKwcBrjF","vm_f54N6F0QQlJbWS6Y"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_iktUEeiwYPQUTX12","size":0}}'
+    body: '{"trash_object":{"id":"trsh_U3ax3p72D7QeTpGv","keep_until":1739033367,"object_id":"fsv_pvycmeQN7UFLBHSq","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_pvycmeQN7UFLBHSq","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CUZ6HttI0EAW9zcr","vm_neKtoLxPoYff62Uk"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_pvycmeQN7UFLBHSq","size":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2665,19 +3189,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:49 GMT
+      - Thu, 06 Feb 2025 16:49:27 GMT
       Etag:
-      - W/"e7c36d0e25dbfce10d430172278ffcfc"
-      Server:
-      - Caddy
+      - W/"ee925b3fbbbe6bc862cfe059a445571b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "924"
+      - "971"
       X-Request-Id:
-      - 1c8240fa-8596-4823-a3d0-2d027baff82a
+      - 600885e8-0934-47fd-81fa-2710aa268d7c
     status: 200 OK
     code: 200
     duration: ""
@@ -2688,14 +3212,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_pvycmeQN7UFLBHSq
     method: DELETE
   response:
-    body: '{"task":{"id":"task_ctkfqnikxXBXCIIK","name":"Purge items from trash","status":"pending","created_at":1679595349,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_upNBXGp1intcOk6P","name":"Purge items from trash","status":"pending","created_at":1738860568,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2705,19 +3231,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:49 GMT
+      - Thu, 06 Feb 2025 16:49:28 GMT
       Etag:
-      - W/"4157df1e69b2d65b1d2d542dfe15a9b0"
-      Server:
-      - Caddy
+      - W/"864350b3a0386a532230ed68b02751ba"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "923"
+      - "970"
       X-Request-Id:
-      - 3d72eb96-117d-4e6e-9ea7-e3f15655bdb3
+      - 9c9de9c1-06af-4ac0-afc3-d0dd915e28bf
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,14 +3254,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_cjlBUADxp92FRBhX","keep_until":1679768149,"object_id":"fsv_iktUEeiwYPQUTX12","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_U3ax3p72D7QeTpGv","keep_until":1739033367,"object_id":"fsv_pvycmeQN7UFLBHSq","object_type":"FileStorageVolume"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2745,19 +3273,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:50 GMT
+      - Thu, 06 Feb 2025 16:49:29 GMT
       Etag:
-      - W/"85c16da8be97e2e22e77c85edc921243"
-      Server:
-      - Caddy
+      - W/"49e39e42d07f6a14fe88d63019b8d2ff"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "922"
+      - "969"
       X-Request-Id:
-      - 76083198-7258-4f3a-bde7-cbaa1037d1c5
+      - 3b24b090-d51e-411c-afa9-725449db7dc4
     status: 200 OK
     code: 200
     duration: ""
@@ -2768,14 +3296,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_cjlBUADxp92FRBhX","keep_until":1679768149,"object_id":"fsv_iktUEeiwYPQUTX12","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_U3ax3p72D7QeTpGv","keep_until":1739033367,"object_id":"fsv_pvycmeQN7UFLBHSq","object_type":"FileStorageVolume"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2785,19 +3315,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:55 GMT
+      - Thu, 06 Feb 2025 16:49:34 GMT
       Etag:
-      - W/"85c16da8be97e2e22e77c85edc921243"
-      Server:
-      - Caddy
+      - W/"49e39e42d07f6a14fe88d63019b8d2ff"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "968"
       X-Request-Id:
-      - 938fc813-16bf-4203-95e2-95cc247f7ad3
+      - 9a00856b-ea86-4036-83a5-c151c04e6946
     status: 200 OK
     code: 200
     duration: ""
@@ -2808,14 +3338,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_cjlBUADxp92FRBhX","keep_until":1679768149,"object_id":"fsv_iktUEeiwYPQUTX12","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_U3ax3p72D7QeTpGv","keep_until":1739033367,"object_id":"fsv_pvycmeQN7UFLBHSq","object_type":"FileStorageVolume"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2825,21 +3357,106 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:05 GMT
+      - Thu, 06 Feb 2025 16:49:44 GMT
       Etag:
-      - W/"85c16da8be97e2e22e77c85edc921243"
-      Server:
-      - Caddy
+      - W/"49e39e42d07f6a14fe88d63019b8d2ff"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - b3c3854b-ac58-4cf1-84ff-64aac97ec177
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_U3ax3p72D7QeTpGv","keep_until":1739033367,"object_id":"fsv_pvycmeQN7UFLBHSq","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:49:54 GMT
+      Etag:
+      - W/"49e39e42d07f6a14fe88d63019b8d2ff"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - cfffa1e6-2221-4b51-bdc5-41ba339fc31d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:50:04 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "999"
       X-Request-Id:
-      - 4a46d7f9-11f3-4a66-ae5b-d814d3eacae1
-    status: 200 OK
-    code: 200
+      - 234f368d-3a4e-40a8-bbfb-9e30bb20407f
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -2848,39 +3465,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
     method: GET
   response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{"virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860521,"initial_root_password":"6EkjEtqsdc72jXWE","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_neKtoLxPoYff62Uk","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
+      - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:15 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:50:04 GMT
+      Etag:
+      - W/"1b10ddbbdd2b08c3d53601964f7ee304"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "998"
       X-Request-Id:
-      - 57c817e4-9e97-45a2-a587-77d9e9eb6a5a
-    status: 404 Not Found
-    code: 404
+      - 783625af-e391-4f00-a34b-9bb93c7fba14
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -2889,43 +3513,86 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595292,"initial_root_password":"1mg1VhGMlsExeVyY","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860474,"initial_root_password":"1aKktBLbIORKToDk","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:50:04 GMT
+      Etag:
+      - W/"9e29bd6285daa55ccc9789c08db307cb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 032d043f-eb60-4866-8fc1-cc8a78656aaa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
+    method: POST
+  response:
+    body: '{"task":{"id":"task_iGTgEBHr7PEoctKn","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2286"
+      - "88"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:15 GMT
+      - Thu, 06 Feb 2025 16:50:04 GMT
       Etag:
-      - W/"2427d460f1d66c145b1f512964b326ad"
-      Server:
-      - Caddy
+      - W/"2171cfd827e44ffcea9097adc911a958"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "996"
       X-Request-Id:
-      - 25bc5fc4-1573-418f-aef1-13155bc49e85
+      - e120ad70-d1d7-4074-9797-eecd49570cb4
     status: 200 OK
     code: 200
     duration: ""
@@ -2936,61 +3603,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595320,"initial_root_password":"R9lLNLmV5h9LVWlH","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f54N6F0QQlJbWS6Y","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2282"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:16:15 GMT
-      Etag:
-      - W/"2ace8206454eea6f54860e8036f217a4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - 161be5ed-248b-4f96-815e-549e81ee9e1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
     method: POST
   response:
-    body: '{"task":{"id":"task_hfjD4mLL80YqM03k","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_0i14JtcSWf6CPCYq","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3000,19 +3622,61 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:15 GMT
+      - Thu, 06 Feb 2025 16:50:04 GMT
       Etag:
-      - W/"cc37504bbc2669f660d6f1cdc4c4d1b0"
-      Server:
-      - Caddy
+      - W/"a2288ee4583ddc57c490619ecf76e682"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 00a055b6-488d-4ca4-b053-4206c2132d4f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_iGTgEBHr7PEoctKn
+    method: GET
+  response:
+    body: '{"task":{"id":"task_iGTgEBHr7PEoctKn","name":"Stop virtual machine","status":"running","created_at":1738860604,"started_at":1738860604,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:50:05 GMT
+      Etag:
+      - W/"e70aea67334626d511e165dbf4aa99e2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "994"
       X-Request-Id:
-      - e5605c03-90cb-44c3-84ad-3510bf67d5b4
+      - 36ac34b8-b6f3-4457-8adc-27aa0d295c99
     status: 200 OK
     code: 200
     duration: ""
@@ -3023,54 +3687,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
-    method: POST
-  response:
-    body: '{"task":{"id":"task_hahrGCBqeZ5vDRjn","name":"Stop virtual machine","status":"pending"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "88"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:16:15 GMT
-      Etag:
-      - W/"5df545e7ec22d66129aa7795f9fc665d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - 8cc9086e-55b0-488c-a57c-af10ad2d83a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_hfjD4mLL80YqM03k
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_0i14JtcSWf6CPCYq
     method: GET
   response:
-    body: '{"task":{"id":"task_hfjD4mLL80YqM03k","name":"Stop virtual machine","status":"running","created_at":1679595375,"started_at":1679595376,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_0i14JtcSWf6CPCYq","name":"Stop virtual machine","status":"running","created_at":1738860604,"started_at":1738860604,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3080,19 +3706,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:16 GMT
+      - Thu, 06 Feb 2025 16:50:05 GMT
       Etag:
-      - W/"1492673c550e0f973906be5c498cfa20"
-      Server:
-      - Caddy
+      - W/"79072e1c467aff926f64bc6ca67ba790"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "993"
       X-Request-Id:
-      - d580f3a6-e5c4-45f5-8118-150cef966763
+      - cfa471f5-c5d7-4129-bee0-10d410649ef8
     status: 200 OK
     code: 200
     duration: ""
@@ -3103,36 +3729,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_hahrGCBqeZ5vDRjn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_0i14JtcSWf6CPCYq
     method: GET
   response:
-    body: '{"task":{"id":"task_hahrGCBqeZ5vDRjn","name":"Stop virtual machine","status":"running","created_at":1679595375,"started_at":1679595376,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_0i14JtcSWf6CPCYq","name":"Stop virtual machine","status":"completed","created_at":1738860604,"started_at":1738860604,"finished_at":1738860608,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "178"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:16 GMT
+      - Thu, 06 Feb 2025 16:50:10 GMT
       Etag:
-      - W/"dd3765ae1c50aa1083f23f8a0fa94187"
-      Server:
-      - Caddy
+      - W/"155e52ebca11f4cca09bcd84c1f15eb3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "992"
       X-Request-Id:
-      - c0e4d4ff-59eb-41fd-b902-40d9b8e7d914
+      - 35577731-3d6c-437b-87ea-36d34aa5a3b0
     status: 200 OK
     code: 200
     duration: ""
@@ -3143,14 +3771,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_hfjD4mLL80YqM03k
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_iGTgEBHr7PEoctKn
     method: GET
   response:
-    body: '{"task":{"id":"task_hfjD4mLL80YqM03k","name":"Stop virtual machine","status":"completed","created_at":1679595375,"started_at":1679595376,"finished_at":1679595378,"progress":100}}'
+    body: '{"task":{"id":"task_iGTgEBHr7PEoctKn","name":"Stop virtual machine","status":"completed","created_at":1738860604,"started_at":1738860604,"finished_at":1738860608,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3160,19 +3790,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:21 GMT
+      - Thu, 06 Feb 2025 16:50:10 GMT
       Etag:
-      - W/"b6ee101252f69ba02233058999526b2e"
-      Server:
-      - Caddy
+      - W/"d91069dabcfa88864dc45e29ecaf1a50"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "992"
       X-Request-Id:
-      - ffc7d6a7-3d8c-40ab-99bb-5751695a2a38
+      - a857dc80-f020-4171-94b9-bf25c57dd006
     status: 200 OK
     code: 200
     duration: ""
@@ -3183,36 +3813,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_hahrGCBqeZ5vDRjn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"task":{"id":"task_hahrGCBqeZ5vDRjn","name":"Stop virtual machine","status":"completed","created_at":1679595375,"started_at":1679595376,"finished_at":1679595380,"progress":100}}'
+    body: '{"virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860474,"initial_root_password":"1aKktBLbIORKToDk","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "178"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:21 GMT
+      - Thu, 06 Feb 2025 16:50:11 GMT
       Etag:
-      - W/"b8ae56fad86bbc033647a54d22d2a990"
-      Server:
-      - Caddy
+      - W/"7e74168e6357f206d98227378cafdaa9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "990"
       X-Request-Id:
-      - 01d9dd65-3bf3-45aa-8952-31cdf6b736d2
+      - 39767fe3-2b34-4878-a679-732fefac10be
     status: 200 OK
     code: 200
     duration: ""
@@ -3223,43 +3861,92 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595292,"initial_root_password":"1mg1VhGMlsExeVyY","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860521,"initial_root_password":"6EkjEtqsdc72jXWE","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_neKtoLxPoYff62Uk","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2286"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:22 GMT
+      - Thu, 06 Feb 2025 16:50:11 GMT
       Etag:
-      - W/"d8fc9ae59ce443e01e3fd3bf4704d24e"
-      Server:
-      - Caddy
+      - W/"d9218463bd9c6da7801b1cc1ef74f24f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - a5fe6fca-dddd-4048-ba7a-6c9420919b90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_neKtoLxPoYff62Uk
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_iRFFO2h9FjouCCUe","keep_until":1739033411,"object_id":"vm_neKtoLxPoYff62Uk","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_neKtoLxPoYff62Uk","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860521,"initial_root_password":"6EkjEtqsdc72jXWE","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.94/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_neKtoLxPoYff62Uk","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:50:11 GMT
+      Etag:
+      - W/"6b9e356190a8029cd01120e25d7334e7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "988"
       X-Request-Id:
-      - 11ad2902-fd0d-4fd8-b1f2-51508b2d77af
+      - cb9c07b0-7767-46a4-ba5f-a4da05ce19f4
     status: 200 OK
     code: 200
     duration: ""
@@ -3270,90 +3957,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595320,"initial_root_password":"R9lLNLmV5h9LVWlH","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f54N6F0QQlJbWS6Y","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2282"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:16:22 GMT
-      Etag:
-      - W/"6f1380ae6aec609845a0496ad629cdf9"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - b61263ea-afe7-460a-822a-6ea40c5ceb3f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CUZ6HttI0EAW9zcr
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_uoycPMKemvXrT6cX","keep_until":1679768182,"object_id":"vm_qQs6VbAQDKwcBrjF","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_qQs6VbAQDKwcBrjF","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-web","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595292,"initial_root_password":"1mg1VhGMlsExeVyY","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_Xe7mp5hz9DTmYjxW","keep_until":1739033411,"object_id":"vm_CUZ6HttI0EAW9zcr","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_CUZ6HttI0EAW9zcr","name":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","hostname":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web","fqdn":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860474,"initial_root_password":"1aKktBLbIORKToDk","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_qQs6VbAQDKwcBrjF","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_PmbvFzngYirSA6Cy","address":"185.44.252.217","reverse_dns":"tf-acc-test-data-source-associations-1i9qkof7v9ph-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.217/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CUZ6HttI0EAW9zcr","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2421"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:22 GMT
+      - Thu, 06 Feb 2025 16:50:11 GMT
       Etag:
-      - W/"cb56481384bbc5b674a8234e9df53491"
-      Server:
-      - Caddy
+      - W/"2d01d6c173cc4a6fcc561fbe3a2a66ff"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - 1ecc3a3e-2382-4df1-98bb-e4559c13b2a3
+      - 7897953f-5cd4-401f-9b0c-652ac4572354
     status: 200 OK
     code: 200
     duration: ""
@@ -3364,61 +4005,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_f54N6F0QQlJbWS6Y
-    method: DELETE
-  response:
-    body: '{"trash_object":{"id":"trsh_ZVn8TbK4eJwiqjKt","keep_until":1679768182,"object_id":"vm_f54N6F0QQlJbWS6Y","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_f54N6F0QQlJbWS6Y","name":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","hostname":"tf-acc-test-data-source-associations-jcmon00bkgg1-db","fqdn":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595320,"initial_root_password":"R9lLNLmV5h9LVWlH","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-associations-jcmon00bkgg1-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_f54N6F0QQlJbWS6Y","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2417"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:16:22 GMT
-      Etag:
-      - W/"7f93a82ae846420a2bee2040a284ba89"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - 4d31bb0e-b76a-48c8-9245-1279dcc743ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_PmbvFzngYirSA6Cy
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3428,19 +4024,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:23 GMT
+      - Thu, 06 Feb 2025 16:50:12 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - 33734577-6603-4d5b-bc12-28af087d401d
+      - ea96cb3d-369f-4bb7-9085-40c172e6658a
     status: 200 OK
     code: 200
     duration: ""
@@ -3451,14 +4047,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_8tA3BEBUDKsioZXp
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3468,19 +4066,61 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:23 GMT
+      - Thu, 06 Feb 2025 16:50:12 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 95807a29-457d-4eb0-9abd-587eff46f756
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_neKtoLxPoYff62Uk
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_wXgRtA220I1ka0Dn","name":"Purge items from trash","status":"pending","created_at":1738860612,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:50:12 GMT
+      Etag:
+      - W/"8b37b76a69a03dd7837b0e3c779af905"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "984"
       X-Request-Id:
-      - dd27cace-3ca2-4c1b-a71b-e390e7488e2e
+      - aa2f30f1-a284-4d6d-9a87-9ded0f60fb21
     status: 200 OK
     code: 200
     duration: ""
@@ -3491,14 +4131,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CUZ6HttI0EAW9zcr
     method: DELETE
   response:
-    body: '{"task":{"id":"task_avdxFPZK6cL3DBmI","name":"Purge items from trash","status":"pending","created_at":1679595383,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_OsBc44vkDkiw3ELa","name":"Purge items from trash","status":"pending","created_at":1738860612,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3508,19 +4150,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:23 GMT
+      - Thu, 06 Feb 2025 16:50:12 GMT
       Etag:
-      - W/"f473806fc67d4218969aa1123489beb3"
-      Server:
-      - Caddy
+      - W/"88dd2cc04880c298962ea7957d025b22"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "983"
       X-Request-Id:
-      - 0e98b9a3-25d3-46b3-a4b9-a0c2a6baa5d6
+      - 2b94d6f0-8bc1-4bd5-ba0f-16eebad52396
     status: 200 OK
     code: 200
     duration: ""
@@ -3531,36 +4173,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_f54N6F0QQlJbWS6Y
-    method: DELETE
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_neKtoLxPoYff62Uk
+    method: GET
   response:
-    body: '{"task":{"id":"task_EZ6jn1sB6DRhk16t","name":"Purge items from trash","status":"pending","created_at":1679595383,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"trash_object":{"id":"trsh_iRFFO2h9FjouCCUe","keep_until":1739033411,"object_id":"vm_neKtoLxPoYff62Uk","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "164"
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:23 GMT
+      - Thu, 06 Feb 2025 16:50:13 GMT
       Etag:
-      - W/"ffd7d13aec2a17d99d44b12553ceacc8"
-      Server:
-      - Caddy
+      - W/"6fd1b5ccbfcdadb6204fe4b2ea3c6d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "982"
       X-Request-Id:
-      - c38e5aa3-c674-4b32-b0e4-8c69efe30c09
+      - c678ef2f-cbcd-4907-8a2a-4691f6c3a3ed
     status: 200 OK
     code: 200
     duration: ""
@@ -3571,14 +4215,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_qQs6VbAQDKwcBrjF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_uoycPMKemvXrT6cX","keep_until":1679768182,"object_id":"vm_qQs6VbAQDKwcBrjF","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_Xe7mp5hz9DTmYjxW","keep_until":1739033411,"object_id":"vm_CUZ6HttI0EAW9zcr","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3588,19 +4234,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:24 GMT
+      - Thu, 06 Feb 2025 16:50:13 GMT
       Etag:
-      - W/"e49b8f4e6f0d706394f62d55156fef50"
-      Server:
-      - Caddy
+      - W/"eb08f9fded6c9eb164b28c7b7be835b9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "981"
       X-Request-Id:
-      - b8881f30-701e-4d4a-9e6c-dd058a6d5280
+      - 1f378e85-5150-4ae1-a9b1-ac7a34bd19de
     status: 200 OK
     code: 200
     duration: ""
@@ -3611,38 +4257,41 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_neKtoLxPoYff62Uk
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_ZVn8TbK4eJwiqjKt","keep_until":1679768182,"object_id":"vm_f54N6F0QQlJbWS6Y","object_type":"VirtualMachine"}}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "136"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:24 GMT
-      Etag:
-      - W/"70d1553d94c488023fe0956a402c0f85"
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:50:18 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "980"
       X-Request-Id:
-      - 972ae413-e398-4289-9a31-c922242eb1ad
-    status: 200 OK
-    code: 200
+      - 77368dec-d9d7-409a-a3b2-e52a776ed836
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -3651,39 +4300,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_qQs6VbAQDKwcBrjF
-    method: GET
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8tA3BEBUDKsioZXp
+    method: DELETE
   response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       Content-Length:
-      - "152"
+      - "2"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:29 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:50:18 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - c3827343-14f3-43b5-b047-931c17915c7f
-    status: 404 Not Found
-    code: 404
+      - fb264ec8-9e9e-44eb-aafc-d9ae3b0e4ff5
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -3692,14 +4342,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_ZVn8TbK4eJwiqjKt","keep_until":1679768182,"object_id":"vm_f54N6F0QQlJbWS6Y","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_Xe7mp5hz9DTmYjxW","keep_until":1739033411,"object_id":"vm_CUZ6HttI0EAW9zcr","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3709,19 +4361,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:29 GMT
+      - Thu, 06 Feb 2025 16:50:18 GMT
       Etag:
-      - W/"70d1553d94c488023fe0956a402c0f85"
-      Server:
-      - Caddy
+      - W/"eb08f9fded6c9eb164b28c7b7be835b9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "978"
       X-Request-Id:
-      - 8f0f3749-0125-41af-90b1-3fceabd4e8ec
+      - 3806e6dc-2d7f-4a52-b5df-deed4e7b9bf4
     status: 200 OK
     code: 200
     duration: ""
@@ -3732,54 +4384,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:16:29 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - a3be1d36-63b2-4a31-b933-741bac97bdc5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_ZVn8TbK4eJwiqjKt","keep_until":1679768182,"object_id":"vm_f54N6F0QQlJbWS6Y","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_Xe7mp5hz9DTmYjxW","keep_until":1739033411,"object_id":"vm_CUZ6HttI0EAW9zcr","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3789,19 +4403,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:39 GMT
+      - Thu, 06 Feb 2025 16:50:28 GMT
       Etag:
-      - W/"70d1553d94c488023fe0956a402c0f85"
-      Server:
-      - Caddy
+      - W/"eb08f9fded6c9eb164b28c7b7be835b9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "976"
+      - "977"
       X-Request-Id:
-      - 5fa2c063-f9a0-4215-8815-f2b4435d7359
+      - d59f9f7b-9de0-4f65-8172-7319e2bd4652
     status: 200 OK
     code: 200
     duration: ""
@@ -3812,15 +4426,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_f54N6F0QQlJbWS6Y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CUZ6HttI0EAW9zcr
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3830,19 +4446,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:49 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:50:38 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "976"
       X-Request-Id:
-      - aadb7791-2b66-469d-9684-5ebc24f2d985
+      - 0c0e686e-3a1b-4ddd-91be-4c1f1927625e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3853,14 +4469,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_PmbvFzngYirSA6Cy
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3870,19 +4488,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:51 GMT
+      - Thu, 06 Feb 2025 16:50:38 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "974"
+      - "975"
       X-Request-Id:
-      - 291259c1-68ae-49ad-bd02-3fd2af654b6c
+      - bd7a63fc-ff65-41fb-9327-d763584ed8bf
     status: 200 OK
     code: 200
     duration: ""
@@ -3893,15 +4511,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
     body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
       storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3911,11 +4531,54 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:50:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - b60d2f4b-8e98-4243-9088-d2627fa8185a
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_pvycmeQN7UFLBHSq
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:50:39 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
@@ -3923,7 +4586,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "973"
       X-Request-Id:
-      - bdc9465c-f557-423d-8cb0-44cef464c83c
+      - e7cb83da-685c-4222-9a43-a4358c6b3fce
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3934,56 +4597,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_iktUEeiwYPQUTX12
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:16:51 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "972"
-      X-Request-Id:
-      - 0bd5f9ae-38c3-45c2-85b6-080b65bdf34e
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
     body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
       storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3993,19 +4617,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:50:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "971"
+      - "972"
       X-Request-Id:
-      - 365b51e1-7a28-42cb-997a-a9e3b15cc36a
+      - 9ebd90ce-d8dc-4933-8324-f4d3eeade4df
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4016,15 +4640,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_iktUEeiwYPQUTX12
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_pvycmeQN7UFLBHSq
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -4034,19 +4660,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:16:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:50:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "970"
+      - "971"
       X-Request-Id:
-      - e96b21b3-47ef-4abe-8e6a-1ef30242971a
+      - 0709c4fd-f384-433a-b2af-90a9245df2d6
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.rand_id
@@ -1,1 +1,1 @@
-ewf2vwax7pz2
+yr9m24bgpauh

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.yaml
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_fqdn.cassette.yaml
@@ -8,14 +8,61 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "196"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:46:51 GMT
+      Etag:
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - abcbd43d-0fcf-41c6-91f8-1a139511ec0b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
+    method: POST
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -25,62 +72,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:47 GMT
+      - Thu, 06 Feb 2025 19:46:51 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"43d14e34161b4d30cec274cbe4ed2255"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "633"
+      - "954"
       X-Request-Id:
-      - 30d8ce2e-47e7-43e9-a7fd-24eb61275f94
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
-    method: POST
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "158"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:47 GMT
-      Etag:
-      - W/"7032dc5c738664423544f6f35c14faee"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "634"
-      X-Request-Id:
-      - 712213e4-f5bf-46f6-8a6d-ef1d908149cf
+      - 98d2c208-4712-41dc-bd1f-0546767c524f
     status: 200 OK
     code: 200
     duration: ""
@@ -91,36 +95,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_d6h64MebflYy05hS
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_WqZ3uibELtRnBldI
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "158"
+      - "181"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:47 GMT
+      - Thu, 06 Feb 2025 19:46:51 GMT
       Etag:
-      - W/"7032dc5c738664423544f6f35c14faee"
-      Server:
-      - Caddy
+      - W/"43d14e34161b4d30cec274cbe4ed2255"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "630"
+      - "947"
       X-Request-Id:
-      - f96f6bca-896d-40bf-9276-c503843e9e96
+      - fca45020-c748-45ce-a628-f038fe913dd4
     status: 200 OK
     code: 200
     duration: ""
@@ -134,38 +140,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"185-44-254-181.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:47 GMT
+      - Thu, 06 Feb 2025 19:46:51 GMT
       Etag:
-      - W/"70ae5cda48cd0cdf599bd81704faa419"
-      Server:
-      - Caddy
+      - W/"790b5e01ebc01b0ae3896f1e3e5f5c04"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "631"
+      - "950"
       X-Request-Id:
-      - d821d82d-843c-4ee3-a3b2-d0970ffad794
+      - 62856f1a-16b1-4c5b-a8aa-2c590e200e98
     status: 200 OK
     code: 200
     duration: ""
@@ -176,38 +184,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_MaUnYBhZnQtJ1wI3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"185-44-254-181.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:47 GMT
+      - Thu, 06 Feb 2025 19:46:52 GMT
       Etag:
-      - W/"7367639e17424126d908b7a96b17219f"
-      Server:
-      - Caddy
+      - W/"45dc89e76aecf1ec0b3ed14884225b4f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "629"
+      - "946"
       X-Request-Id:
-      - 13f3fd45-be92-42ab-be1d-b9b941ca24c3
+      - f077a041-25aa-48a2-83b4-3755d4258aa6
     status: 200 OK
     code: 200
     duration: ""
@@ -218,44 +228,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_MaUnYBhZnQtJ1wI3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"185-44-254-181.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:47 GMT
+      - Thu, 06 Feb 2025 19:46:52 GMT
       Etag:
-      - W/"7367639e17424126d908b7a96b17219f"
-      Server:
-      - Caddy
+      - W/"45dc89e76aecf1ec0b3ed14884225b4f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "628"
+      - "945"
       X-Request-Id:
-      - 56952bf6-5ac1-4b52-86ea-da7c274a4743
+      - 6706741e-879f-41b6-ae04-35361d2322d5
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_2bjWpH3KQBlrSjJ0</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2</Name><Description>A web server.</Description><Group>vmgrp_d6h64MebflYy05hS</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_MaUnYBhZnQtJ1wI3</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-fqdn-yr9m24bgpauh</Name><Description>A web server.</Description><Group>vmgrp_WqZ3uibELtRnBldI</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -263,36 +275,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_AbR9LwEhfsSSUGqt","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_MtVc3ZCectSvrR4m","state":"pending"},"virtual_machine_build":{"id":"vmbuild_MtVc3ZCectSvrR4m","state":"pending"},"hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host"}'
+    body: '{"task":{"id":"task_gWEis81Ox38lbd9a","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_GW1QTJ8VeLjpoEC2","state":"pending"},"virtual_machine_build":{"id":"vmbuild_GW1QTJ8VeLjpoEC2","state":"pending"},"hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "288"
+      - "305"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:47 GMT
+      - Thu, 06 Feb 2025 19:46:52 GMT
       Etag:
-      - W/"39968868a5c89d4ea5d0c452713ab850"
-      Server:
-      - Caddy
+      - W/"ed8a6cd9271848a4b42b47b39d4e438d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "627"
+      - "944"
       X-Request-Id:
-      - a33d8273-737f-4520-8937-825ec7797505
+      - d6345537-aec7-4c7a-88e9-235582fc0b89
     status: 201 Created
     code: 201
     duration: ""
@@ -303,44 +317,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MtVc3ZCectSvrR4m
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GW1QTJ8VeLjpoEC2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_MtVc3ZCectSvrR4m","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_GW1QTJ8VeLjpoEC2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-ewf2vwax7pz2\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_d6h64MebflYy05hS\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.181\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-yr9m24bgpauh\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_WqZ3uibELtRnBldI\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595227}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738871212},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2058"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:49 GMT
+      - Thu, 06 Feb 2025 19:46:54 GMT
       Etag:
-      - W/"690354f06e3efcc8d235fb8df1f97883"
-      Server:
-      - Caddy
+      - W/"5ccbb41e2899e120aaa56d74149bd0d3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "600"
+      - "940"
       X-Request-Id:
-      - 9cb5a2e8-0cab-43fc-9788-59b0911c1ef4
+      - 297a9c68-bcbc-40fc-a235-6424fc289c50
     status: 200 OK
     code: 200
     duration: ""
@@ -351,44 +365,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MtVc3ZCectSvrR4m
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GW1QTJ8VeLjpoEC2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_MtVc3ZCectSvrR4m","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_GW1QTJ8VeLjpoEC2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-ewf2vwax7pz2\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_d6h64MebflYy05hS\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.181\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-yr9m24bgpauh\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_WqZ3uibELtRnBldI\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595227}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738871212},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2058"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:54 GMT
+      - Thu, 06 Feb 2025 19:46:59 GMT
       Etag:
-      - W/"690354f06e3efcc8d235fb8df1f97883"
-      Server:
-      - Caddy
+      - W/"98810789ed3ea4955110c7f268264803"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "578"
+      - "938"
       X-Request-Id:
-      - 5ca3ef3c-2a73-4da8-8979-ee6b65988212
+      - 1122e99f-f092-475a-a9b2-32423c52ba0c
     status: 200 OK
     code: 200
     duration: ""
@@ -399,50 +413,98 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MtVc3ZCectSvrR4m
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GW1QTJ8VeLjpoEC2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_MtVc3ZCectSvrR4m","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_GW1QTJ8VeLjpoEC2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-ewf2vwax7pz2\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_d6h64MebflYy05hS\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.181\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-yr9m24bgpauh\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_WqZ3uibELtRnBldI\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595227}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738871212},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2058"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:04 GMT
+      - Thu, 06 Feb 2025 19:47:09 GMT
       Etag:
-      - W/"33632122a5095d2ac320c6888ae43c52"
-      Server:
-      - Caddy
+      - W/"98810789ed3ea4955110c7f268264803"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "910"
+      - "999"
       X-Request-Id:
-      - 169c5f0a-4881-4332-959b-e598018706dc
+      - 4eb3fc0e-0afd-4d2a-a291-5bb6aae8b3db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_GW1QTJ8VeLjpoEC2
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_GW1QTJ8VeLjpoEC2","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.181\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-fqdn-yr9m24bgpauh\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_WqZ3uibELtRnBldI\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738871212},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:19 GMT
+      Etag:
+      - W/"ce33f34fee6dd55ff9028d02d7508512"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 2c194abe-c6b2-4585-90b5-f88ed9facf85
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -450,44 +512,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:04 GMT
+      - Thu, 06 Feb 2025 19:47:19 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"4c19ac738490356c5f44f4f35f691ff9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "908"
+      - "963"
       X-Request-Id:
-      - 6752d100-e91f-4579-a865-31d47ee77d3b
+      - 29dce622-5c0f-4971-a399-ecad5bb757d1
     status: 200 OK
     code: 200
     duration: ""
@@ -498,44 +561,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:21 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "856"
+      - "962"
       X-Request-Id:
-      - 5113fd3b-cca2-44bc-94a4-270ef478b3da
+      - 60b410ae-e5cc-4c38-aaf2-8e492495ae93
     status: 200 OK
     code: 200
     duration: ""
@@ -546,44 +610,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:21 GMT
+      Etag:
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - 5b7e913a-ac26-4744-8c66-c76651f86e8f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rg3wcxZmshtnsFo8","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2593"
+      - "395"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:21 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"7a53c4f8fefd6748e2978f218db1b9a2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "855"
+      - "960"
       X-Request-Id:
-      - 6e5c0dc6-31a7-48dc-bc8a-f9a8f73c1ae7
+      - c15505f6-1944-4ce5-a300-7d8decd87710
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "537"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:21 GMT
+      Etag:
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - 9d5b84c4-a6c5-4ece-9a2c-270df32c05c3
     status: 200 OK
     code: 200
     duration: ""
@@ -594,38 +743,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5QUDHY5rEB9RmsX","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "371"
+      - "537"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:21 GMT
       Etag:
-      - W/"c0e6ac8cb8ce13b09102cc417bd8cbda"
-      Server:
-      - Caddy
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "854"
+      - "958"
       X-Request-Id:
-      - c3ae6851-c444-4eb0-ae3c-c89d4329ab35
+      - 620d08b4-cea7-4a48-8567-5b857d4d8b9e
     status: 200 OK
     code: 200
     duration: ""
@@ -636,86 +787,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5QUDHY5rEB9RmsX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5QUDHY5rEB9RmsX","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:98:e6:8a:d6:89","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "514"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
-      Etag:
-      - W/"ea4760e9205cfc76e26039cbf6c0cea4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "853"
-      X-Request-Id:
-      - a3134b0e-e5a8-4ad3-a4d4-33f0614011f3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:21 GMT
+      Etag:
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - f50ba48c-2210-448d-b80c-2eeefc8b8e5b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rg3wcxZmshtnsFo8","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2593"
+      - "395"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:21 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"7a53c4f8fefd6748e2978f218db1b9a2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "852"
+      - "956"
       X-Request-Id:
-      - 364e4ae7-cd05-48d1-a8ae-bfefe6b567b9
+      - e7187406-471e-476f-83ba-6af25e290e43
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "537"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:21 GMT
+      Etag:
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - 4383cf68-c886-4cd2-8018-73c824fd2b4c
     status: 200 OK
     code: 200
     duration: ""
@@ -726,38 +920,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5QUDHY5rEB9RmsX","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "371"
+      - "537"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:21 GMT
       Etag:
-      - W/"c0e6ac8cb8ce13b09102cc417bd8cbda"
-      Server:
-      - Caddy
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "851"
+      - "954"
       X-Request-Id:
-      - cb351eee-2e13-4524-baf6-41fb747062f7
+      - da9d9057-cf92-4f94-9685-4fabf3f12621
     status: 200 OK
     code: 200
     duration: ""
@@ -768,86 +964,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5QUDHY5rEB9RmsX
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5QUDHY5rEB9RmsX","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:98:e6:8a:d6:89","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "514"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
-      Etag:
-      - W/"ea4760e9205cfc76e26039cbf6c0cea4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "850"
-      X-Request-Id:
-      - 9d791f53-3898-4f90-8007-ded486035a05
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:21 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "849"
+      - "953"
       X-Request-Id:
-      - 07f3edbb-d55f-4547-9643-5da7fffa5cdb
+      - c1160e97-5a56-4ce7-b72b-3cd4dec5d8f2
     status: 200 OK
     code: 200
     duration: ""
@@ -858,44 +1013,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:21 GMT
+      Etag:
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - 5406e5b4-877f-4981-a151-4076a1c49e28
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rg3wcxZmshtnsFo8","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2593"
+      - "395"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:21 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"7a53c4f8fefd6748e2978f218db1b9a2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "848"
+      - "951"
       X-Request-Id:
-      - edc6576c-7351-4de0-a1cc-9ffbd6e2ad0a
+      - 9e211c01-5f63-4775-b64b-7367bb03d05c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "537"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:22 GMT
+      Etag:
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "950"
+      X-Request-Id:
+      - a0761bcb-f994-483a-be17-cd04ad24f0f2
     status: 200 OK
     code: 200
     duration: ""
@@ -906,38 +1146,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5QUDHY5rEB9RmsX","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "371"
+      - "537"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:22 GMT
       Etag:
-      - W/"c0e6ac8cb8ce13b09102cc417bd8cbda"
-      Server:
-      - Caddy
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "844"
+      - "949"
       X-Request-Id:
-      - 6b007763-ff25-41c7-b531-41fdcd3db8bf
+      - 81140090-f38a-438d-9b14-a33267c0b7ae
     status: 200 OK
     code: 200
     duration: ""
@@ -948,38 +1190,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5QUDHY5rEB9RmsX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_WqZ3uibELtRnBldI
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5QUDHY5rEB9RmsX","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:98:e6:8a:d6:89","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "514"
+      - "181"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:06 GMT
+      - Thu, 06 Feb 2025 19:47:22 GMT
       Etag:
-      - W/"ea4760e9205cfc76e26039cbf6c0cea4"
-      Server:
-      - Caddy
+      - W/"43d14e34161b4d30cec274cbe4ed2255"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "841"
+      - "948"
       X-Request-Id:
-      - e3459958-d539-41a7-adce-3096b5b81b2f
+      - 6c3e38fb-712b-42da-9c5f-a27526b2310a
     status: 200 OK
     code: 200
     duration: ""
@@ -990,36 +1232,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_d6h64MebflYy05hS
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_MaUnYBhZnQtJ1wI3
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227}}'
+    body: '{"ip_address":{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "158"
+      - "772"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:22 GMT
       Etag:
-      - W/"7032dc5c738664423544f6f35c14faee"
-      Server:
-      - Caddy
+      - W/"c65a44f0463cf32b77ea5fcb306eed78"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "835"
+      - "947"
       X-Request-Id:
-      - a71c99e4-f0e9-4e06-a88b-d1ec36855f81
+      - 52303778-88d1-4f7e-9a98-01870d7e000f
     status: 200 OK
     code: 200
     duration: ""
@@ -1030,86 +1276,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "757"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
-      Etag:
-      - W/"2ea7e6ee700a2668948a249ff6f6813b"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "834"
-      X-Request-Id:
-      - 83576ad8-d076-4462-820d-66bae44da6f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:22 GMT
+      Etag:
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 2dc957f5-bdc8-4a7c-a161-4b4d695a84cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rg3wcxZmshtnsFo8","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2593"
+      - "395"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:22 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"7a53c4f8fefd6748e2978f218db1b9a2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "833"
+      - "945"
       X-Request-Id:
-      - e9dd5d67-cd2f-4f4c-8d73-c04e5d7e0f16
+      - beda1430-46ae-4811-92c2-8a7e6ae1a8b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "537"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:22 GMT
+      Etag:
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - a39a8fa8-cf16-4fa7-9145-c7cf903b4022
     status: 200 OK
     code: 200
     duration: ""
@@ -1120,38 +1409,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5QUDHY5rEB9RmsX","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "371"
+      - "537"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:22 GMT
       Etag:
-      - W/"c0e6ac8cb8ce13b09102cc417bd8cbda"
-      Server:
-      - Caddy
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "832"
+      - "943"
       X-Request-Id:
-      - 9a52b42b-9a3a-434b-8ed3-a622a7b2619c
+      - d3dded24-ce21-4d97-9913-fea146e42771
     status: 200 OK
     code: 200
     duration: ""
@@ -1162,86 +1453,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5QUDHY5rEB9RmsX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5QUDHY5rEB9RmsX","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:98:e6:8a:d6:89","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "514"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
-      Etag:
-      - W/"ea4760e9205cfc76e26039cbf6c0cea4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "831"
-      X-Request-Id:
-      - 7eb958f0-3a90-4fc4-833e-662daaf99f45
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:22 GMT
+      Etag:
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - ae3e075a-4501-4031-afaa-d3881c12743a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rg3wcxZmshtnsFo8","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2593"
+      - "395"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:22 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"7a53c4f8fefd6748e2978f218db1b9a2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "829"
+      - "941"
       X-Request-Id:
-      - 2e769c3c-2d56-47db-b3e4-de8dc718a03c
+      - 1cb22091-c71a-4d72-a7db-7e589cd291ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "537"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:22 GMT
+      Etag:
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "940"
+      X-Request-Id:
+      - e3a58a37-c76b-4a7a-be77-17a95c977f3c
     status: 200 OK
     code: 200
     duration: ""
@@ -1252,38 +1586,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5QUDHY5rEB9RmsX","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "371"
+      - "537"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:22 GMT
       Etag:
-      - W/"c0e6ac8cb8ce13b09102cc417bd8cbda"
-      Server:
-      - Caddy
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "828"
+      - "939"
       X-Request-Id:
-      - a8f04704-7603-42a9-a2a7-a74f55a87638
+      - 75f29290-f719-41af-8092-5faeca7332ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1294,86 +1630,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5QUDHY5rEB9RmsX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5QUDHY5rEB9RmsX","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:98:e6:8a:d6:89","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "514"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
-      Etag:
-      - W/"ea4760e9205cfc76e26039cbf6c0cea4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "827"
-      X-Request-Id:
-      - b8b7f115-3435-4ec2-9119-f0268f62c1c9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bfqdn%5D=tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:22 GMT
+      Etag:
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "938"
+      X-Request-Id:
+      - 20cf1453-4efc-401c-8b5d-6f7d1c610058
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rg3wcxZmshtnsFo8","name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2593"
+      - "395"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:23 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"7a53c4f8fefd6748e2978f218db1b9a2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "822"
+      - "937"
       X-Request-Id:
-      - 331942db-d3f0-41ac-a372-484fc4b6310f
+      - 86da0b46-4a3a-40c8-a7da-2f5188e7bc32
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "537"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:23 GMT
+      Etag:
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "936"
+      X-Request-Id:
+      - 52fd23d5-121f-40e2-b781-2eb9400f3991
     status: 200 OK
     code: 200
     duration: ""
@@ -1384,38 +1763,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rg3wcxZmshtnsFo8
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5QUDHY5rEB9RmsX","name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rg3wcxZmshtnsFo8","virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh"},"name":"Public
+      Network on tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:57:b7:ea:6e:94","state":"attached","ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "371"
+      - "537"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:23 GMT
       Etag:
-      - W/"c0e6ac8cb8ce13b09102cc417bd8cbda"
-      Server:
-      - Caddy
+      - W/"2cd4dffb3bd61805c544d2fc796f3224"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "820"
+      - "935"
       X-Request-Id:
-      - ece68eca-1c69-4c57-9395-df14facbcf09
+      - c294e97a-3454-4e88-9323-dc43f8e5cb2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1426,86 +1807,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5QUDHY5rEB9RmsX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5QUDHY5rEB9RmsX","virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2"},"name":"Public
-      Network on tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:98:e6:8a:d6:89","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "514"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
-      Etag:
-      - W/"ea4760e9205cfc76e26039cbf6c0cea4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "819"
-      X-Request-Id:
-      - 1e589a37-d91b-404f-9a52-35228e55654f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:23 GMT
       Etag:
-      - W/"4ee38cfbcc771c761600c441f545bb89"
-      Server:
-      - Caddy
+      - W/"e50f158074580dbf16ace8b01e8ba1e9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "814"
+      - "934"
       X-Request-Id:
-      - 1cd79862-c354-4b9f-8609-a66393d4d590
+      - 0a2a17d6-ed4b-4eca-a9b3-01a4fdc70d99
     status: 200 OK
     code: 200
     duration: ""
@@ -1516,14 +1856,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: POST
   response:
-    body: '{"task":{"id":"task_cETmjldHmThEtznc","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_jEWPQgZDlidrbC9c","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1533,19 +1875,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:23 GMT
       Etag:
-      - W/"f534d3af062fc45b496c1c5713d0b35b"
-      Server:
-      - Caddy
+      - W/"c960fcceb1a5efab0524ddf4d12b71e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "813"
+      - "933"
       X-Request-Id:
-      - 6c7984a2-7f5e-497f-ae56-fcfc638e2682
+      - 680f6de5-56a1-4d5d-a0cd-10f16966b8d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1556,14 +1898,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_cETmjldHmThEtznc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_jEWPQgZDlidrbC9c
     method: GET
   response:
-    body: '{"task":{"id":"task_cETmjldHmThEtznc","name":"Stop virtual machine","status":"pending","created_at":1679595247,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_jEWPQgZDlidrbC9c","name":"Stop virtual machine","status":"pending","created_at":1738871243,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1573,19 +1917,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:24 GMT
       Etag:
-      - W/"c8358d3fe2f75f0cdd365dd56f9ac606"
-      Server:
-      - Caddy
+      - W/"f3d5bb088fb26d505ab26bcf69618615"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "775"
+      - "931"
       X-Request-Id:
-      - 79e2896c-e9d7-4c3f-aba1-add550d7b61e
+      - f304998b-cbc6-4df9-884c-5e30e5b551c6
     status: 200 OK
     code: 200
     duration: ""
@@ -1596,14 +1940,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_cETmjldHmThEtznc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_jEWPQgZDlidrbC9c
     method: GET
   response:
-    body: '{"task":{"id":"task_cETmjldHmThEtznc","name":"Stop virtual machine","status":"pending","created_at":1679595247,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_jEWPQgZDlidrbC9c","name":"Stop virtual machine","status":"pending","created_at":1738871243,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1613,19 +1959,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:13 GMT
+      - Thu, 06 Feb 2025 19:47:29 GMT
       Etag:
-      - W/"c8358d3fe2f75f0cdd365dd56f9ac606"
-      Server:
-      - Caddy
+      - W/"f3d5bb088fb26d505ab26bcf69618615"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "726"
+      - "930"
       X-Request-Id:
-      - ac5803d2-f0f0-4d67-ab91-173b1a7fd3b9
+      - 951d9aa4-3301-4a0a-b6c2-ceba319bbeaa
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,36 +1982,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_cETmjldHmThEtznc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_jEWPQgZDlidrbC9c
     method: GET
   response:
-    body: '{"task":{"id":"task_cETmjldHmThEtznc","name":"Stop virtual machine","status":"running","created_at":1679595247,"started_at":1679595262,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_jEWPQgZDlidrbC9c","name":"Stop virtual machine","status":"running","created_at":1738871243,"started_at":1738871259,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:23 GMT
+      - Thu, 06 Feb 2025 19:47:39 GMT
       Etag:
-      - W/"106c472a60ff76719e177d6c9ec2226a"
-      Server:
-      - Caddy
+      - W/"02e7cac79268a4cf52eeafecb15534ad"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "696"
+      - "928"
       X-Request-Id:
-      - f2a1c9b9-6e98-4e58-972c-d5ada7ecc8c3
+      - 25541534-a937-4676-be60-14194b81a187
     status: 200 OK
     code: 200
     duration: ""
@@ -1676,14 +2024,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_cETmjldHmThEtznc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_jEWPQgZDlidrbC9c
     method: GET
   response:
-    body: '{"task":{"id":"task_cETmjldHmThEtznc","name":"Stop virtual machine","status":"completed","created_at":1679595247,"started_at":1679595262,"finished_at":1679595264,"progress":100}}'
+    body: '{"task":{"id":"task_jEWPQgZDlidrbC9c","name":"Stop virtual machine","status":"completed","created_at":1738871243,"started_at":1738871259,"finished_at":1738871260,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1693,19 +2043,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:33 GMT
+      - Thu, 06 Feb 2025 19:47:49 GMT
       Etag:
-      - W/"1d11359cdefa31eaab5b6f60f72e6385"
-      Server:
-      - Caddy
+      - W/"2ec13a9bb0e6f169724cc7345a13ce85"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "682"
+      - "921"
       X-Request-Id:
-      - 333bd819-4416-4d91-9cd6-e5b2aafc45ff
+      - dac4513a-f489-449a-8945-eebb452cfa7e
     status: 200 OK
     code: 200
     duration: ""
@@ -1716,44 +2066,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2593"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:35 GMT
+      - Thu, 06 Feb 2025 19:47:50 GMT
       Etag:
-      - W/"2b9fcd25977a90b224da4f7a71e8f50e"
-      Server:
-      - Caddy
+      - W/"3a7b8ca47a49a492e69870e49139b180"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "680"
+      - "920"
       X-Request-Id:
-      - fc0e6398-f48b-4b01-ae6f-b3bc5c1e44af
+      - 9488ed54-0bcb-49fc-8545-37d34667ad27
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,44 +2115,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_gnUlmKWajM9AlD5W","keep_until":1679768075,"object_id":"vm_e5Sl79fBqYvPG0Kh","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_e5Sl79fBqYvPG0Kh","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2","hostname":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host","fqdn":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595228,"initial_root_password":"urxhg8bjRl7x8i0L","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_x6DLTzqu4KmS3gIa","keep_until":1739044070,"object_id":"vm_kL3Nvcn0gkaaRIVW","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_kL3Nvcn0gkaaRIVW","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh","hostname":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host","fqdn":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"uUYvgVXbKy248CXI","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_e5Sl79fBqYvPG0Kh","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_MaUnYBhZnQtJ1wI3","address":"185.44.254.181","reverse_dns":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.181/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_kL3Nvcn0gkaaRIVW","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2728"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:35 GMT
+      - Thu, 06 Feb 2025 19:47:50 GMT
       Etag:
-      - W/"d926ebf0202e143c7d96782966126fae"
-      Server:
-      - Caddy
+      - W/"2e65820aa119c38bfa79f84bc24b3614"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "679"
+      - "919"
       X-Request-Id:
-      - 10f0a74c-dc77-41b6-bfa3-a0e07b120781
+      - b8bb4ff6-862d-46a4-83a5-11b437def8e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1812,14 +2164,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_MaUnYBhZnQtJ1wI3
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1829,19 +2183,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:35 GMT
+      - Thu, 06 Feb 2025 19:47:51 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "678"
+      - "918"
       X-Request-Id:
-      - 1f3894c8-712d-4524-affd-b58aa0541985
+      - 05fd17bb-6a55-4e8e-92da-ab9c3f9124da
     status: 200 OK
     code: 200
     duration: ""
@@ -1852,14 +2206,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kL3Nvcn0gkaaRIVW
     method: DELETE
   response:
-    body: '{"task":{"id":"task_eQ9FAUr1dY5iXkIQ","name":"Purge items from trash","status":"pending","created_at":1679595275,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_DJ4D4Fcc1KPD5mR8","name":"Purge items from trash","status":"pending","created_at":1738871271,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1869,19 +2225,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:35 GMT
+      - Thu, 06 Feb 2025 19:47:51 GMT
       Etag:
-      - W/"c2ba38d12deecc4ec84aa4b73f7e3f3e"
-      Server:
-      - Caddy
+      - W/"29965fd45eff7f3a0d8174cb522aa21d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "676"
+      - "917"
       X-Request-Id:
-      - f9d7c3f1-590f-4d84-8827-884a130fab68
+      - db6871ea-4c3d-44ec-ac32-5129bf2b142a
     status: 200 OK
     code: 200
     duration: ""
@@ -1892,14 +2248,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_gnUlmKWajM9AlD5W","keep_until":1679768075,"object_id":"vm_e5Sl79fBqYvPG0Kh","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_x6DLTzqu4KmS3gIa","keep_until":1739044070,"object_id":"vm_kL3Nvcn0gkaaRIVW","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1909,19 +2267,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:36 GMT
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Etag:
-      - W/"a88bbf241a0889b8c8116131de70596b"
-      Server:
-      - Caddy
+      - W/"08c16bdc597d104596b6dda77d2134ea"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "673"
+      - "916"
       X-Request-Id:
-      - 1f511e60-e540-4d40-b7f5-ea0a99ea03f1
+      - 86e2bb0e-aca3-4c6a-ac1e-89d34dc8faa9
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,14 +2290,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_gnUlmKWajM9AlD5W","keep_until":1679768075,"object_id":"vm_e5Sl79fBqYvPG0Kh","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_x6DLTzqu4KmS3gIa","keep_until":1739044070,"object_id":"vm_kL3Nvcn0gkaaRIVW","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1949,19 +2309,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:41 GMT
+      - Thu, 06 Feb 2025 19:47:57 GMT
       Etag:
-      - W/"a88bbf241a0889b8c8116131de70596b"
-      Server:
-      - Caddy
+      - W/"08c16bdc597d104596b6dda77d2134ea"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "653"
+      - "907"
       X-Request-Id:
-      - 1c82adf6-66ae-4731-8ed3-a15e4a676dd0
+      - 61d0cdda-c255-4c0b-9fe9-c3b7849bc7aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1972,15 +2332,101 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kL3Nvcn0gkaaRIVW
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_x6DLTzqu4KmS3gIa","keep_until":1739044070,"object_id":"vm_kL3Nvcn0gkaaRIVW","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:48:07 GMT
+      Etag:
+      - W/"08c16bdc597d104596b6dda77d2134ea"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - b2282b94-9a94-420b-8d00-370528d236b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kL3Nvcn0gkaaRIVW
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_x6DLTzqu4KmS3gIa","keep_until":1739044070,"object_id":"vm_kL3Nvcn0gkaaRIVW","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:48:17 GMT
+      Etag:
+      - W/"08c16bdc597d104596b6dda77d2134ea"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 4fe8d616-d06e-4256-93dc-354ebb9b991c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1990,19 +2436,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:48:27 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "635"
+      - "997"
       X-Request-Id:
-      - 4d9f1bbe-7be6-452c-a0c5-c18882d1b60e
+      - 3a0e56cc-f181-4843-9545-7d67744f85ad
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2013,36 +2459,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_d6h64MebflYy05hS
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_WqZ3uibELtRnBldI
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_d6h64MebflYy05hS","name":"tf-acc-test-data-source-by-fqdn-ewf2vwax7pz2-group","segregate":true,"created_at":1679595227}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_WqZ3uibELtRnBldI","name":"tf-acc-test-data-source-by-fqdn-yr9m24bgpauh-group","segregate":true,"auto_segregate":false,"created_at":1738871211}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "158"
+      - "181"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
+      - Thu, 06 Feb 2025 19:48:27 GMT
       Etag:
-      - W/"7032dc5c738664423544f6f35c14faee"
-      Server:
-      - Caddy
+      - W/"43d14e34161b4d30cec274cbe4ed2255"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "633"
+      - "996"
       X-Request-Id:
-      - 18ae0ef6-dfb9-4d76-84c7-724960254975
+      - 51ce9da9-7cbf-4771-8cc8-0ab758cfe41b
     status: 200 OK
     code: 200
     duration: ""
@@ -2053,14 +2501,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_MaUnYBhZnQtJ1wI3
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2070,19 +2520,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
+      - Thu, 06 Feb 2025 19:48:27 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "634"
+      - "996"
       X-Request-Id:
-      - ae20e606-a9a4-47a1-a25f-04bbafe77888
+      - cfba99c8-d5e5-4150-ac47-9aa914366678
     status: 200 OK
     code: 200
     duration: ""
@@ -2093,15 +2543,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2111,19 +2563,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:48:27 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "632"
+      - "994"
       X-Request-Id:
-      - 2b5ebf8e-64e4-44dd-a9e8-c09fcdcd03e1
+      - 6927031d-fa44-43e5-8b40-f0bf28ab9a99
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2134,15 +2586,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2152,19 +2606,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:48:27 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "631"
+      - "993"
       X-Request-Id:
-      - d9104c7b-097e-470c-a6bc-ce5d54ba7acf
+      - 983d46aa-b0f5-41a7-a43e-a896096d7d1d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2175,15 +2629,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2193,19 +2649,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:48:27 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "630"
+      - "992"
       X-Request-Id:
-      - 6c5f1124-2c40-4ee2-8bcd-1c2a503ad1cc
+      - 154de4c9-f226-4674-96ca-929e69929398
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2216,15 +2672,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_e5Sl79fBqYvPG0Kh
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_kL3Nvcn0gkaaRIVW
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2234,19 +2692,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:48:27 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "629"
+      - "991"
       X-Request-Id:
-      - a5b3a7d0-a8e4-4958-a321-79a1051e768e
+      - 0231ce63-29e3-4b3e-82ad-b3d90d4e6bab
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2257,15 +2715,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_MaUnYBhZnQtJ1wI3
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2275,19 +2735,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:48:27 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "628"
+      - "990"
       X-Request-Id:
-      - b21e277c-b909-4a2c-ba95-c0ad9ae9a04a
+      - c9d7df74-c4dc-422c-a136-5c753fe1f069
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.rand_id
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.rand_id
@@ -1,1 +1,1 @@
-x6yd8jkqij70
+80u4iknsy497

--- a/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.yaml
+++ b/internal/provider/testdata/DataSourceVirtualMachine_by_id.cassette.yaml
@@ -8,42 +8,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
+      - Thu, 06 Feb 2025 19:46:51 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "615"
+      - "954"
       X-Request-Id:
-      - 82133e15-e080-4c09-a246-c19445fae474
+      - e17aaa2b-8590-433f-bdd1-0f5ff1db757c
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -51,36 +53,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "156"
+      - "179"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
+      - Thu, 06 Feb 2025 19:46:51 GMT
       Etag:
-      - W/"ced5dbbea9fb2e3469cc795e6e32b763"
-      Server:
-      - Caddy
+      - W/"1bb580e6a6c0a7f751ef38f09b626da7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "615"
+      - "954"
       X-Request-Id:
-      - 54c6865c-dbe9-41bd-9af9-ccc6718afc6f
+      - e97761de-cd8d-412e-aef3-bf5af5643ef2
     status: 200 OK
     code: 200
     duration: ""
@@ -91,36 +95,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_0mWPLMNbTijokzTX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_0UJXpqrmsmy1Xptr
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "156"
+      - "179"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
+      - Thu, 06 Feb 2025 19:46:51 GMT
       Etag:
-      - W/"ced5dbbea9fb2e3469cc795e6e32b763"
-      Server:
-      - Caddy
+      - W/"1bb580e6a6c0a7f751ef38f09b626da7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "612"
+      - "948"
       X-Request-Id:
-      - cae33208-8957-44cc-a9f6-03cd11237bdc
+      - b55c032c-e846-4ac3-8b11-bb42f7f3e0a9
     status: 200 OK
     code: 200
     duration: ""
@@ -134,38 +140,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"185-44-254-91.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
+      - Thu, 06 Feb 2025 19:46:52 GMT
       Etag:
-      - W/"137b10129b421fd5b21a6014fed1266d"
-      Server:
-      - Caddy
+      - W/"f943cb9d68796582903be8a55aa121d2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "613"
+      - "950"
       X-Request-Id:
-      - dfcc4327-81d4-4914-8d95-b28efb937396
+      - ea2aae42-5685-4371-b9d3-68eb81268a26
     status: 200 OK
     code: 200
     duration: ""
@@ -176,38 +184,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_rJTdcQgSTaGPuIrY
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"185-44-254-91.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
+      - Thu, 06 Feb 2025 19:46:52 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"ba24dac13c6e319ce588b6b7efede152"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "611"
+      - "943"
       X-Request-Id:
-      - f21e16ec-73f9-4aa5-ab46-99b87b40ba19
+      - a5b803bc-f8cb-4e27-b740-21ce788c2ef3
     status: 200 OK
     code: 200
     duration: ""
@@ -218,44 +228,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_rJTdcQgSTaGPuIrY
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"185-44-254-91.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
+      - Thu, 06 Feb 2025 19:46:52 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"ba24dac13c6e319ce588b6b7efede152"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "610"
+      - "942"
       X-Request-Id:
-      - 2aa9deae-357f-4394-a314-07a430005381
+      - f8caefe5-37d0-4767-a63b-720d5599f35d
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_hc3GUyhBe6toov2e</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-id-x6yd8jkqij70-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-id-x6yd8jkqij70</Name><Description>A web server.</Description><Group>vmgrp_0mWPLMNbTijokzTX</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_rJTdcQgSTaGPuIrY</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-by-id-80u4iknsy497-host</Hostname></Hostname><Name>tf-acc-test-data-source-by-id-80u4iknsy497</Name><Description>A web server.</Description><Group>vmgrp_0UJXpqrmsmy1Xptr</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -263,36 +275,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Htz01LmqrHOrvfnO","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_MaQuyOOPDaIwOp7M","state":"pending"},"virtual_machine_build":{"id":"vmbuild_MaQuyOOPDaIwOp7M","state":"pending"},"hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host"}'
+    body: '{"task":{"id":"task_aHpRdx2YlV5akG43","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_BSxZu23YhEBY81Ck","state":"pending"},"virtual_machine_build":{"id":"vmbuild_BSxZu23YhEBY81Ck","state":"pending"},"hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "286"
+      - "303"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
+      - Thu, 06 Feb 2025 19:46:52 GMT
       Etag:
-      - W/"cd2ea1d1e34c031a8f625ce31cb4157f"
-      Server:
-      - Caddy
+      - W/"57b6e44102176327ab9da8460d79b5f4"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "609"
+      - "941"
       X-Request-Id:
-      - c89ea6dc-c910-4552-89d4-ded65ec797f3
+      - d268a102-2a6a-4384-8036-5c62b129c571
     status: 201 Created
     code: 201
     duration: ""
@@ -303,44 +317,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MaQuyOOPDaIwOp7M
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_BSxZu23YhEBY81Ck
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_MaQuyOOPDaIwOp7M","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_BSxZu23YhEBY81Ck","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-x6yd8jkqij70-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-x6yd8jkqij70\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0mWPLMNbTijokzTX\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.91\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-80u4iknsy497-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-80u4iknsy497\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0UJXpqrmsmy1Xptr\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595228}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738871212},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2048"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:50 GMT
+      - Thu, 06 Feb 2025 19:46:54 GMT
       Etag:
-      - W/"874aeae84a1bf35fb582d6001f65cf1b"
-      Server:
-      - Caddy
+      - W/"b7323fd8b1ce4b4032ef4748ac1e4cd7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "593"
+      - "939"
       X-Request-Id:
-      - 1b49bbed-6c06-4fda-ab87-3c0d117ad5d9
+      - 3b62845e-d031-4c01-b7d5-f7764cd9a4f8
     status: 200 OK
     code: 200
     duration: ""
@@ -351,44 +365,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MaQuyOOPDaIwOp7M
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_BSxZu23YhEBY81Ck
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_MaQuyOOPDaIwOp7M","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_BSxZu23YhEBY81Ck","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-x6yd8jkqij70-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-x6yd8jkqij70\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0mWPLMNbTijokzTX\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.91\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-80u4iknsy497-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-80u4iknsy497\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0UJXpqrmsmy1Xptr\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595228}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738871212},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2048"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:55 GMT
+      - Thu, 06 Feb 2025 19:46:59 GMT
       Etag:
-      - W/"874aeae84a1bf35fb582d6001f65cf1b"
-      Server:
-      - Caddy
+      - W/"5c22c77f55473f019e08bfe16aa4df65"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "566"
+      - "937"
       X-Request-Id:
-      - c35e93da-f3fe-4596-8430-19254220b8be
+      - ecc220b1-bf06-464d-bd04-29ae3dbca62f
     status: 200 OK
     code: 200
     duration: ""
@@ -399,50 +413,50 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MaQuyOOPDaIwOp7M
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_BSxZu23YhEBY81Ck
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_MaQuyOOPDaIwOp7M","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_BSxZu23YhEBY81Ck","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-x6yd8jkqij70-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-x6yd8jkqij70\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0mWPLMNbTijokzTX\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.91\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-by-id-80u4iknsy497-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-data-source-by-id-80u4iknsy497\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0UJXpqrmsmy1Xptr\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595228}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738871212},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2048"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:05 GMT
+      - Thu, 06 Feb 2025 19:47:09 GMT
       Etag:
-      - W/"fed4392a02cd8befbcd279ef0a96a3cb"
-      Server:
-      - Caddy
+      - W/"b8a16517b77f8009cd8676ad04c971a1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "867"
+      - "998"
       X-Request-Id:
-      - 709eb2a4-172c-4237-ab98-4e9da36052a7
+      - 77c0b042-8380-41ac-98bf-d25b3920c514
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -450,44 +464,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:05 GMT
+      - Thu, 06 Feb 2025 19:47:09 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"a6a0ed76347318a3c7e19cea2b612552"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "866"
+      - "997"
       X-Request-Id:
-      - f2e1b152-d986-47cd-9f22-3027bbb79902
+      - a7055e6c-0a1d-4056-aca4-559795824258
     status: 200 OK
     code: 200
     duration: ""
@@ -498,44 +513,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:07 GMT
+      - Thu, 06 Feb 2025 19:47:11 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"53cee1d0de4002630aaa6a23f6f95137"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "812"
+      - "996"
       X-Request-Id:
-      - 48314633-37bc-4575-b407-b9191c22a3de
+      - 2b306a8b-5f70-44a3-b2d7-51bdac86924e
     status: 200 OK
     code: 200
     duration: ""
@@ -546,44 +562,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:16 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "811"
+      - "995"
       X-Request-Id:
-      - d3f981bb-f812-4859-a1ab-dd1d7e7bf5e8
+      - 12f00d6a-1482-492e-be7a-95c1ddb2b029
     status: 200 OK
     code: 200
     duration: ""
@@ -594,128 +611,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_0dMxN2LomNUUb8LX","name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "369"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"0be91cb90ba8794e3f10980522c43177"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "810"
-      X-Request-Id:
-      - fec0e3ac-7d02-43a5-b000-00be1e3bfeca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_0dMxN2LomNUUb8LX
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_0dMxN2LomNUUb8LX","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:8d:70:f2:ec:17","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "510"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"73d5f4310d0093917ea20be85b0883a2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "809"
-      X-Request-Id:
-      - 9214135b-2471-47d0-beca-f8b6a7c0c557
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:16 GMT
+      Etag:
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - e4579372-a113-42b2-914c-6b5a0812b1e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tuyrYlL6oH5gCmF4","name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2583"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:16 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"66bd77ae60720879daa02722216d33cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "808"
+      - "993"
       X-Request-Id:
-      - 7ced1079-c237-4099-8d67-5c69fe3938ad
+      - c5a72bdb-2d4f-411b-88f5-08b32689c056
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:16 GMT
+      Etag:
+      - W/"32090da093c5ba0b000b74f493d12322"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 1044d150-2236-41ee-8d1b-e79bbdd6e1dc
     status: 200 OK
     code: 200
     duration: ""
@@ -726,38 +744,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_0dMxN2LomNUUb8LX","name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "369"
+      - "532"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:16 GMT
       Etag:
-      - W/"0be91cb90ba8794e3f10980522c43177"
-      Server:
-      - Caddy
+      - W/"32090da093c5ba0b000b74f493d12322"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "807"
+      - "991"
       X-Request-Id:
-      - 9c2a1256-1613-4bf0-8e0e-a92b892554f0
+      - fa62363e-0930-4009-8c7f-56bcc00547df
     status: 200 OK
     code: 200
     duration: ""
@@ -768,86 +788,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_0dMxN2LomNUUb8LX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_0dMxN2LomNUUb8LX","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:8d:70:f2:ec:17","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "510"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"73d5f4310d0093917ea20be85b0883a2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "806"
-      X-Request-Id:
-      - 78fc2519-a254-41eb-b5a8-73960325f772
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:16 GMT
+      Etag:
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 12369d99-79b4-4e49-895b-0ee5a96f97b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tuyrYlL6oH5gCmF4","name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2583"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:16 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"66bd77ae60720879daa02722216d33cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "804"
+      - "989"
       X-Request-Id:
-      - 5f6bad70-f7b3-491e-89b1-8cb5b9ba9c7e
+      - 56026a55-8770-4e40-83ab-41fa4650441c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:16 GMT
+      Etag:
+      - W/"32090da093c5ba0b000b74f493d12322"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 8cf35700-5c3a-4b7a-a6f8-fc51236203b1
     status: 200 OK
     code: 200
     duration: ""
@@ -858,44 +921,89 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:16 GMT
+      Etag:
+      - W/"32090da093c5ba0b000b74f493d12322"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 321d94c2-738b-4309-9d52-0155d7c83544
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "803"
+      - "986"
       X-Request-Id:
-      - c312bf66-86dc-4681-863c-c58a4d067262
+      - e4018204-9b0e-4527-8b9c-c1ac50be819a
     status: 200 OK
     code: 200
     duration: ""
@@ -906,210 +1014,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_0dMxN2LomNUUb8LX","name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "369"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"0be91cb90ba8794e3f10980522c43177"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "802"
-      X-Request-Id:
-      - 77be178d-bef5-4973-8288-0e3cd5598b48
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_0dMxN2LomNUUb8LX
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_0dMxN2LomNUUb8LX","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:8d:70:f2:ec:17","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "510"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"73d5f4310d0093917ea20be85b0883a2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "801"
-      X-Request-Id:
-      - 9b6c349e-4679-42cd-9ac4-67e5e859500d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_0mWPLMNbTijokzTX
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "156"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"ced5dbbea9fb2e3469cc795e6e32b763"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "792"
-      X-Request-Id:
-      - 98cf60d7-9f14-4cff-932f-28116df4922f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "753"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"b48d4736d27eb253382a11fd0cc4fe13"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "791"
-      X-Request-Id:
-      - 527516ce-dc28-43f4-b599-8f102fcbc50b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 82a89ff5-12d6-4fbb-a37e-d62383c141db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tuyrYlL6oH5gCmF4","name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2583"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"66bd77ae60720879daa02722216d33cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "789"
+      - "984"
       X-Request-Id:
-      - b25bc942-0807-404a-bacf-98c1258895a4
+      - 8e0a65db-befa-4cae-8b0b-73fb47a4451a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"32090da093c5ba0b000b74f493d12322"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 72a94787-5579-4789-a5e3-c7ad8777c1f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1120,38 +1147,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_0dMxN2LomNUUb8LX","name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "369"
+      - "532"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"0be91cb90ba8794e3f10980522c43177"
-      Server:
-      - Caddy
+      - W/"32090da093c5ba0b000b74f493d12322"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "787"
+      - "982"
       X-Request-Id:
-      - adce5267-564c-4c66-aec7-d76ece7aed97
+      - a4f34b54-2b6e-49a2-9b81-618a090320ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1162,38 +1191,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_0dMxN2LomNUUb8LX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_0UJXpqrmsmy1Xptr
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_0dMxN2LomNUUb8LX","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:8d:70:f2:ec:17","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "510"
+      - "179"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"73d5f4310d0093917ea20be85b0883a2"
-      Server:
-      - Caddy
+      - W/"1bb580e6a6c0a7f751ef38f09b626da7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "785"
+      - "981"
       X-Request-Id:
-      - 56b52897-f0b5-4b49-b005-48aa2ed2482c
+      - e27d79a8-7876-496d-8756-99535e5241f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,44 +1233,173 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_rJTdcQgSTaGPuIrY
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"ip_address":{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "766"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"613a8116b018e599b289142ba3a6ca4a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - c224bcf1-59c6-49e6-b20e-f71093e1dfe0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 13d4d25a-d0d2-4aef-891c-9827a78df58d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tuyrYlL6oH5gCmF4","name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2583"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"66bd77ae60720879daa02722216d33cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "784"
+      - "978"
       X-Request-Id:
-      - f2277376-020e-43f3-9ecb-11973978a42f
+      - bbe8fca3-ef4c-4f45-b184-1de539835de8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"32090da093c5ba0b000b74f493d12322"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - c64f1fad-2575-4bdd-bc62-fed9124db9ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1252,38 +1410,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_0dMxN2LomNUUb8LX","name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "369"
+      - "532"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"0be91cb90ba8794e3f10980522c43177"
-      Server:
-      - Caddy
+      - W/"32090da093c5ba0b000b74f493d12322"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "782"
+      - "976"
       X-Request-Id:
-      - 4da30788-b3c1-4874-b964-4a5774ad92c1
+      - 268cad57-e332-4ecc-a949-7c1500de0230
     status: 200 OK
     code: 200
     duration: ""
@@ -1294,86 +1454,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_0dMxN2LomNUUb8LX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_0dMxN2LomNUUb8LX","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:8d:70:f2:ec:17","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "510"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"73d5f4310d0093917ea20be85b0883a2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "781"
-      X-Request-Id:
-      - a7eb4937-eee5-4b5e-b389-8d9650094bd4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 4989836e-36e3-434e-8638-3f398ce1f437
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tuyrYlL6oH5gCmF4","name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2583"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"66bd77ae60720879daa02722216d33cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "777"
+      - "974"
       X-Request-Id:
-      - 01ae11cf-a309-4b9e-9628-04b7613bc3fc
+      - d23cac54-0ec1-42c1-bb02-e542a319dc4d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"32090da093c5ba0b000b74f493d12322"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - fd2fe306-8dd0-4bb4-a76b-30fc00a740cb
     status: 200 OK
     code: 200
     duration: ""
@@ -1384,38 +1587,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_0dMxN2LomNUUb8LX","name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "369"
+      - "532"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"0be91cb90ba8794e3f10980522c43177"
-      Server:
-      - Caddy
+      - W/"32090da093c5ba0b000b74f493d12322"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "774"
+      - "972"
       X-Request-Id:
-      - 6f58370e-b520-4f65-b229-700fe943699c
+      - 22cec403-be0f-4b80-b182-98c70cfd3432
     status: 200 OK
     code: 200
     duration: ""
@@ -1426,86 +1631,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_0dMxN2LomNUUb8LX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_0dMxN2LomNUUb8LX","virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70"},"name":"Public
-      Network on tf-acc-test-data-source-by-id-x6yd8jkqij70","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:8d:70:f2:ec:17","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "510"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:08 GMT
-      Etag:
-      - W/"73d5f4310d0093917ea20be85b0883a2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "772"
-      X-Request-Id:
-      - a93623e0-61d8-4b2b-81a8-8e608d522ab2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 239ddfeb-080a-4186-ba95-8bb4c821bce3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_tuyrYlL6oH5gCmF4","name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2583"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:09 GMT
+      - Thu, 06 Feb 2025 19:47:17 GMT
       Etag:
-      - W/"b385bb88f6e63a5655e51187fdd94f73"
-      Server:
-      - Caddy
+      - W/"66bd77ae60720879daa02722216d33cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "767"
+      - "970"
       X-Request-Id:
-      - e9755481-91eb-4d94-8714-1fcf7b3296ae
+      - 7748697c-ac45-482c-93d1-49583d202ba2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"32090da093c5ba0b000b74f493d12322"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - fbd4e612-7727-4b39-a09f-3aeb80664e1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1516,14 +1764,109 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_tuyrYlL6oH5gCmF4
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_tuyrYlL6oH5gCmF4","virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497"},"name":"Public
+      Network on tf-acc-test-data-source-by-id-80u4iknsy497","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:ce:4e:fa:fc","state":"attached","ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:17 GMT
+      Etag:
+      - W/"32090da093c5ba0b000b74f493d12322"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - 2c006e46-7e64-4941-9376-e080226ebba8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 19:47:18 GMT
+      Etag:
+      - W/"f50a8b36e232db897b25620bc6e9cc78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 8c727746-44f8-45e6-a141-8f2cf5c432a6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: POST
   response:
-    body: '{"task":{"id":"task_G918IxEbVjS6hEsL","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_oWcYIRc0ylYgjQ2D","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1533,19 +1876,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:09 GMT
+      - Thu, 06 Feb 2025 19:47:18 GMT
       Etag:
-      - W/"9057b635368ee0a16fd826fc8631f5ed"
-      Server:
-      - Caddy
+      - W/"b4dbc219138c229a3a2641ceb8f238d6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "765"
+      - "966"
       X-Request-Id:
-      - d7e029f4-58d1-4994-bc20-ad2411139c10
+      - a14b0a0e-695a-423b-a0fe-e10c2cd53dd0
     status: 200 OK
     code: 200
     duration: ""
@@ -1556,14 +1899,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_G918IxEbVjS6hEsL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_oWcYIRc0ylYgjQ2D
     method: GET
   response:
-    body: '{"task":{"id":"task_G918IxEbVjS6hEsL","name":"Stop virtual machine","status":"pending","created_at":1679595249,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_oWcYIRc0ylYgjQ2D","name":"Stop virtual machine","status":"pending","created_at":1738871238,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1573,19 +1918,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:10 GMT
+      - Thu, 06 Feb 2025 19:47:19 GMT
       Etag:
-      - W/"12eacf63ef8af04d160f85ac59063693"
-      Server:
-      - Caddy
+      - W/"5c4e3500d40127ae69ad87ee95655c6c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "749"
+      - "965"
       X-Request-Id:
-      - ec12229a-2022-4a0f-b6aa-627ea4872e2f
+      - 63e61671-6838-430d-bd8a-358baca19f5a
     status: 200 OK
     code: 200
     duration: ""
@@ -1596,14 +1941,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_G918IxEbVjS6hEsL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_oWcYIRc0ylYgjQ2D
     method: GET
   response:
-    body: '{"task":{"id":"task_G918IxEbVjS6hEsL","name":"Stop virtual machine","status":"pending","created_at":1679595249,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_oWcYIRc0ylYgjQ2D","name":"Stop virtual machine","status":"pending","created_at":1738871238,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1613,19 +1960,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:15 GMT
+      - Thu, 06 Feb 2025 19:47:24 GMT
       Etag:
-      - W/"12eacf63ef8af04d160f85ac59063693"
-      Server:
-      - Caddy
+      - W/"5c4e3500d40127ae69ad87ee95655c6c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "725"
+      - "932"
       X-Request-Id:
-      - 33c226fc-f979-4298-a068-7e0d39a86ce8
+      - 65121d42-588d-4234-85cc-147bbfde4e02
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,36 +1983,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_G918IxEbVjS6hEsL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_oWcYIRc0ylYgjQ2D
     method: GET
   response:
-    body: '{"task":{"id":"task_G918IxEbVjS6hEsL","name":"Stop virtual machine","status":"running","created_at":1679595249,"started_at":1679595264,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_oWcYIRc0ylYgjQ2D","name":"Stop virtual machine","status":"pending","created_at":1738871238,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "162"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:25 GMT
+      - Thu, 06 Feb 2025 19:47:34 GMT
       Etag:
-      - W/"2f755abde0b6c6e6fb4d2c33ef4ffa61"
-      Server:
-      - Caddy
+      - W/"5c4e3500d40127ae69ad87ee95655c6c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "689"
+      - "929"
       X-Request-Id:
-      - 681244f0-c002-456a-abe0-cb4552167814
+      - a9b3dc86-35ed-46bf-b895-9792edec9689
     status: 200 OK
     code: 200
     duration: ""
@@ -1676,14 +2025,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_G918IxEbVjS6hEsL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_oWcYIRc0ylYgjQ2D
     method: GET
   response:
-    body: '{"task":{"id":"task_G918IxEbVjS6hEsL","name":"Stop virtual machine","status":"completed","created_at":1679595249,"started_at":1679595264,"finished_at":1679595267,"progress":100}}'
+    body: '{"task":{"id":"task_oWcYIRc0ylYgjQ2D","name":"Stop virtual machine","status":"completed","created_at":1738871238,"started_at":1738871258,"finished_at":1738871259,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1693,19 +2044,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:35 GMT
+      - Thu, 06 Feb 2025 19:47:44 GMT
       Etag:
-      - W/"45e704fb7e6cceca0c8e9f769cecb47a"
-      Server:
-      - Caddy
+      - W/"502302deecdb874efb629dc7d34f0b56"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "677"
+      - "927"
       X-Request-Id:
-      - 854e6841-6d55-4dc0-8866-567dbc7c26e4
+      - fe0e1332-bb4b-43f6-9711-7307f4dc3f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1716,44 +2067,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2583"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:36 GMT
+      - Thu, 06 Feb 2025 19:47:45 GMT
       Etag:
-      - W/"642eed3790543fd4816a743319886c2a"
-      Server:
-      - Caddy
+      - W/"a6a0ed76347318a3c7e19cea2b612552"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "674"
+      - "926"
       X-Request-Id:
-      - 6677d630-53a5-4cc9-9acb-d0735ea1192c
+      - a5938ebf-5762-4383-8368-a48f1409cb38
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,44 +2116,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_uKpElHkeS5NWUgMc","keep_until":1679768076,"object_id":"vm_DebmB7LpFnsm8E5P","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_DebmB7LpFnsm8E5P","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70","hostname":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host","fqdn":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595230,"initial_root_password":"rzqBWqpl276Zh8dG","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_l5Fn9bamZFZYabO5","keep_until":1739044065,"object_id":"vm_cKYCT7dzYLkCshtb","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_cKYCT7dzYLkCshtb","name":"tf-acc-test-data-source-by-id-80u4iknsy497","hostname":"tf-acc-test-data-source-by-id-80u4iknsy497-host","fqdn":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738871217,"initial_root_password":"QrEpjBinM6JWYlir","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-data-source-by-id-x6yd8jkqij70-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_DebmB7LpFnsm8E5P","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_rJTdcQgSTaGPuIrY","address":"185.44.254.91","reverse_dns":"tf-acc-test-data-source-by-id-80u4iknsy497-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.91/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cKYCT7dzYLkCshtb","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2718"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:36 GMT
+      - Thu, 06 Feb 2025 19:47:45 GMT
       Etag:
-      - W/"ba4f8c468529ec318e5759d110adb8cf"
-      Server:
-      - Caddy
+      - W/"4d856b5427db47c9bdd0dbb9c6a4259c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "672"
+      - "925"
       X-Request-Id:
-      - 4fa4c548-033a-459d-ab0b-908f95f433d5
+      - ab259c58-258e-49d8-a4b8-07f4a9609353
     status: 200 OK
     code: 200
     duration: ""
@@ -1812,14 +2165,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_rJTdcQgSTaGPuIrY
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1829,19 +2184,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:36 GMT
+      - Thu, 06 Feb 2025 19:47:46 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "671"
+      - "924"
       X-Request-Id:
-      - ade9570e-294d-41ec-9275-3582b1041b63
+      - fe75b4c0-4e03-422e-bd3f-09f2f6d326a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1852,14 +2207,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_cKYCT7dzYLkCshtb
     method: DELETE
   response:
-    body: '{"task":{"id":"task_qxvR8YLiXtrOvnFp","name":"Purge items from trash","status":"pending","created_at":1679595276,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_4o5C63kdATvB2sFV","name":"Purge items from trash","status":"pending","created_at":1738871266,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1869,19 +2226,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:36 GMT
+      - Thu, 06 Feb 2025 19:47:46 GMT
       Etag:
-      - W/"0c92548ad02794f3637c1515bfa82a56"
-      Server:
-      - Caddy
+      - W/"8478cf60631ea0b65f20339cbe79399b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "670"
+      - "923"
       X-Request-Id:
-      - ba8bcd4f-a2d0-48ab-bb72-febab4529e95
+      - 2ea897f2-e081-4c86-93e3-18d92903cfd3
     status: 200 OK
     code: 200
     duration: ""
@@ -1892,14 +2249,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_uKpElHkeS5NWUgMc","keep_until":1679768076,"object_id":"vm_DebmB7LpFnsm8E5P","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_l5Fn9bamZFZYabO5","keep_until":1739044065,"object_id":"vm_cKYCT7dzYLkCshtb","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1909,19 +2268,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:14:37 GMT
+      - Thu, 06 Feb 2025 19:47:47 GMT
       Etag:
-      - W/"ab14c6a32bcb43b12781abf8c57a2dd8"
-      Server:
-      - Caddy
+      - W/"61b243ea069ebe0a4bfb63c8fe199e4c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "669"
+      - "922"
       X-Request-Id:
-      - e7039c08-ae21-4036-a065-8c6016a4f5d5
+      - d625d87d-fd3e-4e88-b510-9bf078902e38
     status: 200 OK
     code: 200
     duration: ""
@@ -1932,95 +2291,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_DebmB7LpFnsm8E5P
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_uKpElHkeS5NWUgMc","keep_until":1679768076,"object_id":"vm_DebmB7LpFnsm8E5P","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:42 GMT
-      Etag:
-      - W/"ab14c6a32bcb43b12781abf8c57a2dd8"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "648"
-      X-Request-Id:
-      - 2c950a74-eabf-472d-91ba-2f94e2740441
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_DebmB7LpFnsm8E5P
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_uKpElHkeS5NWUgMc","keep_until":1679768076,"object_id":"vm_DebmB7LpFnsm8E5P","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:14:52 GMT
-      Etag:
-      - W/"ab14c6a32bcb43b12781abf8c57a2dd8"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "622"
-      X-Request-Id:
-      - a1ffd9a2-c0a5-4c10-8849-7fc7d3aae7f8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2030,19 +2311,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:02 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "915"
       X-Request-Id:
-      - 00ec50b5-fdb7-4c9a-9660-63e59fb4de83
+      - 3b86a01d-bc56-4d44-886c-c61f617b38a5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2053,36 +2334,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_0mWPLMNbTijokzTX
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_0UJXpqrmsmy1Xptr
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_0mWPLMNbTijokzTX","name":"tf-acc-test-data-source-by-id-x6yd8jkqij70-group","segregate":true,"created_at":1679595228}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_0UJXpqrmsmy1Xptr","name":"tf-acc-test-data-source-by-id-80u4iknsy497-group","segregate":true,"auto_segregate":false,"created_at":1738871211}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "156"
+      - "179"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:03 GMT
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Etag:
-      - W/"ced5dbbea9fb2e3469cc795e6e32b763"
-      Server:
-      - Caddy
+      - W/"1bb580e6a6c0a7f751ef38f09b626da7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "913"
       X-Request-Id:
-      - f7c96066-241e-4b4d-b4b9-bd4055ae488d
+      - 26759e09-4a45-4b9d-b290-cc00dc79b55c
     status: 200 OK
     code: 200
     duration: ""
@@ -2093,14 +2376,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_rJTdcQgSTaGPuIrY
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2110,19 +2395,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:03 GMT
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "914"
       X-Request-Id:
-      - 31243d2b-f3c5-431e-aac1-d67f853fc5ac
+      - e45dc4b5-b539-41ff-9f97-4a6b957d3502
     status: 200 OK
     code: 200
     duration: ""
@@ -2133,15 +2418,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2151,19 +2438,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:03 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "912"
       X-Request-Id:
-      - f9475756-5c3c-43ad-9aa6-c42958ad3c52
+      - 7e6ac529-61a3-4be2-93ed-5521f334dc5e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2174,15 +2461,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2192,19 +2481,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:03 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "911"
       X-Request-Id:
-      - 68b53965-20eb-4684-84f6-a003513ba3aa
+      - 57e83c21-ea4a-4b18-ae1d-8e410cb47eb9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2215,15 +2504,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2233,19 +2524,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:03 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "910"
       X-Request-Id:
-      - b7ddcf83-e7de-4dcb-b88e-77a78c9984b2
+      - 8087bdd7-4001-4ad4-9f97-aff1f61663fa
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2256,15 +2547,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_DebmB7LpFnsm8E5P
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_cKYCT7dzYLkCshtb
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2274,19 +2567,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:03 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "909"
       X-Request-Id:
-      - 1bda3d21-28ae-44d9-a9b3-464d14a0b7b1
+      - 02b0b6c6-694a-461c-966a-9a07aae9dd4d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2297,15 +2590,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_rJTdcQgSTaGPuIrY
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2315,19 +2610,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:15:03 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 19:47:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "908"
       X-Request-Id:
-      - 7a266c16-5234-462f-a1ca-8d1f70f42eb2
+      - 6076a4fb-2e25-4433-8428-841c723cec92
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/FileStorageVolume_associations.cassette.rand_id
+++ b/internal/provider/testdata/FileStorageVolume_associations.cassette.rand_id
@@ -1,1 +1,1 @@
-rlc6dflfua0w
+ni9kr1cjg9nl

--- a/internal/provider/testdata/FileStorageVolume_associations.cassette.yaml
+++ b/internal/provider/testdata/FileStorageVolume_associations.cassette.yaml
@@ -3,7 +3,7 @@ version: 1
 interactions:
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"permalink":"uk-lon-01"}}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"permalink":"uk-lon-01"}}}
     form: {}
     headers:
       Accept:
@@ -11,36 +11,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/file_storage_volumes
     method: POST
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"pending","nfs_location":null,"size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "249"
+      - "266"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:27 GMT
+      - Thu, 06 Feb 2025 16:43:51 GMT
       Etag:
-      - W/"1588e6b18e5ca5f898107dd69bbb5f61"
-      Server:
-      - Caddy
+      - W/"54fc0915dea267797ad1f0f6ef44ab39"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "999"
       X-Request-Id:
-      - 924ad42c-28e8-413a-8da3-53f668e3771a
+      - 1d8ee2f6-0a89-4857-b505-7a48e90734b9
     status: 201 Created
     code: 201
     duration: ""
@@ -51,36 +53,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":null,"size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "253"
+      - "270"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:29 GMT
+      - Thu, 06 Feb 2025 16:43:53 GMT
       Etag:
-      - W/"ab97df7fc450bce89f4b642ceab718c9"
-      Server:
-      - Caddy
+      - W/"3af8d482e39c0cec35e671aebb67af7f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "998"
       X-Request-Id:
-      - 5861f90d-5dc6-4e7f-9115-e0531335c0a3
+      - 7ad69810-2533-4fdb-9382-85be2a8d3695
     status: 200 OK
     code: 200
     duration: ""
@@ -91,36 +95,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "270"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:34 GMT
+      - Thu, 06 Feb 2025 16:43:58 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"3af8d482e39c0cec35e671aebb67af7f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "997"
       X-Request-Id:
-      - 659c7f13-4940-4eee-b32e-e9c8ebfed792
+      - ad17f0af-9565-440d-9323-49eeea46ba02
     status: 200 OK
     code: 200
     duration: ""
@@ -131,36 +137,164 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "321"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:34 GMT
+      - Thu, 06 Feb 2025 16:44:08 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - dcaa21fc-ec3f-4ce1-9ca3-7b0d4cebf416
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:08 GMT
+      Etag:
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 369eb238-74de-4d19-9f2f-728a906cd056
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:08 GMT
+      Etag:
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - e22ec371-3a5b-4b7a-9e00-50ac84c0696c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:09 GMT
+      Etag:
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "996"
       X-Request-Id:
-      - 67d90fd6-708e-4a98-bac9-9cc15fecd31c
+      - 1c8a6b31-f5b1-4ef3-982e-3e0bf84ba1dd
     status: 200 OK
     code: 200
     duration: ""
@@ -171,36 +305,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "321"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:35 GMT
+      - Thu, 06 Feb 2025 16:44:09 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "995"
       X-Request-Id:
-      - 4badff97-2fd7-4547-8294-000b1ff678bc
+      - efc33765-96d2-4f2b-a49a-979dc9d46ea5
     status: 200 OK
     code: 200
     duration: ""
@@ -211,116 +347,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:35 GMT
+      - Thu, 06 Feb 2025 16:44:09 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "994"
       X-Request-Id:
-      - dda1c400-f43d-42eb-9273-1ce92d069620
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "304"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:16:35 GMT
-      Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - 22118807-6368-4236-ae0e-485b647eb1ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
-    method: GET
-  response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "181"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:16:35 GMT
-      Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - 9a6b2fbc-d591-4c26-b281-abaabb1f3d88
+      - f1ab809c-265f-4d4b-ad37-fa9b42da6e8b
     status: 200 OK
     code: 200
     duration: ""
@@ -334,128 +392,134 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"185-44-254-140.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:36 GMT
+      - Thu, 06 Feb 2025 16:44:09 GMT
       Etag:
-      - W/"70ae5cda48cd0cdf599bd81704faa419"
-      Server:
-      - Caddy
+      - W/"7997c45e1ae5e08f0406ddf7d70cebb0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 7a9bc943-4316-4376-8b8f-491592f202c8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"185-44-254-140.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "579"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:09 GMT
+      Etag:
+      - W/"361c0d64b5d3d420604c0e2abe8c2199"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 5443515f-bd05-4be2-95b5-f6a0a3fbda8e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"185-44-254-140.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "579"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:09 GMT
+      Etag:
+      - W/"361c0d64b5d3d420604c0e2abe8c2199"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "991"
       X-Request-Id:
-      - 8e55f1ad-cb12-411c-81bb-c0a4ac0568df
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:16:36 GMT
-      Etag:
-      - W/"7367639e17424126d908b7a96b17219f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - fda00564-9b7e-4c6f-915c-2d7c684566c2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"185-199-221-55.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:16:36 GMT
-      Etag:
-      - W/"7367639e17424126d908b7a96b17219f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - fd6c5c8a-6554-4846-a100-2b2bee138a87
+      - 4f8c9560-5692-43ad-b915-8dc45e9c3613
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_2bjWpH3KQBlrSjJ0</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-associations-rlc6dflfua0w-web</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_la7rTtAU6BKxHpmG</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-associations-ni9kr1cjg9nl-web</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -463,36 +527,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Es8GvEImK8My8w3O","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_fcC00JA4tq0S8vP0","state":"pending"},"virtual_machine_build":{"id":"vmbuild_fcC00JA4tq0S8vP0","state":"pending"},"hostname":"tf-acc-test-associations-rlc6dflfua0w-web"}'
+    body: '{"task":{"id":"task_dY05sLHRV5kZineZ","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_Ilzk08gsEYjVxNbk","state":"pending"},"virtual_machine_build":{"id":"vmbuild_Ilzk08gsEYjVxNbk","state":"pending"},"hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "280"
+      - "297"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:36 GMT
+      - Thu, 06 Feb 2025 16:44:09 GMT
       Etag:
-      - W/"e31208bafbda44d2943465ae61497637"
-      Server:
-      - Caddy
+      - W/"531948750cda77237278756497947d31"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "990"
       X-Request-Id:
-      - ad79d403-6901-4ca0-bd2d-fca4baa2dc53
+      - ff14b143-60e8-4796-b387-7e576a2ee63f
     status: 201 Created
     code: 201
     duration: ""
@@ -503,43 +569,137 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_fcC00JA4tq0S8vP0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Ilzk08gsEYjVxNbk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_fcC00JA4tq0S8vP0","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Ilzk08gsEYjVxNbk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-rlc6dflfua0w-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679598996}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860249},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1624"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:38 GMT
+      - Thu, 06 Feb 2025 16:44:11 GMT
       Etag:
-      - W/"80a21f468d7ffed7fc22135fe370a83d"
-      Server:
-      - Caddy
+      - W/"a5fcf0fb962b516e53251f4e2fb7c746"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 24d08049-503b-4958-bbe7-9de9df7de0b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Ilzk08gsEYjVxNbk
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_Ilzk08gsEYjVxNbk","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860249},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:16 GMT
+      Etag:
+      - W/"0350e9f29d9b9c46040baf320fc3c2a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 8443220a-74bc-44cc-86cd-a0116ff9f512
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Ilzk08gsEYjVxNbk
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_Ilzk08gsEYjVxNbk","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860249},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:26 GMT
+      Etag:
+      - W/"0350e9f29d9b9c46040baf320fc3c2a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - ef7c6b11-b0ac-4f23-be44-a5a8f66f762a
+      - a58bd092-0328-4dc1-bef7-c0e5a6b0b82f
     status: 200 OK
     code: 200
     duration: ""
@@ -550,43 +710,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_fcC00JA4tq0S8vP0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Ilzk08gsEYjVxNbk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_fcC00JA4tq0S8vP0","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_Ilzk08gsEYjVxNbk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-rlc6dflfua0w-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679598996}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738860249},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1624"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:43 GMT
+      - Thu, 06 Feb 2025 16:44:36 GMT
       Etag:
-      - W/"80a21f468d7ffed7fc22135fe370a83d"
-      Server:
-      - Caddy
+      - W/"2848cbfc76af700bb1d82a74db9726c9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - 5b7d0d26-5072-47a9-882b-01b1fba50f02
+      - f093fb92-4a4b-455e-bd6e-d69f0cff01a9
     status: 200 OK
     code: 200
     duration: ""
@@ -597,43 +757,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_fcC00JA4tq0S8vP0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_fcC00JA4tq0S8vP0","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-rlc6dflfua0w-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679598996}}'
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1624"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:53 GMT
+      - Thu, 06 Feb 2025 16:44:38 GMT
       Etag:
-      - W/"45aa0c483ae2c0d2ef019747fb087168"
-      Server:
-      - Caddy
+      - W/"97aba99d7bfc77dc15d088b3bc730f2c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - e4af94ab-c4c3-4b8d-a34e-c011294f2b40
+      - 21c8ea29-40c7-49dc-8891-ac611b7853f0
     status: 200 OK
     code: 200
     duration: ""
@@ -644,43 +805,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2238"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:56 GMT
+      - Thu, 06 Feb 2025 16:44:43 GMT
       Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "984"
       X-Request-Id:
-      - dedd7f79-0fec-492d-8945-979d128d552f
+      - 87c196da-d2f9-4e3c-b63b-f031d2ada0e5
     status: 200 OK
     code: 200
     duration: ""
@@ -691,43 +853,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2238"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:56 GMT
+      - Thu, 06 Feb 2025 16:44:43 GMT
       Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "983"
       X-Request-Id:
-      - d8da3046-6b00-43e6-9ebd-d4b3e6ca546a
+      - 6bb911d5-3611-4bf2-a8f3-ec9ad549e4a1
     status: 200 OK
     code: 200
     duration: ""
@@ -735,41 +898,83 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_WtF6oekQbqTIT9Z1","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bnWioM07yubgjgMv","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "368"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:56 GMT
+      - Thu, 06 Feb 2025 16:44:43 GMT
       Etag:
-      - W/"1495b45f867462197f42a21314a3afdb"
-      Server:
-      - Caddy
+      - W/"85222f7e95b1c0947e4ceb87e4668074"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "982"
       X-Request-Id:
-      - 55302b6d-4d44-4452-97e6-f28b42b1d5e9
+      - 297da392-84a5-4ed4-8943-d11c3883f46c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "533"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:43 GMT
+      Etag:
+      - W/"4985923a0418a48eea8ee5258d816d2e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 6b77113a-ddde-4a8f-bd22-d649e6cc214b
     status: 200 OK
     code: 200
     duration: ""
@@ -780,87 +985,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_WtF6oekQbqTIT9Z1
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_WtF6oekQbqTIT9Z1","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2f:3e:d2:17:ff","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "510"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:56 GMT
+      - Thu, 06 Feb 2025 16:44:44 GMT
       Etag:
-      - W/"8634b1c952a6002f27616e9f73a50120"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "981"
-      X-Request-Id:
-      - 8f5d7737-e52a-41b4-be5e-288987b25289
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"]}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/file_storage_volumes
-    method: POST
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"pending","nfs_location":null,"size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "276"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:16:56 GMT
-      Etag:
-      - W/"b853a7183c82d00b5bb7d398e50bc752"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "980"
       X-Request-Id:
-      - bb4279e4-a8e5-47fd-b071-722ad75cf1eb
-    status: 201 Created
-    code: 201
+      - 61b2d9f9-609c-4879-92ec-5d17d08ebd79
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: |
-      {"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor"},"properties":{"associations":["vm_VfFea7edbX4wtydr"]}}
+      {"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN"},"properties":{"associations":["vm_Jz1rzwtJ7kaeWEEc"]}}
     form: {}
     headers:
       Accept:
@@ -868,76 +1032,125 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/file_storage_volumes/_
     method: PATCH
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:56 GMT
+      - Thu, 06 Feb 2025 16:44:44 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - 0622217f-b593-4ae4-bd9a-612c095ce030
+      - 62ca079d-acc6-4cb9-a468-00c639974125
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"]}}
     form: {}
     headers:
       Accept:
       - application/json
+      Content-Type:
+      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/file_storage_volumes
+    method: POST
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"configuring","nfs_location":null,"size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "280"
+      - "293"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:16:59 GMT
+      - Thu, 06 Feb 2025 16:44:44 GMT
       Etag:
-      - W/"2876aa866f6c2c41793ed545f8bfe1a0"
-      Server:
-      - Caddy
+      - W/"612d1db9fefb0de2f2a38b62fa7f22be"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "978"
+      - "979"
       X-Request-Id:
-      - 52c9afd6-fec2-45a5-8173-e07903ccbcae
+      - 991fca60-b8eb-48c4-ad23-7852030a569b
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "297"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:46 GMT
+      Etag:
+      - W/"c194986a89d3e35dfee51f3b4f8d6f46"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - dbffdbca-4930-449c-ad3b-6c5dbd367f73
     status: 200 OK
     code: 200
     duration: ""
@@ -948,36 +1161,164 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "348"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:02 GMT
+      - Thu, 06 Feb 2025 16:44:49 GMT
       Etag:
-      - W/"96c11299db2066ab34566e908df4c34f"
-      Server:
-      - Caddy
+      - W/"90a0310caa80cb9ad700a00ba3172f74"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 0ce51c76-1afc-4697-929f-575c7b718d95
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "297"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:51 GMT
+      Etag:
+      - W/"c194986a89d3e35dfee51f3b4f8d6f46"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 3aff2150-f100-44f7-b84b-41b516cf584a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:44:54 GMT
+      Etag:
+      - W/"90a0310caa80cb9ad700a00ba3172f74"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 35770080-12a7-486f-ab69-af205b533762
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:45:01 GMT
+      Etag:
+      - W/"b6ddc425b7c24826bc50e4c3500efcbb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "999"
       X-Request-Id:
-      - 82527d0a-b1bf-4fc7-95ce-41111209a25e
+      - b347775c-d770-4c17-a208-815849953785
     status: 200 OK
     code: 200
     duration: ""
@@ -988,36 +1329,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "348"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:04 GMT
+      - Thu, 06 Feb 2025 16:45:01 GMT
       Etag:
-      - W/"be7583d0a1be03c0607f351540a9ec04"
-      Server:
-      - Caddy
+      - W/"b6ddc425b7c24826bc50e4c3500efcbb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "998"
       X-Request-Id:
-      - 65e9f55b-8ac3-4a6d-8d19-3fd6b2067db3
+      - 6abd7a1a-e639-4bc7-9cc9-c030e98a99b1
     status: 200 OK
     code: 200
     duration: ""
@@ -1028,36 +1371,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:04 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"be7583d0a1be03c0607f351540a9ec04"
-      Server:
-      - Caddy
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "997"
       X-Request-Id:
-      - 25cfc3fa-6f1b-406c-8871-49387ea554f9
+      - aa70492c-60e0-4141-870f-a15dcd0c4a58
     status: 200 OK
     code: 200
     duration: ""
@@ -1068,36 +1413,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:07 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "996"
       X-Request-Id:
-      - 5923dfa1-0d59-498c-a9c7-a43ade3f1f1f
+      - 8dbaddbd-851c-40f6-87d3-010bdff683e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1108,36 +1455,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:07 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "995"
       X-Request-Id:
-      - fcd9874d-f5f0-401e-98a7-19327c9a82be
+      - cb9a8a2f-b622-4194-8cfe-aa0aa71fc840
     status: 200 OK
     code: 200
     duration: ""
@@ -1148,36 +1497,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "348"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:07 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"b6ddc425b7c24826bc50e4c3500efcbb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "994"
       X-Request-Id:
-      - 584069db-435c-426c-adcf-65a4aa433524
+      - 15338d9e-d6c4-4ecb-9e80-fdeafab74f6e
     status: 200 OK
     code: 200
     duration: ""
@@ -1188,36 +1539,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "761"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:07 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"be7583d0a1be03c0607f351540a9ec04"
-      Server:
-      - Caddy
+      - W/"fa1d0fe9e09b729570c7e2355deb1c59"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "993"
       X-Request-Id:
-      - b8ad3ede-d24e-43d1-9b3d-ba1e77cedf1a
+      - 48887038-a744-4d23-954b-02fa961fc9d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1228,38 +1583,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"}}}'
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "746"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:07 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"0218178fb6dd36bbca6ea5ffc8fd61e2"
-      Server:
-      - Caddy
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "992"
       X-Request-Id:
-      - 9d07be7e-ef55-435e-95c1-ea743cf22b82
+      - 5d962f50-c3f7-428a-9d12-d0872fef7452
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,46 +1628,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bnWioM07yubgjgMv","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2238"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:07 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
+      - W/"85222f7e95b1c0947e4ceb87e4668074"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "991"
       X-Request-Id:
-      - 7b8314e7-03db-4ce7-829a-de3f0666f015
+      - 42850deb-0a68-4947-8c92-bbd08a3401bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1314,41 +1670,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_WtF6oekQbqTIT9Z1","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "368"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:07 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"1495b45f867462197f42a21314a3afdb"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "990"
       X-Request-Id:
-      - 79a846f4-6bd7-490f-95b1-c836916c0835
+      - aa3d968c-fe5f-4f2c-98c1-4455c6e5e37e
     status: 200 OK
     code: 200
     duration: ""
@@ -1359,38 +1715,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_WtF6oekQbqTIT9Z1
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_WtF6oekQbqTIT9Z1","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2f:3e:d2:17:ff","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "510"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"8634b1c952a6002f27616e9f73a50120"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "989"
       X-Request-Id:
-      - de7bef66-bcdd-4e4e-9440-6a7c048aeb45
+      - bbfd9d52-ef74-4bfd-b7a1-ff9f5b6a75b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,36 +1759,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "348"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"b6ddc425b7c24826bc50e4c3500efcbb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "988"
       X-Request-Id:
-      - 45ddeac2-716a-4df2-b59a-c2398c688851
+      - 33e7eca9-d35d-49af-a33d-e5c7e9533f3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1441,36 +1801,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"be7583d0a1be03c0607f351540a9ec04"
-      Server:
-      - Caddy
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "987"
       X-Request-Id:
-      - 51a2140d-c60c-41ce-bfb9-3617eb2b716d
+      - 966ca7e3-0258-4ab0-b8e7-957d2eca7a4d
     status: 200 OK
     code: 200
     duration: ""
@@ -1481,38 +1843,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"}}}'
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "746"
+      - "761"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"0218178fb6dd36bbca6ea5ffc8fd61e2"
-      Server:
-      - Caddy
+      - W/"fa1d0fe9e09b729570c7e2355deb1c59"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - 8a8f6907-407e-476a-8710-4b0188acd3b0
+      - 8f626cb4-ba72-4bc0-b820-20e4ea448a84
     status: 200 OK
     code: 200
     duration: ""
@@ -1523,36 +1887,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "348"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"be7583d0a1be03c0607f351540a9ec04"
-      Server:
-      - Caddy
+      - W/"b6ddc425b7c24826bc50e4c3500efcbb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - f85e0b35-1f1c-40b7-942e-e01fe1113075
+      - d98a278b-f099-4032-a861-4668e59cc70c
     status: 200 OK
     code: 200
     duration: ""
@@ -1563,43 +1929,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2238"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "984"
       X-Request-Id:
-      - 9882b7d0-f90f-49fb-999e-1537eb402b67
+      - 8a75e939-8f8e-4087-8299-2629fd23c5f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1607,41 +1974,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_WtF6oekQbqTIT9Z1","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bnWioM07yubgjgMv","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "368"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:04 GMT
       Etag:
-      - W/"1495b45f867462197f42a21314a3afdb"
-      Server:
-      - Caddy
+      - W/"85222f7e95b1c0947e4ceb87e4668074"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "983"
       X-Request-Id:
-      - 02877bda-5156-4172-b8bc-207e88b6a474
+      - 1e479a24-f5b1-4fa3-93d0-eb720a985c0a
     status: 200 OK
     code: 200
     duration: ""
@@ -1649,41 +2016,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_WtF6oekQbqTIT9Z1
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_WtF6oekQbqTIT9Z1","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2f:3e:d2:17:ff","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "510"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:05 GMT
       Etag:
-      - W/"8634b1c952a6002f27616e9f73a50120"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "982"
       X-Request-Id:
-      - 8dcda962-b889-498b-9bd0-78460297f5a1
+      - 2b110546-38cf-499b-b09d-f75bb52a8fbf
     status: 200 OK
     code: 200
     duration: ""
@@ -1694,36 +2061,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:05 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "981"
       X-Request-Id:
-      - 3dc58ab2-77c0-441b-936b-546d1f539a39
+      - 20f352a0-d16f-4f61-9207-456136bd5f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,36 +2105,80 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:08 GMT
+      - Thu, 06 Feb 2025 16:45:05 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "980"
       X-Request-Id:
-      - 9cd305f4-e8c9-4405-a306-fcb01c722928
+      - 962c8d2f-738a-4660-8da2-e6dc44f22820
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
+    method: GET
+  response:
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "196"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:45:05 GMT
+      Etag:
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 7a6c0ff8-728c-4a38-ae89-c90064585e46
     status: 200 OK
     code: 200
     duration: ""
@@ -1777,80 +2192,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"185-44-255-49.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:09 GMT
+      - Thu, 06 Feb 2025 16:45:05 GMT
       Etag:
-      - W/"137b10129b421fd5b21a6014fed1266d"
-      Server:
-      - Caddy
+      - W/"1b5b0b25920ddf22e9c9bbd4f8fc320d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - 3ec7e886-07c5-454c-925d-d1390ad25889
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:09 GMT
-      Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "978"
       X-Request-Id:
-      - 149d4766-debc-40a6-95ea-20628082cde3
+      - 0f5bf918-4aed-4f57-83c1-27bc425c7c15
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,44 +2236,90 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"185-44-255-49.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:09 GMT
+      - Thu, 06 Feb 2025 16:45:05 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"a062507a6b604deebe6684d01a381b4e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "977"
       X-Request-Id:
-      - 33813d4e-ef23-411a-a8ba-6216a52bcf3c
+      - f28a4908-6a91-4f80-bb12-e68ef0e60269
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"185-44-255-49.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "576"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:45:05 GMT
+      Etag:
+      - W/"a062507a6b604deebe6684d01a381b4e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 17b36c59-3cef-473f-8f9c-542f1596aca9
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_hc3GUyhBe6toov2e</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-associations-rlc6dflfua0w-db</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_I5iBFR5yTEbZlqZV</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-associations-ni9kr1cjg9nl-db</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -1906,36 +2327,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_KYxZ3jbJ4MLitlz3","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_LhEIxCgDFlePSEBb","state":"pending"},"virtual_machine_build":{"id":"vmbuild_LhEIxCgDFlePSEBb","state":"pending"},"hostname":"tf-acc-test-associations-rlc6dflfua0w-db"}'
+    body: '{"task":{"id":"task_531DMEdbXzTGghyg","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_JAIiIQNPNNvqWO1f","state":"pending"},"virtual_machine_build":{"id":"vmbuild_JAIiIQNPNNvqWO1f","state":"pending"},"hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "279"
+      - "296"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:09 GMT
+      - Thu, 06 Feb 2025 16:45:05 GMT
       Etag:
-      - W/"8fe563a0bc1d07c9eb2ee6cc116b154f"
-      Server:
-      - Caddy
+      - W/"98bb0bbc8cd7b8fc7b7fff142221e7a7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "976"
+      - "975"
       X-Request-Id:
-      - a11c6fa2-81fa-46cd-a0db-55d0f598c393
+      - 974a5c11-fba5-467d-8081-09590cc1af62
     status: 201 Created
     code: 201
     duration: ""
@@ -1946,90 +2369,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LhEIxCgDFlePSEBb
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JAIiIQNPNNvqWO1f
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_LhEIxCgDFlePSEBb","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_JAIiIQNPNNvqWO1f","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-rlc6dflfua0w-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.49\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679599029}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860305},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1390"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:11 GMT
+      - Thu, 06 Feb 2025 16:45:07 GMT
       Etag:
-      - W/"21697680b17d6a1b64b861e6ba005646"
-      Server:
-      - Caddy
+      - W/"768a9ef4f67fdc5d50ce9c5bd32ee272"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "975"
-      X-Request-Id:
-      - 8104c61d-e719-40a8-b9a4-22d29af27de3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LhEIxCgDFlePSEBb
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_LhEIxCgDFlePSEBb","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-rlc6dflfua0w-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679599029}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1620"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:16 GMT
-      Etag:
-      - W/"f9e9f814fdfc60805d7122501f66fce5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "974"
       X-Request-Id:
-      - d976e456-ffdf-4804-a510-8c66c89d4e32
+      - a640e5df-ff1a-47f7-8a36-28404535e7a6
     status: 200 OK
     code: 200
     duration: ""
@@ -2040,43 +2416,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LhEIxCgDFlePSEBb
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JAIiIQNPNNvqWO1f
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_LhEIxCgDFlePSEBb","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_JAIiIQNPNNvqWO1f","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-rlc6dflfua0w-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.49\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679599029}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860305},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1620"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:26 GMT
+      - Thu, 06 Feb 2025 16:45:12 GMT
       Etag:
-      - W/"f9e9f814fdfc60805d7122501f66fce5"
-      Server:
-      - Caddy
+      - W/"768a9ef4f67fdc5d50ce9c5bd32ee272"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "973"
       X-Request-Id:
-      - 5473116c-8bc3-4028-9641-a5bd9eb30f53
+      - 4440c3b9-8b98-4be4-9770-203c39107487
     status: 200 OK
     code: 200
     duration: ""
@@ -2087,43 +2463,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LhEIxCgDFlePSEBb
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JAIiIQNPNNvqWO1f
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_LhEIxCgDFlePSEBb","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_JAIiIQNPNNvqWO1f","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-rlc6dflfua0w-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.49\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679599029}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860305},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1620"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:36 GMT
+      - Thu, 06 Feb 2025 16:45:23 GMT
       Etag:
-      - W/"f5a9245e5e5104be0a6df4fc0f403080"
-      Server:
-      - Caddy
+      - W/"cd61399b86ad447c91de6e99b7a0a4e3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "972"
       X-Request-Id:
-      - d79a238d-8e05-4cb2-9c1a-eff050f77ac3
+      - 4e540633-9273-4a0e-ba61-c85160201ae3
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,43 +2510,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JAIiIQNPNNvqWO1f
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679599035,"initial_root_password":"xEw0gMiiIKRg3kA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_JAIiIQNPNNvqWO1f","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.49\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860305},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2234"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:38 GMT
+      - Thu, 06 Feb 2025 16:45:33 GMT
       Etag:
-      - W/"052ca38f794a6d3b8570c394aa0924a2"
-      Server:
-      - Caddy
+      - W/"cd61399b86ad447c91de6e99b7a0a4e3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "971"
       X-Request-Id:
-      - 42140e45-e3b4-4daa-a484-55181d1541bf
+      - f89643ce-a0cb-4a1c-a205-5049e6e19fa8
     status: 200 OK
     code: 200
     duration: ""
@@ -2181,43 +2557,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JAIiIQNPNNvqWO1f
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679599035,"initial_root_password":"xEw0gMiiIKRg3kA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_JAIiIQNPNNvqWO1f","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.49\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-ni9kr1cjg9nl-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1738860305},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2234"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:38 GMT
+      - Thu, 06 Feb 2025 16:45:43 GMT
       Etag:
-      - W/"052ca38f794a6d3b8570c394aa0924a2"
-      Server:
-      - Caddy
+      - W/"69998a3931a83c312f9ba997247798f0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "970"
       X-Request-Id:
-      - 24666b44-6ef9-4358-8b43-e289cab6e8b5
+      - ebd79b5b-9d13-4035-b0f7-382e6e499ed4
     status: 200 OK
     code: 200
     duration: ""
@@ -2228,38 +2604,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_kiBcpjGZSzILXaps","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860313,"initial_root_password":"8lDSOSwDzGMwCnkd","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "367"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:38 GMT
+      - Thu, 06 Feb 2025 16:45:45 GMT
       Etag:
-      - W/"f18527e5cfdff01e4970bd17e10322dd"
-      Server:
-      - Caddy
+      - W/"f769f3746882e8b0dffdb4e5661e2e8b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "969"
       X-Request-Id:
-      - 53ce96af-85e2-45fe-bfa2-6ae293c0fb2a
+      - 5d35754f-b2c8-432c-9f94-6ae59150bf17
     status: 200 OK
     code: 200
     duration: ""
@@ -2270,81 +2652,86 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_kiBcpjGZSzILXaps
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_kiBcpjGZSzILXaps","virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c4:74:3b:d2:63","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860313,"initial_root_password":"8lDSOSwDzGMwCnkd","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "508"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:38 GMT
+      - Thu, 06 Feb 2025 16:45:45 GMT
       Etag:
-      - W/"907ad73c49392a67fcf45d2f0e914c94"
-      Server:
-      - Caddy
+      - W/"f769f3746882e8b0dffdb4e5661e2e8b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "968"
       X-Request-Id:
-      - deeb118f-8fd6-4a5b-90d6-4b76978f5bd6
+      - 07b3e2b0-c896-4a88-a818-10c7432079e8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: |
-      {"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3"},"properties":{"associations":["vm_8dC3fxOuJxAM0yao"]}}
+    body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_
-    method: PATCH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_8dC3fxOuJxAM0yao"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_8r3277IMPhP7fcaa","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "390"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:38 GMT
+      - Thu, 06 Feb 2025 16:45:45 GMT
       Etag:
-      - W/"7f7b39fad490e481b76f0041913372bf"
-      Server:
-      - Caddy
+      - W/"e1b18550d874d59fb1fe1f5147643730"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "967"
       X-Request-Id:
-      - 8925caff-7802-4fab-b74a-fa4c4b661dff
+      - 69391d23-8661-4f80-b026-d64a2bf7fac4
     status: 200 OK
     code: 200
     duration: ""
@@ -2352,39 +2739,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_8r3277IMPhP7fcaa
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_8dC3fxOuJxAM0yao"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_8r3277IMPhP7fcaa","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:f9:f5:65:95:82","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "337"
+      - "530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:44 GMT
+      - Thu, 06 Feb 2025 16:45:45 GMT
       Etag:
-      - W/"cb069236a012a351135cdf37de7a7aa5"
-      Server:
-      - Caddy
+      - W/"4fbd9239e57f286c6dc7591a2791b61b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "966"
       X-Request-Id:
-      - cdfa83bc-6ca1-461c-a4d9-9f898fa53ab4
+      - 9d7240ec-1ca7-427c-8e6c-a94ab1a67d1e
     status: 200 OK
     code: 200
     duration: ""
@@ -2395,76 +2784,85 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_8r3277IMPhP7fcaa
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_8dC3fxOuJxAM0yao"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_8r3277IMPhP7fcaa","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:f9:f5:65:95:82","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "530"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:45:45 GMT
       Etag:
-      - W/"7f7b39fad490e481b76f0041913372bf"
-      Server:
-      - Caddy
+      - W/"4fbd9239e57f286c6dc7591a2791b61b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "965"
       X-Request-Id:
-      - 3fca0f50-5edf-4b54-9a69-9d5199a480fd
+      - 650a60b1-6cb8-4571-8ce8-aaef40f929d8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: |
+      {"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq"},"properties":{"associations":["vm_otz3phVWBheJ2odc"]}}
     form: {}
     headers:
       Accept:
       - application/json
+      Content-Type:
+      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_
+    method: PATCH
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_8dC3fxOuJxAM0yao"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_otz3phVWBheJ2odc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "348"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:45:45 GMT
       Etag:
-      - W/"7f7b39fad490e481b76f0041913372bf"
-      Server:
-      - Caddy
+      - W/"300a35765e53b6e892845f2f9141c408"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "964"
       X-Request-Id:
-      - 2fc843bb-d9d2-4256-a278-f00ed21d6e7d
+      - 0d1e4044-719e-41af-ac2a-60e4877fcc19
     status: 200 OK
     code: 200
     duration: ""
@@ -2475,36 +2873,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_otz3phVWBheJ2odc"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:45:50 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"ed0810d754c5437f25d275c510d599c2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "963"
       X-Request-Id:
-      - ab956979-3c09-4b98-a38b-7391bce10ea0
+      - 0b85515d-c784-439e-b5ec-b50fd60dd685
     status: 200 OK
     code: 200
     duration: ""
@@ -2515,36 +2915,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_8dC3fxOuJxAM0yao"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_otz3phVWBheJ2odc"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:45:55 GMT
       Etag:
-      - W/"7f7b39fad490e481b76f0041913372bf"
-      Server:
-      - Caddy
+      - W/"ed0810d754c5437f25d275c510d599c2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "962"
       X-Request-Id:
-      - a2346f85-2d62-4672-a000-f587b7826a43
+      - 7d8e514f-38fa-4034-955a-ce8bce4c3c23
     status: 200 OK
     code: 200
     duration: ""
@@ -2555,80 +2957,1738 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_otz3phVWBheJ2odc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "744"
+      - "348"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:05 GMT
       Etag:
-      - W/"a20760f8876f664865c99ed05a80ff0a"
-      Server:
-      - Caddy
+      - W/"300a35765e53b6e892845f2f9141c408"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - e5f0b697-e7dc-48f5-a872-86a0512ec642
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_otz3phVWBheJ2odc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"300a35765e53b6e892845f2f9141c408"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - a1211018-f999-4a6c-9aa4-67760ac61111
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 0b89e3ee-3225-45b1-b401-3673a3a0cde9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_otz3phVWBheJ2odc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"300a35765e53b6e892845f2f9141c408"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 8d7b51ce-b19a-4c1c-a170-90c66892ed2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "757"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"18a98a99417066c3c212d3721034fbc9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 3b264365-745c-4bac-a746-3b0099c187bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "761"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"fa1d0fe9e09b729570c7e2355deb1c59"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 0a727806-c435-409e-8cda-b488ea464010
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 07ecc00c-6af0-4afa-ac89-14d9afdca215
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860313,"initial_root_password":"8lDSOSwDzGMwCnkd","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"f769f3746882e8b0dffdb4e5661e2e8b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - a2ac2e5a-bc4f-48d0-a20d-1064710b7d80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bnWioM07yubgjgMv","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "392"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"85222f7e95b1c0947e4ceb87e4668074"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 88610383-c34e-42ff-8874-05269736e5d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_8r3277IMPhP7fcaa","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "390"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"e1b18550d874d59fb1fe1f5147643730"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 290734b5-503e-4e7a-9753-9698524b2e0e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_8r3277IMPhP7fcaa
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_8r3277IMPhP7fcaa","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:f9:f5:65:95:82","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "530"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"4fbd9239e57f286c6dc7591a2791b61b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - e1d1c649-7e7b-4519-b44c-d91632f4c94a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "533"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:05 GMT
+      Etag:
+      - W/"4985923a0418a48eea8ee5258d816d2e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 6d3976d6-5ef2-4072-ac7a-3be1e7a7a598
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_8r3277IMPhP7fcaa
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_8r3277IMPhP7fcaa","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:f9:f5:65:95:82","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "530"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"4fbd9239e57f286c6dc7591a2791b61b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 0607caea-c5ee-40cd-9acb-fed80da4f3b9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "533"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"4985923a0418a48eea8ee5258d816d2e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - f08c3267-6620-49cd-b4cd-38a84a04a410
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_otz3phVWBheJ2odc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"300a35765e53b6e892845f2f9141c408"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 973e334a-b661-44ab-a1ad-2e784064838f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 9d626bf5-a1df-492c-9dee-8c088a12c4f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "761"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"fa1d0fe9e09b729570c7e2355deb1c59"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 9021b917-a24c-45c9-8aa6-0b0486c93aa6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "757"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"18a98a99417066c3c212d3721034fbc9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 6d3e50a3-f0f0-4263-89fd-a78fab0fcd0a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_otz3phVWBheJ2odc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"300a35765e53b6e892845f2f9141c408"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 823ebefc-96e6-4f2a-a527-088dc3670d86
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860313,"initial_root_password":"8lDSOSwDzGMwCnkd","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"f769f3746882e8b0dffdb4e5661e2e8b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - 147f5add-2ab7-4c5c-b26f-ae815d6c06ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 43c7a40f-c8c9-4599-9d96-52170f4d7740
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_8r3277IMPhP7fcaa","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "390"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"e1b18550d874d59fb1fe1f5147643730"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 48ca8dd4-c9de-461e-8241-78f4485e7999
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bnWioM07yubgjgMv","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "392"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"85222f7e95b1c0947e4ceb87e4668074"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - 33c126b7-fc12-4702-9b22-ea12cfa6c4aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_8r3277IMPhP7fcaa
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_8r3277IMPhP7fcaa","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:f9:f5:65:95:82","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "530"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"4fbd9239e57f286c6dc7591a2791b61b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 5a24ee71-9d48-4588-b5d1-c5ef54a616da
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "533"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"4985923a0418a48eea8ee5258d816d2e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 969963b0-c63c-4bb3-91d0-3333b18df630
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_8r3277IMPhP7fcaa
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_8r3277IMPhP7fcaa","virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:f9:f5:65:95:82","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "530"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"4fbd9239e57f286c6dc7591a2791b61b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 8ca8d8c3-230c-4480-8efd-028c397f01c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "533"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"4985923a0418a48eea8ee5258d816d2e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 38dc9ea9-6ecb-4c3f-a64f-85769562a47d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - ea604afb-465e-4f1b-bd96-98ef0b0ab146
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860313,"initial_root_password":"8lDSOSwDzGMwCnkd","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"f769f3746882e8b0dffdb4e5661e2e8b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 2589ce74-640b-4edd-aaf8-2bfb197dfde9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: POST
+  response:
+    body: '{"task":{"id":"task_qyOJM3VhHerZ4YCJ","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:06 GMT
+      Etag:
+      - W/"3eb9ca84c6ff2d2d67615a8c2c22a2d2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - b2b2e9e0-7f2d-4453-8753-a6b860309a54
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_qyOJM3VhHerZ4YCJ
+    method: GET
+  response:
+    body: '{"task":{"id":"task_qyOJM3VhHerZ4YCJ","name":"Stop virtual machine","status":"running","created_at":1738860366,"started_at":1738860367,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:07 GMT
+      Etag:
+      - W/"39c727bf5286c3cc317e479a34da7735"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 6ca5e871-e7d9-474b-93cf-0d735ff715f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_qyOJM3VhHerZ4YCJ
+    method: GET
+  response:
+    body: '{"task":{"id":"task_qyOJM3VhHerZ4YCJ","name":"Stop virtual machine","status":"completed","created_at":1738860366,"started_at":1738860367,"finished_at":1738860369,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:12 GMT
+      Etag:
+      - W/"8111b3b2ed438c6719e3cf68cf24671e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - d64b4c2f-09df-4de3-8e91-2289ef02ecd5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860313,"initial_root_password":"8lDSOSwDzGMwCnkd","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:13 GMT
+      Etag:
+      - W/"b46562d0f458c871e820d506fdf8c048"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 0b52f046-9e52-4076-95b4-392789b1e05d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_otz3phVWBheJ2odc
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_qSAkpvrzVNpVMBbI","keep_until":1739033173,"object_id":"vm_otz3phVWBheJ2odc","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_otz3phVWBheJ2odc","name":"tf-acc-test-associations-ni9kr1cjg9nl-db","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-db","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860313,"initial_root_password":"8lDSOSwDzGMwCnkd","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_otz3phVWBheJ2odc","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:13 GMT
+      Etag:
+      - W/"e4cf81f6d3c7e5a7d0ffc2a7df1df35a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 6317a35e-db8e-4f8a-8649-a5787d26825a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:14 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - 39f3d75c-e5cf-4eec-804a-5bf81cbb8cf2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_otz3phVWBheJ2odc
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_ocosG51kyuRbNN0B","name":"Purge items from trash","status":"pending","created_at":1738860374,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:14 GMT
+      Etag:
+      - W/"94176b2e32baf64bec2c98a7ad6345f2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - ae609d0c-2654-47af-8532-b5738cb9f672
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_otz3phVWBheJ2odc
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_qSAkpvrzVNpVMBbI","keep_until":1739033173,"object_id":"vm_otz3phVWBheJ2odc","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:15 GMT
+      Etag:
+      - W/"287cac0f463869c6acbb486bcf35d4a4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - b615187b-d338-4482-aa8c-58817a17e5e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_otz3phVWBheJ2odc
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:20 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - e66569b0-6481-4ef7-841a-e6e109fe0b23
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:20 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "961"
       X-Request-Id:
-      - c7f0b51c-bac2-48b6-8c51-f8e520ebef8d
+      - 5144d40f-cc23-40e0-9450-452c3ff02d3c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: |
+      {"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq"},"properties":{"associations":[]}}
     form: {}
     headers:
       Accept:
       - application/json
+      Content-Type:
+      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
-    method: GET
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_
+    method: PATCH
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "746"
+      - "333"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:20 GMT
       Etag:
-      - W/"0218178fb6dd36bbca6ea5ffc8fd61e2"
-      Server:
-      - Caddy
+      - W/"72477a7b21f9748f775279fdf8aaaace"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "960"
       X-Request-Id:
-      - 4715bb64-2dff-4d7c-9f73-de434c989947
+      - 321b6f59-167a-4f0d-bdd7-72e78a578f4f
     status: 200 OK
     code: 200
     duration: ""
@@ -2639,43 +4699,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2238"
+      - "333"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:25 GMT
       Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
+      - W/"72477a7b21f9748f775279fdf8aaaace"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "959"
       X-Request-Id:
-      - 0ddc35cb-98e8-4702-8711-c221a8c2b043
+      - 8104cde0-9ac5-4d1c-8c35-e4395527e396
     status: 200 OK
     code: 200
     duration: ""
@@ -2686,43 +4741,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679599035,"initial_root_password":"xEw0gMiiIKRg3kA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"}]}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2234"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:30 GMT
       Etag:
-      - W/"052ca38f794a6d3b8570c394aa0924a2"
-      Server:
-      - Caddy
+      - W/"0759042e3c06326e061e5c71faac95e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "958"
       X-Request-Id:
-      - 162d024f-e202-4992-bf3f-22bb8051ba2b
+      - c511587e-74e4-43c7-a0ee-508b138989ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2733,38 +4783,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_WtF6oekQbqTIT9Z1","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "368"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:30 GMT
       Etag:
-      - W/"1495b45f867462197f42a21314a3afdb"
-      Server:
-      - Caddy
+      - W/"0759042e3c06326e061e5c71faac95e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "957"
       X-Request-Id:
-      - 1900e350-8d97-4cfa-9c6d-6a7c1f5a99f9
+      - 1f400c36-bd34-4317-84d3-455432e27b75
     status: 200 OK
     code: 200
     duration: ""
@@ -2775,38 +4825,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_kiBcpjGZSzILXaps","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "367"
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:30 GMT
       Etag:
-      - W/"f18527e5cfdff01e4970bd17e10322dd"
-      Server:
-      - Caddy
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "956"
       X-Request-Id:
-      - fbb73b2f-a693-4dc1-8169-9df7ecceb34a
+      - fb13b984-276b-491e-9e34-dc510809eecc
     status: 200 OK
     code: 200
     duration: ""
@@ -2817,38 +4867,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_WtF6oekQbqTIT9Z1
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_WtF6oekQbqTIT9Z1","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2f:3e:d2:17:ff","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "510"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"8634b1c952a6002f27616e9f73a50120"
-      Server:
-      - Caddy
+      - W/"0759042e3c06326e061e5c71faac95e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "955"
       X-Request-Id:
-      - 0b346319-01e5-4e77-9eee-9a4e42e7fefd
+      - 152586a9-9f44-4935-83a8-89973133ba4d
     status: 200 OK
     code: 200
     duration: ""
@@ -2859,38 +4909,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_kiBcpjGZSzILXaps
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_kiBcpjGZSzILXaps","virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c4:74:3b:d2:63","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "508"
+      - "761"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"907ad73c49392a67fcf45d2f0e914c94"
-      Server:
-      - Caddy
+      - W/"fa1d0fe9e09b729570c7e2355deb1c59"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "954"
       X-Request-Id:
-      - 4b0bd67d-7d44-4f29-8fb4-40f96354d53b
+      - 234b72d4-46f1-452d-be9c-fbb7d91f558a
     status: 200 OK
     code: 200
     duration: ""
@@ -2901,36 +4953,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:49 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"0759042e3c06326e061e5c71faac95e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "953"
       X-Request-Id:
-      - e02bb2ed-cb2b-4bc6-8a70-5ced2b4bd0db
+      - 1b8075cc-13ea-4845-ba09-9907b452e952
     status: 200 OK
     code: 200
     duration: ""
@@ -2941,36 +4995,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_8dC3fxOuJxAM0yao"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "331"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"7f7b39fad490e481b76f0041913372bf"
-      Server:
-      - Caddy
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "952"
       X-Request-Id:
-      - 784c0ce5-f640-4f48-8204-bc633de21984
+      - 31d9080d-05e5-4105-a4cf-264426ccb9ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2978,39 +5040,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_8dC3fxOuJxAM0yao"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bnWioM07yubgjgMv","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "331"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"7f7b39fad490e481b76f0041913372bf"
-      Server:
-      - Caddy
+      - W/"85222f7e95b1c0947e4ceb87e4668074"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "951"
       X-Request-Id:
-      - 5cb8ec65-946d-46bb-9491-48dea0984954
+      - b9ed674f-ebf3-415b-8ce3-348c5a334ba7
     status: 200 OK
     code: 200
     duration: ""
@@ -3018,130 +5082,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "746"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"0218178fb6dd36bbca6ea5ffc8fd61e2"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "948"
-      X-Request-Id:
-      - 99c6f237-7bea-412b-a700-d6ab3396c40d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "744"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
-      Etag:
-      - W/"a20760f8876f664865c99ed05a80ff0a"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "949"
-      X-Request-Id:
-      - 20f8db47-11bc-49f8-9c13-0041e22a2c9b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679599035,"initial_root_password":"xEw0gMiiIKRg3kA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2234"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
-      Etag:
-      - W/"052ca38f794a6d3b8570c394aa0924a2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "950"
       X-Request-Id:
-      - a4afdd23-2236-4dd3-848e-a1a38471450d
+      - 3ce0eb86-e46f-4586-aff6-7b47609508ac
     status: 200 OK
     code: 200
     duration: ""
@@ -3152,38 +5127,126 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_kiBcpjGZSzILXaps","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "367"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"f18527e5cfdff01e4970bd17e10322dd"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "949"
+      X-Request-Id:
+      - b6c374d6-2ebe-4ec7-976f-086a5ed785d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:31 GMT
+      Etag:
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - 1426d1bb-02f4-4eff-8367-355a3995a89e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "761"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:31 GMT
+      Etag:
+      - W/"fa1d0fe9e09b729570c7e2355deb1c59"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "947"
       X-Request-Id:
-      - 797501f6-08f0-472b-a6c9-01200586e2b3
+      - 97ed47e6-c561-432c-baa1-2929fbcbb14f
     status: 200 OK
     code: 200
     duration: ""
@@ -3194,38 +5257,80 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_kiBcpjGZSzILXaps
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_kiBcpjGZSzILXaps","virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:c4:74:3b:d2:63","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "508"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"907ad73c49392a67fcf45d2f0e914c94"
-      Server:
-      - Caddy
+      - W/"0759042e3c06326e061e5c71faac95e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - c70094d3-b5f3-4578-bddf-5bc71d845ab7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Jz1rzwtJ7kaeWEEc"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:31 GMT
+      Etag:
+      - W/"6c48cd4ba553c137105bd90a9e74b5de"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "945"
       X-Request-Id:
-      - 9572c889-24bb-4db7-8c1e-fcef0250f19c
+      - a5854369-2014-49d5-828c-401c9827fc44
     status: 200 OK
     code: 200
     duration: ""
@@ -3236,43 +5341,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2238"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "946"
+      - "947"
       X-Request-Id:
-      - 945920de-9008-4fc2-b14d-0e7223ee9a2b
+      - 68fd9b19-d86c-46af-aa1e-d5ee33199351
     status: 200 OK
     code: 200
     duration: ""
@@ -3280,83 +5386,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_WtF6oekQbqTIT9Z1","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_bnWioM07yubgjgMv","name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "368"
+      - "392"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"1495b45f867462197f42a21314a3afdb"
-      Server:
-      - Caddy
+      - W/"85222f7e95b1c0947e4ceb87e4668074"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "944"
-      X-Request-Id:
-      - d8fc9ef9-41c5-4472-856a-26c80a379d8b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_WtF6oekQbqTIT9Z1
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_WtF6oekQbqTIT9Z1","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2f:3e:d2:17:ff","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "510"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
-      Etag:
-      - W/"8634b1c952a6002f27616e9f73a50120"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "943"
       X-Request-Id:
-      - 882c6b1e-5109-4a15-abdc-6a9ab2e5ed1d
+      - 8d827df9-04fa-4956-b3b0-092273e0c52d
     status: 200 OK
     code: 200
     duration: ""
@@ -3364,39 +5428,41 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "325"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "942"
       X-Request-Id:
-      - 298528b5-3d97-441b-9b59-ecdff0b44ece
+      - 2061d7db-24da-482b-bcda-be4d6ddf573e
     status: 200 OK
     code: 200
     duration: ""
@@ -3407,43 +5473,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_bnWioM07yubgjgMv
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679599035,"initial_root_password":"xEw0gMiiIKRg3kA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_bnWioM07yubgjgMv","virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web"},"name":"Public
+      Network on tf-acc-test-associations-ni9kr1cjg9nl-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:0e:bd:54:7b:e5","state":"attached","ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2234"
+      - "533"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"052ca38f794a6d3b8570c394aa0924a2"
-      Server:
-      - Caddy
+      - W/"4985923a0418a48eea8ee5258d816d2e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "941"
       X-Request-Id:
-      - 4870a835-3df5-4e90-a58a-8d3ec3306a76
+      - 6cf45719-f9f4-4c42-bc72-d11ce340a349
     status: 200 OK
     code: 200
     duration: ""
@@ -3454,36 +5517,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
-    method: POST
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
+    method: GET
   response:
-    body: '{"task":{"id":"task_3ZAInVwEqiHuREYv","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "88"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:17:50 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"98f99270bb82d2ddb304b9467af62e14"
-      Server:
-      - Caddy
+      - W/"2b55feeb545ceed2e488b8773d3bf89f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "940"
       X-Request-Id:
-      - 892cf654-377c-46f0-a539-b967a6647450
+      - 8e1fe738-4e99-4cc2-bd08-af38bfe81881
     status: 200 OK
     code: 200
     duration: ""
@@ -3494,1145 +5565,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_3ZAInVwEqiHuREYv
-    method: GET
-  response:
-    body: '{"task":{"id":"task_3ZAInVwEqiHuREYv","name":"Stop virtual machine","status":"running","created_at":1679599070,"started_at":1679599071,"finished_at":null,"progress":5}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "168"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:51 GMT
-      Etag:
-      - W/"ee62e1c31d8b854df6b76dd597e67351"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "939"
-      X-Request-Id:
-      - cc5f10b2-5fcd-48a7-ba9d-232f3b0c3b3b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_3ZAInVwEqiHuREYv
-    method: GET
-  response:
-    body: '{"task":{"id":"task_3ZAInVwEqiHuREYv","name":"Stop virtual machine","status":"completed","created_at":1679599070,"started_at":1679599071,"finished_at":1679599074,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "178"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:57 GMT
-      Etag:
-      - W/"cde0225d0d5fa26939b2ce8b66ff3ead"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "938"
-      X-Request-Id:
-      - 07f1ea51-ffc8-411d-b47d-86261ad2ca13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679599035,"initial_root_password":"xEw0gMiiIKRg3kA1","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2234"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:58 GMT
-      Etag:
-      - W/"024bb1a30e2ed400889d2a51f8323ef6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "937"
-      X-Request-Id:
-      - 9f18b268-b7cf-4011-90b6-064bb9052adf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_8dC3fxOuJxAM0yao
-    method: DELETE
-  response:
-    body: '{"trash_object":{"id":"trsh_d4mIKqrd0vqIoQQG","keep_until":1679771878,"object_id":"vm_8dC3fxOuJxAM0yao","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_8dC3fxOuJxAM0yao","name":"tf-acc-test-associations-rlc6dflfua0w-db","hostname":"tf-acc-test-associations-rlc6dflfua0w-db","fqdn":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1679599035,"initial_root_password":"xEw0gMiiIKRg3kA1","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_8dC3fxOuJxAM0yao","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2369"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:58 GMT
-      Etag:
-      - W/"abc17947897d7b6e16450ac1ee941d05"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "936"
-      X-Request-Id:
-      - 54a7b826-3ddf-4f1d-b2ec-d65200d619dc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: POST
   response:
-    body: '{}'
+    body: '{"task":{"id":"task_9DXvQzf2JHS4YfVE","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:58 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "935"
-      X-Request-Id:
-      - e25b92e8-fdad-4265-8eaa-4546b061a9c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_8dC3fxOuJxAM0yao
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_ZmuJF2hMzdnGaVjG","name":"Purge items from trash","status":"pending","created_at":1679599078,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:58 GMT
-      Etag:
-      - W/"cac3a78c33d4ba0605aa116d6fb1dcf2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "934"
-      X-Request-Id:
-      - 0008aeeb-de38-438d-b104-286c3874ef93
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_8dC3fxOuJxAM0yao
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_d4mIKqrd0vqIoQQG","keep_until":1679771878,"object_id":"vm_8dC3fxOuJxAM0yao","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:17:59 GMT
-      Etag:
-      - W/"bbbbedfccf19c9425683cb7f4b7f5d7d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "933"
-      X-Request-Id:
-      - 78c47b16-383d-4633-999f-7377d6a0785d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_8dC3fxOuJxAM0yao
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:05 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - 0a3d3531-5660-4168-ad31-54f3fd5bbfaf
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:05 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - 19587f62-dfc3-4d65-8ef1-7d83eae8a46b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3"},"properties":{"associations":[]}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_
-    method: PATCH
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "310"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:05 GMT
-      Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - 94486d8e-46f6-470b-a295-c577309fdda0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "310"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:10 GMT
-      Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - b5261458-4c89-4808-b71f-d42461d40dfd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "310"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:10 GMT
-      Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - 16f70e58-275b-4e9b-aa00-f3bf0d9ef086
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "325"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:11 GMT
-      Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - be821025-37ad-4a55-bdb1-0bb7bb1021bd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "310"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:11 GMT
-      Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - da1d7a25-9f39-4d80-857e-fbf5131d9d9b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "310"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:11 GMT
-      Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "991"
-      X-Request-Id:
-      - d66dc666-089d-48dc-8a2a-99e86433b8d4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "746"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:11 GMT
-      Etag:
-      - W/"0218178fb6dd36bbca6ea5ffc8fd61e2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - 3a348189-1a9a-4f7c-aa32-766fdc894f5f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2238"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:11 GMT
-      Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - 8abc283a-972c-46ac-9605-f0a2e7ddeea5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_WtF6oekQbqTIT9Z1","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "368"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:11 GMT
-      Etag:
-      - W/"1495b45f867462197f42a21314a3afdb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - aa3e7342-c6f5-4e1e-9d32-e4128ce46e52
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_WtF6oekQbqTIT9Z1
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_WtF6oekQbqTIT9Z1","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2f:3e:d2:17:ff","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "510"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:11 GMT
-      Etag:
-      - W/"8634b1c952a6002f27616e9f73a50120"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - 439e5132-3cdc-4552-86ea-2b166cb905c8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "325"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:11 GMT
-      Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - d0351e7f-f764-46fd-84aa-e350e20a9852
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_VfFea7edbX4wtydr"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "325"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:12 GMT
-      Etag:
-      - W/"996ff0fbbe51e737bf8b27909ead633e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - 46442fbd-5e13-44b0-8c5e-f370b25ca07b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "310"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:12 GMT
-      Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "985"
-      X-Request-Id:
-      - f91b7ce0-4e6c-4d31-8d6a-afe54f010e98
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "746"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:12 GMT
-      Etag:
-      - W/"0218178fb6dd36bbca6ea5ffc8fd61e2"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 48bd886a-170a-46b8-accc-ffec6a630b5b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2238"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:12 GMT
-      Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - ca4fe9bb-7d48-4bd9-a368-7c07b948f05e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_WtF6oekQbqTIT9Z1","name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "368"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:12 GMT
-      Etag:
-      - W/"1495b45f867462197f42a21314a3afdb"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "982"
-      X-Request-Id:
-      - 56f24890-43f2-430f-9d84-775e2003fcae
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_WtF6oekQbqTIT9Z1
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_WtF6oekQbqTIT9Z1","virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web"},"name":"Public
-      Network on tf-acc-test-associations-rlc6dflfua0w-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:2f:3e:d2:17:ff","state":"attached","ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "510"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:12 GMT
-      Etag:
-      - W/"8634b1c952a6002f27616e9f73a50120"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "981"
-      X-Request-Id:
-      - cc88c086-7c0a-44e6-b83d-b52e21fdad38
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2238"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:12 GMT
-      Etag:
-      - W/"15dc32b4f6a8b66f4009118c212e5ec3"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - c19cba89-093e-4016-908c-b429c8573e3f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
-    method: POST
-  response:
-    body: '{"task":{"id":"task_shdXqV2jNaI2r1fM","name":"Stop virtual machine","status":"pending"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -4642,19 +5584,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:12 GMT
+      - Thu, 06 Feb 2025 16:46:31 GMT
       Etag:
-      - W/"9ae224d25c7c10f33f1b461bc449b9a3"
-      Server:
-      - Caddy
+      - W/"122ba4426ac87fd719f73b643abd0db7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "979"
+      - "939"
       X-Request-Id:
-      - e512a92e-bb1a-4e0a-a334-0f3f77593cc8
+      - 3c683759-3c20-477b-94ed-d5a9694fff5a
     status: 200 OK
     code: 200
     duration: ""
@@ -4665,14 +5607,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_shdXqV2jNaI2r1fM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_9DXvQzf2JHS4YfVE
     method: GET
   response:
-    body: '{"task":{"id":"task_shdXqV2jNaI2r1fM","name":"Stop virtual machine","status":"running","created_at":1679599092,"started_at":1679599093,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_9DXvQzf2JHS4YfVE","name":"Stop virtual machine","status":"running","created_at":1738860391,"started_at":1738860392,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -4682,19 +5626,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:13 GMT
+      - Thu, 06 Feb 2025 16:46:32 GMT
       Etag:
-      - W/"895b79b326b50d0b206d0e1c30710ebf"
-      Server:
-      - Caddy
+      - W/"ae2cf6345a16c3fd34271f0cf35f66d1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "978"
+      - "938"
       X-Request-Id:
-      - 4329b762-8bde-4b7c-9dfb-50a9fa226720
+      - aea29a19-eecd-4bda-af69-55d9bb484cd7
     status: 200 OK
     code: 200
     duration: ""
@@ -4705,14 +5649,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_shdXqV2jNaI2r1fM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_9DXvQzf2JHS4YfVE
     method: GET
   response:
-    body: '{"task":{"id":"task_shdXqV2jNaI2r1fM","name":"Stop virtual machine","status":"completed","created_at":1679599092,"started_at":1679599093,"finished_at":1679599095,"progress":100}}'
+    body: '{"task":{"id":"task_9DXvQzf2JHS4YfVE","name":"Stop virtual machine","status":"completed","created_at":1738860391,"started_at":1738860392,"finished_at":1738860393,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -4722,19 +5668,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:19 GMT
+      - Thu, 06 Feb 2025 16:46:37 GMT
       Etag:
-      - W/"349f7b1456788e63d7548d8c114191e4"
-      Server:
-      - Caddy
+      - W/"078e853ed81f73121c6f29b7c2cf6f75"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "977"
+      - "937"
       X-Request-Id:
-      - f8cb9434-3f76-42e2-82c9-57f8210945f4
+      - 697be367-73fe-41d2-97f5-4702ab544bbe
     status: 200 OK
     code: 200
     duration: ""
@@ -4745,43 +5691,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2238"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:20 GMT
+      - Thu, 06 Feb 2025 16:46:38 GMT
       Etag:
-      - W/"96b55bdec3ed4b098695660788d70709"
-      Server:
-      - Caddy
+      - W/"476a2e27f27d07552b011ccc6a595f2f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "976"
+      - "936"
       X-Request-Id:
-      - 0ed6a8b3-06f0-4bb3-8bb0-e9d5804ffdce
+      - 63036838-7531-4b74-a27f-83bb1eb1350a
     status: 200 OK
     code: 200
     duration: ""
@@ -4792,43 +5739,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Jz1rzwtJ7kaeWEEc
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_89rl3MgxxwFGKabw","keep_until":1679771900,"object_id":"vm_VfFea7edbX4wtydr","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_VfFea7edbX4wtydr","name":"tf-acc-test-associations-rlc6dflfua0w-web","hostname":"tf-acc-test-associations-rlc6dflfua0w-web","fqdn":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1679598997,"initial_root_password":"9WlyzKccVTW0UCvC","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_fFa4IDOBndciSsl4","keep_until":1739033198,"object_id":"vm_Jz1rzwtJ7kaeWEEc","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_Jz1rzwtJ7kaeWEEc","name":"tf-acc-test-associations-ni9kr1cjg9nl-web","hostname":"tf-acc-test-associations-ni9kr1cjg9nl-web","fqdn":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860255,"initial_root_password":"wih3GmbdNNxaXHzy","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2bjWpH3KQBlrSjJ0","address":"185.199.221.55","reverse_dns":"tf-acc-test-associations-rlc6dflfua0w-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.55/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VfFea7edbX4wtydr","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_la7rTtAU6BKxHpmG","address":"185.44.254.140","reverse_dns":"tf-acc-test-associations-ni9kr1cjg9nl-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Jz1rzwtJ7kaeWEEc","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2373"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:20 GMT
+      - Thu, 06 Feb 2025 16:46:38 GMT
       Etag:
-      - W/"d3006d7403046c3452008ad1826b4046"
-      Server:
-      - Caddy
+      - W/"c49d3c8266f0db30739c451d2420bbed"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "935"
       X-Request-Id:
-      - 341a7d29-0b02-4f78-aa14-abbe6c0259c5
+      - 89345a82-5c06-4298-88aa-cd64286a706c
     status: 200 OK
     code: 200
     duration: ""
@@ -4839,14 +5787,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -4856,19 +5806,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:20 GMT
+      - Thu, 06 Feb 2025 16:46:39 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "974"
+      - "934"
       X-Request-Id:
-      - 565b5607-4c47-4145-8ed7-218f6ed2aa04
+      - b335b180-370f-44ba-9d7a-ca52bdc647df
     status: 200 OK
     code: 200
     duration: ""
@@ -4879,14 +5829,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Jz1rzwtJ7kaeWEEc
     method: DELETE
   response:
-    body: '{"task":{"id":"task_6tm7rSVs6jQtfd0L","name":"Purge items from trash","status":"pending","created_at":1679599100,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_YyBFXccMUmWLcctg","name":"Purge items from trash","status":"pending","created_at":1738860399,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -4896,19 +5848,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:20 GMT
+      - Thu, 06 Feb 2025 16:46:39 GMT
       Etag:
-      - W/"295f845fca5549cb6aa09aaa8e0f0fad"
-      Server:
-      - Caddy
+      - W/"4b81949d4bf30c7226c27fdd52f4a433"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "973"
+      - "933"
       X-Request-Id:
-      - e96bb2fd-c780-4c0d-ba97-c95ba220b759
+      - f4f667e8-de8a-4ef9-aba5-117af2ba74de
     status: 200 OK
     code: 200
     duration: ""
@@ -4919,14 +5871,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_89rl3MgxxwFGKabw","keep_until":1679771900,"object_id":"vm_VfFea7edbX4wtydr","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_fFa4IDOBndciSsl4","keep_until":1739033198,"object_id":"vm_Jz1rzwtJ7kaeWEEc","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -4936,19 +5890,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:21 GMT
+      - Thu, 06 Feb 2025 16:46:40 GMT
       Etag:
-      - W/"8cc9b1229ed982af4a5c0ab6a78a9345"
-      Server:
-      - Caddy
+      - W/"68479f186c18bcb003f32235ac34fc29"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "972"
+      - "932"
       X-Request-Id:
-      - eaeadb02-c741-4a04-8ac5-d9080a85d3bb
+      - a7bbc049-236d-4cea-862b-e2a8d3599718
     status: 200 OK
     code: 200
     duration: ""
@@ -4959,15 +5913,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_VfFea7edbX4wtydr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Jz1rzwtJ7kaeWEEc
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -4977,19 +5933,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:27 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:46:45 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "971"
+      - "931"
       X-Request-Id:
-      - 238029cf-ee8b-4b30-afa6-2821248bf7be
+      - 7f41e90f-0387-4894-86d0-040aff75c2ba
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5000,14 +5956,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2bjWpH3KQBlrSjJ0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_la7rTtAU6BKxHpmG
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -5017,25 +5975,25 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:28 GMT
+      - Thu, 06 Feb 2025 16:46:45 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "970"
+      - "930"
       X-Request-Id:
-      - d3361b97-cb35-40f1-bda2-3ab16c7f7567
+      - abf9c36e-9c18-49e3-b873-3a7ee0fb4a0a
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor"},"properties":{"associations":[]}}
+      {"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN"},"properties":{"associations":[]}}
     form: {}
     headers:
       Accept:
@@ -5043,36 +6001,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/file_storage_volumes/_
     method: PATCH
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:28 GMT
+      - Thu, 06 Feb 2025 16:46:45 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"f3bb89acbd96508dd353d7ece6d7f16e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "969"
+      - "929"
       X-Request-Id:
-      - 0c696d65-6817-43b6-92db-9afb785e36f3
+      - d1ce502a-c60f-43b5-b1e3-4bd7c532b24d
     status: 200 OK
     code: 200
     duration: ""
@@ -5083,36 +6043,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:33 GMT
+      - Thu, 06 Feb 2025 16:46:50 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"f3bb89acbd96508dd353d7ece6d7f16e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "968"
+      - "928"
       X-Request-Id:
-      - 0adccc45-7743-4426-b41e-ebca306f4652
+      - a46e2848-8495-484d-a16d-a7969162e260
     status: 200 OK
     code: 200
     duration: ""
@@ -5123,36 +6085,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "321"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:33 GMT
+      - Thu, 06 Feb 2025 16:46:55 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "927"
       X-Request-Id:
-      - f55421f4-f283-4773-b396-2330dd9b2395
+      - d43d7700-812f-4c01-833d-b1e5e6aa14f0
     status: 200 OK
     code: 200
     duration: ""
@@ -5163,36 +6127,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "321"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:34 GMT
+      - Thu, 06 Feb 2025 16:46:55 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "926"
       X-Request-Id:
-      - fe541cc7-162d-42c1-8ddb-13899bd5d6f7
+      - d389141d-266d-4fc7-9b3f-14ed324c9c42
     status: 200 OK
     code: 200
     duration: ""
@@ -5203,36 +6169,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "310"
+      - "321"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:34 GMT
+      - Thu, 06 Feb 2025 16:46:55 GMT
       Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "925"
       X-Request-Id:
-      - a52a4308-1dfa-4dfe-9cc5-aa04889ca12d
+      - 06189faf-96e1-4b54-8471-572d68b805a6
     status: 200 OK
     code: 200
     duration: ""
@@ -5243,36 +6211,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "310"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:34 GMT
+      - Thu, 06 Feb 2025 16:46:55 GMT
       Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
+      - W/"0759042e3c06326e061e5c71faac95e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "924"
       X-Request-Id:
-      - 78ba7feb-6f8a-4334-9ef3-b336c48da966
+      - 00d81b18-9d46-45fd-bdb0-7741554c640d
     status: 200 OK
     code: 200
     duration: ""
@@ -5283,36 +6253,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "321"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:34 GMT
+      - Thu, 06 Feb 2025 16:46:56 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "923"
       X-Request-Id:
-      - f51e8881-18b7-4ae5-8823-f6aeec702788
+      - 7f89c2ee-e0b0-48af-8085-7110e0c0adbf
     status: 200 OK
     code: 200
     duration: ""
@@ -5323,36 +6295,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:34 GMT
+      - Thu, 06 Feb 2025 16:46:56 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"0759042e3c06326e061e5c71faac95e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "922"
       X-Request-Id:
-      - cb590de3-f227-44c9-a3e8-cfbcd74d627b
+      - ff13892b-2c41-4a87-8f85-dfc09d1dd406
     status: 200 OK
     code: 200
     duration: ""
@@ -5363,36 +6337,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "310"
+      - "321"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:35 GMT
+      - Thu, 06 Feb 2025 16:46:56 GMT
       Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "921"
       X-Request-Id:
-      - ede7ca0f-10a6-48cf-b9cf-fc6430a0473b
+      - 45b9240b-5aec-48cc-b500-aa5179767619
     status: 200 OK
     code: 200
     duration: ""
@@ -5403,36 +6379,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "304"
+      - "327"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:35 GMT
+      - Thu, 06 Feb 2025 16:46:56 GMT
       Etag:
-      - W/"b0e3321add81b0c7ec2fd92f7dc80ddb"
-      Server:
-      - Caddy
+      - W/"0759042e3c06326e061e5c71faac95e5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "920"
       X-Request-Id:
-      - 088ab279-702d-4c0a-a051-8b41164e52b6
+      - 14f0fe1a-1ca2-4ec2-b17a-3c8f91780e72
     status: 200 OK
     code: 200
     duration: ""
@@ -5443,36 +6421,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
+    body: '{"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "310"
+      - "321"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:35 GMT
+      - Thu, 06 Feb 2025 16:46:56 GMT
       Etag:
-      - W/"a6b05ab2afaa378db3a985ad286611bb"
-      Server:
-      - Caddy
+      - W/"390eb4cfdde954cc0c14a1f247eec384"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "919"
       X-Request-Id:
-      - fca770d2-35de-456c-803d-cfaedae54e57
+      - 1a563ebd-72cd-4904-a09f-b50801a072a4
     status: 200 OK
     code: 200
     duration: ""
@@ -5483,14 +6463,58 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:56 GMT
+      Etag:
+      - W/"0759042e3c06326e061e5c71faac95e5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "919"
+      X-Request-Id:
+      - fb269317-69b1-447b-946a-4d3ecc517fda
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_oukvjp0DCtAVKxJz","keep_until":1679771915,"object_id":"fsv_Pvmld7z81CanIjor","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_Pvmld7z81CanIjor","name":"tf-acc-test-associations-rlc6dflfua0w","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Pvmld7z81CanIjor","size":0}}'
+    body: '{"trash_object":{"id":"trsh_Wrb2Yqz45NkOpDJ3","keep_until":1739033216,"object_id":"fsv_nAIsvYQVdDsVCraN","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_nAIsvYQVdDsVCraN","name":"tf-acc-test-associations-ni9kr1cjg9nl","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_nAIsvYQVdDsVCraN","size":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -5500,19 +6524,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:35 GMT
+      - Thu, 06 Feb 2025 16:46:56 GMT
       Etag:
-      - W/"60756a3b2dd7a630ee31e06e1c457d0d"
-      Server:
-      - Caddy
+      - W/"d782556d35ffb93d5ad21a86251ba097"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "917"
       X-Request-Id:
-      - 8cd4158c-0623-46dc-ae9f-9bf647e6ffd2
+      - 0cfb694e-666a-4562-b9bc-e5cc02c86e57
     status: 200 OK
     code: 200
     duration: ""
@@ -5523,54 +6547,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
     method: DELETE
   response:
-    body: '{"task":{"id":"task_Gxhl0dPk4zaY3ss9","name":"Purge items from trash","status":"pending","created_at":1679599115,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"trash_object":{"id":"trsh_LKzI0wSPGyY5CbIg","keep_until":1739033216,"object_id":"fsv_TxhsfR2UJ7n4qMbq","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_TxhsfR2UJ7n4qMbq","name":"tf-acc-test-associations-ni9kr1cjg9nl-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_TxhsfR2UJ7n4qMbq","size":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:35 GMT
-      Etag:
-      - W/"7c1860e704e175cd2d06fd5bbb8e808d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "956"
-      X-Request-Id:
-      - 0fef7bca-0d63-4d16-9bdf-9f2ec498137d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: DELETE
-  response:
-    body: '{"trash_object":{"id":"trsh_iGNj7rElRN7c50EU","keep_until":1679771915,"object_id":"fsv_ZCmnr1Tc6J6Ao0A3","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_ZCmnr1Tc6J6Ao0A3","name":"tf-acc-test-associations-rlc6dflfua0w-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_ZCmnr1Tc6J6Ao0A3","size":0}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -5580,19 +6566,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:35 GMT
+      - Thu, 06 Feb 2025 16:46:56 GMT
       Etag:
-      - W/"db9b08b25254b3a346145309e1dd90bf"
-      Server:
-      - Caddy
+      - W/"97d6bedf50a3b6d4583e0484eee3476e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "917"
       X-Request-Id:
-      - f49547ed-c036-458e-bfd1-23e933ccb0e0
+      - b9417345-5cfe-429f-8382-7eee0cfa70fa
     status: 200 OK
     code: 200
     duration: ""
@@ -5603,14 +6589,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_nAIsvYQVdDsVCraN
     method: DELETE
   response:
-    body: '{"task":{"id":"task_CBYY5DnHi48uOlQQ","name":"Purge items from trash","status":"pending","created_at":1679599115,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_BQZC2RLNsdHU3jfR","name":"Purge items from trash","status":"pending","created_at":1738860416,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -5620,19 +6608,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:35 GMT
+      - Thu, 06 Feb 2025 16:46:56 GMT
       Etag:
-      - W/"37cdba970029bc0bf17ad26e514958d4"
-      Server:
-      - Caddy
+      - W/"cfd3821fd52e2321d5f8369f7ddebb70"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "915"
       X-Request-Id:
-      - 1a531b85-de89-42b2-bdcf-a59fbfc0a273
+      - 8f4bd046-b415-4cd4-b373-622a2cc6ef5b
     status: 200 OK
     code: 200
     duration: ""
@@ -5643,14 +6631,58 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_EO5HcCNiIe83uuZP","name":"Purge items from trash","status":"pending","created_at":1738860416,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:46:56 GMT
+      Etag:
+      - W/"b87cb5e3688011d7797039c3f1704ad1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "915"
+      X-Request-Id:
+      - f6dbc6db-f973-4374-b308-b97c4f9f5eda
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_oukvjp0DCtAVKxJz","keep_until":1679771915,"object_id":"fsv_Pvmld7z81CanIjor","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_LKzI0wSPGyY5CbIg","keep_until":1739033216,"object_id":"fsv_TxhsfR2UJ7n4qMbq","object_type":"FileStorageVolume"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -5660,19 +6692,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:36 GMT
+      - Thu, 06 Feb 2025 16:46:57 GMT
       Etag:
-      - W/"c8a903dc233f3ba46690fd7aaaa268f4"
-      Server:
-      - Caddy
+      - W/"65d2b04d60a9b16f0d1c384257541f99"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "913"
       X-Request-Id:
-      - ce68dc9b-8c04-43e6-9ae8-de89bd67dfd5
+      - 2004fa43-0de0-4d76-b719-672bfa6d5d2c
     status: 200 OK
     code: 200
     duration: ""
@@ -5683,14 +6715,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_iGNj7rElRN7c50EU","keep_until":1679771915,"object_id":"fsv_ZCmnr1Tc6J6Ao0A3","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_Wrb2Yqz45NkOpDJ3","keep_until":1739033216,"object_id":"fsv_nAIsvYQVdDsVCraN","object_type":"FileStorageVolume"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -5700,19 +6734,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:36 GMT
+      - Thu, 06 Feb 2025 16:46:57 GMT
       Etag:
-      - W/"e8c3f6bee84bdf4b32c355d565c0f861"
-      Server:
-      - Caddy
+      - W/"86fb5f417ac0e3ef7a630acb9c0158c0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "913"
       X-Request-Id:
-      - 788719e5-6dc1-447f-be1f-aafcb08722af
+      - eb0c712b-091a-4bb4-a45e-7214fb01bb45
     status: 200 OK
     code: 200
     duration: ""
@@ -5723,14 +6757,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_oukvjp0DCtAVKxJz","keep_until":1679771915,"object_id":"fsv_Pvmld7z81CanIjor","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_Wrb2Yqz45NkOpDJ3","keep_until":1739033216,"object_id":"fsv_nAIsvYQVdDsVCraN","object_type":"FileStorageVolume"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -5740,223 +6776,21 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:18:41 GMT
+      - Thu, 06 Feb 2025 16:47:02 GMT
       Etag:
-      - W/"c8a903dc233f3ba46690fd7aaaa268f4"
-      Server:
-      - Caddy
+      - W/"86fb5f417ac0e3ef7a630acb9c0158c0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - bdae9a06-8bc6-42fb-83ef-7804b1f96422
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_iGNj7rElRN7c50EU","keep_until":1679771915,"object_id":"fsv_ZCmnr1Tc6J6Ao0A3","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:41 GMT
-      Etag:
-      - W/"e8c3f6bee84bdf4b32c355d565c0f861"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "951"
-      X-Request-Id:
-      - 0ee7f521-fa0d-4757-98dc-4b75993ccfcf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_Pvmld7z81CanIjor
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_oukvjp0DCtAVKxJz","keep_until":1679771915,"object_id":"fsv_Pvmld7z81CanIjor","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:51 GMT
-      Etag:
-      - W/"c8a903dc233f3ba46690fd7aaaa268f4"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - 24d39475-5c44-4d46-8f72-8a993fde69ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_iGNj7rElRN7c50EU","keep_until":1679771915,"object_id":"fsv_ZCmnr1Tc6J6Ao0A3","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:18:51 GMT
-      Etag:
-      - W/"e8c3f6bee84bdf4b32c355d565c0f861"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "949"
-      X-Request-Id:
-      - a7b7cf90-a0cf-421e-84a8-84b739b23759
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_Pvmld7z81CanIjor
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:19:01 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - 2d62f537-bdc9-4eac-92b6-590766068d9c
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_ZCmnr1Tc6J6Ao0A3
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:19:01 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "998"
       X-Request-Id:
-      - 318b6ae5-05dd-4320-9ae7-d8f9a632b649
-    status: 404 Not Found
-    code: 404
+      - 7b8558dd-3765-4ec6-ab4b-2856d6c4483f
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -5965,39 +6799,124 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
-    body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
-      storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
+    body: '{"trash_object":{"id":"trsh_LKzI0wSPGyY5CbIg","keep_until":1739033216,"object_id":"fsv_TxhsfR2UJ7n4qMbq","object_type":"FileStorageVolume"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - no-cache
+      - max-age=0, private, must-revalidate
       Content-Length:
-      - "167"
+      - "140"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:19:02 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:47:02 GMT
+      Etag:
+      - W/"65d2b04d60a9b16f0d1c384257541f99"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 27280c5d-0121-499d-a594-05f964a7f107
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_LKzI0wSPGyY5CbIg","keep_until":1739033216,"object_id":"fsv_TxhsfR2UJ7n4qMbq","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:12 GMT
+      Etag:
+      - W/"65d2b04d60a9b16f0d1c384257541f99"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - c6175795-17c0-4af7-b246-4344cff52362
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_Wrb2Yqz45NkOpDJ3","keep_until":1739033216,"object_id":"fsv_nAIsvYQVdDsVCraN","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:12 GMT
+      Etag:
+      - W/"86fb5f417ac0e3ef7a630acb9c0158c0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "997"
       X-Request-Id:
-      - 69ec613a-178f-4402-9d3a-c292cd2a0de3
-    status: 404 Not Found
-    code: 404
+      - eb1c6780-eb81-4898-90ef-c1163d53dd3a
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -6006,15 +6925,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_ZCmnr1Tc6J6Ao0A3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_nAIsvYQVdDsVCraN
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -6024,52 +6945,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:19:02 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:47:22 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 03bb013a-f4ce-4150-9d78-007cee60cecd
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_Pvmld7z81CanIjor
-    method: GET
-  response:
-    body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
-      storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "167"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 19:19:02 GMT
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
@@ -6077,7 +6957,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "995"
       X-Request-Id:
-      - 8dcbf6f3-64dd-4c77-9052-15c41295ee80
+      - 56a1d7ce-b838-4c9c-b843-aa458c569619
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6088,15 +6968,59 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_Pvmld7z81CanIjor
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_LKzI0wSPGyY5CbIg","keep_until":1739033216,"object_id":"fsv_TxhsfR2UJ7n4qMbq","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:22 GMT
+      Etag:
+      - W/"65d2b04d60a9b16f0d1c384257541f99"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 07715ef4-850f-4999-85ee-fbb0f189d57e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_TxhsfR2UJ7n4qMbq
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -6106,19 +7030,191 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 19:19:02 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:47:32 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "993"
       X-Request-Id:
-      - 724f8620-5531-4f03-bd7c-94c583c7dc30
+      - 9171b3fa-48cc-4734-86b1-c96f6cfbb78e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
+      storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "167"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:32 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - e285eb9d-4249-4555-a186-4abd50bf0e3e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_TxhsfR2UJ7n4qMbq
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:32 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 18b119e5-faad-4936-9293-79ea57120f50
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/file_storage_volumes/_?file_storage_volume%5Bid%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
+      storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "167"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:33 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - df225342-3e32-45f0-8cae-0ff966100edd
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=fsv_nAIsvYQVdDsVCraN
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:47:33 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 3bbd7a78-c49a-4ae8-834a-500f08f1b792
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_basic.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_basic.cassette.rand_id
@@ -1,1 +1,1 @@
-kp0bb6ldt3ov
+6jc7qudt1ltc

--- a/internal/provider/testdata/VirtualMachine_basic.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_basic.cassette.yaml
@@ -8,36 +8,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
+      - Thu, 06 Feb 2025 16:37:25 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "999"
       X-Request-Id:
-      - 5cc605af-d6e8-44ba-adc5-a6de33606e09
+      - b02d897f-60b9-4c69-954c-c4d3a6068a22
     status: 200 OK
     code: 200
     duration: ""
@@ -48,42 +50,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
+      - Thu, 06 Feb 2025 16:37:25 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "999"
       X-Request-Id:
-      - a76f3b6f-7fb3-414c-aa90-3dc6003cd668
+      - ba99c0b4-73ec-422d-917a-e032f0ee4b75
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -91,36 +95,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "144"
+      - "167"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
+      - Thu, 06 Feb 2025 16:37:25 GMT
       Etag:
-      - W/"7409480a46bd0c05a524299e74610065"
-      Server:
-      - Caddy
+      - W/"eac886d80b16dcff10bac4b8418566e6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "999"
       X-Request-Id:
-      - 3ab2cc21-69bd-4bc7-a5b8-6442f7017b7d
+      - 78f55cbc-d121-472f-8d25-7a5ae976b067
     status: 200 OK
     code: 200
     duration: ""
@@ -131,36 +137,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_pIuWN0BEJCv5SLNY
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_hHGjRZT6jYfTfQku
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "144"
+      - "167"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
+      - Thu, 06 Feb 2025 16:37:25 GMT
       Etag:
-      - W/"7409480a46bd0c05a524299e74610065"
-      Server:
-      - Caddy
+      - W/"eac886d80b16dcff10bac4b8418566e6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "995"
       X-Request-Id:
-      - 4065fe72-4fea-45e2-9c2c-c50f88408815
+      - 1f7be3eb-b13b-4ec6-a4fd-090551cb94c1
     status: 200 OK
     code: 200
     duration: ""
@@ -174,38 +182,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"185-44-255-215.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:21 GMT
+      - Thu, 06 Feb 2025 16:37:25 GMT
       Etag:
-      - W/"bca869113d81fc0901f92a0d7516e299"
-      Server:
-      - Caddy
+      - W/"6268340767e24240ef3a96c4c64df328"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "996"
       X-Request-Id:
-      - e7c7ad63-0b67-477a-a666-83f8ba6ce69e
+      - b9650c59-ad6b-4fae-aea5-7371adf8d821
     status: 200 OK
     code: 200
     duration: ""
@@ -216,38 +226,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_7Bh60E8rzVXXhogw
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"185-44-255-215.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:21 GMT
+      - Thu, 06 Feb 2025 16:37:25 GMT
       Etag:
-      - W/"e885820193fa788a5a81f9194c9217d1"
-      Server:
-      - Caddy
+      - W/"ee0fd3e588aa62b525db423d1ede8748"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "951"
+      - "994"
       X-Request-Id:
-      - c539e4df-8b2d-4c4c-88c6-b5354be1cd93
+      - 5b6aee63-1880-406f-8dbe-be5795275239
     status: 200 OK
     code: 200
     duration: ""
@@ -261,38 +273,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"185-199-222-82.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"185-44-254-202.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:24 GMT
+      - Thu, 06 Feb 2025 16:37:26 GMT
       Etag:
-      - W/"621cf5e7e023db96570a2f8c12646d58"
-      Server:
-      - Caddy
+      - W/"3c422a77177663cb1326520c287504d4"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "993"
       X-Request-Id:
-      - 687390a7-0377-4e1e-b3a3-4b3e7112a4a7
+      - cc0afe3f-df8a-4a4a-8929-b408552977de
     status: 200 OK
     code: 200
     duration: ""
@@ -303,38 +317,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GxsiO1h6yadD4mCe
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"185-199-222-82.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"185-44-254-202.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:24 GMT
+      - Thu, 06 Feb 2025 16:37:26 GMT
       Etag:
-      - W/"cda0687c826fe99974a1eaa7b8a9c2d8"
-      Server:
-      - Caddy
+      - W/"9ce4380b70e04c73480e49c793d8f447"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "949"
+      - "992"
       X-Request-Id:
-      - cfbbbb13-8858-4cbb-a9ee-fdffcb759183
+      - 882d7fa4-58ed-447f-98f9-d648b9d35730
     status: 200 OK
     code: 200
     duration: ""
@@ -345,38 +361,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GxsiO1h6yadD4mCe
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"185-199-222-16.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"185-44-254-202.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:24 GMT
+      - Thu, 06 Feb 2025 16:37:26 GMT
       Etag:
-      - W/"e885820193fa788a5a81f9194c9217d1"
-      Server:
-      - Caddy
+      - W/"9ce4380b70e04c73480e49c793d8f447"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "991"
       X-Request-Id:
-      - 19dc6247-4e98-410a-83a6-7fbee0baec63
+      - 2e50b4c4-3c60-411b-986d-d3036e2acaef
     status: 200 OK
     code: 200
     duration: ""
@@ -387,44 +405,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_7Bh60E8rzVXXhogw
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"185-199-222-82.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"185-44-255-215.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:24 GMT
+      - Thu, 06 Feb 2025 16:37:26 GMT
       Etag:
-      - W/"cda0687c826fe99974a1eaa7b8a9c2d8"
-      Server:
-      - Caddy
+      - W/"ee0fd3e588aa62b525db423d1ede8748"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "947"
+      - "990"
       X-Request-Id:
-      - 974cc5c9-a0e6-41a1-8d47-51e21564bc89
+      - 948ecbc7-672f-4a5a-bfcc-937f35180fcd
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_Ntu5DTZickqN6c9T</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_z6ShjS7x8jv8GyKH</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-basic-kp0bb6ldt3ov-host</Hostname></Hostname><Name>tf-acc-test-basic-kp0bb6ldt3ov</Name><Description>A web server.</Description><Group>vmgrp_pIuWN0BEJCv5SLNY</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_GxsiO1h6yadD4mCe</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_7Bh60E8rzVXXhogw</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-basic-6jc7qudt1ltc-host</Hostname></Hostname><Name>tf-acc-test-basic-6jc7qudt1ltc</Name><Description>A web server.</Description><Group>vmgrp_hHGjRZT6jYfTfQku</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -432,36 +452,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_B0iAJ8AoiUfUbSOh","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_U524UoQxPW61DoYs","state":"pending"},"virtual_machine_build":{"id":"vmbuild_U524UoQxPW61DoYs","state":"pending"},"hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host"}'
+    body: '{"task":{"id":"task_nbU2MvTbMG1LT5mZ","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_T2WNv0C7oMze53tS","state":"pending"},"virtual_machine_build":{"id":"vmbuild_T2WNv0C7oMze53tS","state":"pending"},"hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "274"
+      - "291"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:24 GMT
+      - Thu, 06 Feb 2025 16:37:26 GMT
       Etag:
-      - W/"71cc9637a632ee23d45fc3d8321a90b6"
-      Server:
-      - Caddy
+      - W/"e71a7c645f2f93cfe7183eb7629fbadc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "946"
+      - "989"
       X-Request-Id:
-      - b32b0156-c55c-4d17-9a3d-f756f6732344
+      - b6cfed6d-a6b7-4188-ba07-91a8cc9a71f6
     status: 201 Created
     code: 201
     duration: ""
@@ -472,45 +494,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_U524UoQxPW61DoYs
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_T2WNv0C7oMze53tS
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_U524UoQxPW61DoYs","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_T2WNv0C7oMze53tS","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.82\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-kp0bb6ldt3ov-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-kp0bb6ldt3ov\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_pIuWN0BEJCv5SLNY\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.202\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-6jc7qudt1ltc-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-6jc7qudt1ltc\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_hHGjRZT6jYfTfQku\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679595144}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738859846},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1957"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:26 GMT
+      - Thu, 06 Feb 2025 16:37:28 GMT
       Etag:
-      - W/"ae8dfc0c5c6089febb7ea459bf9c49db"
-      Server:
-      - Caddy
+      - W/"0912e89c62639706832ff6061ccc0f56"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "945"
+      - "988"
       X-Request-Id:
-      - 857cb106-1a01-492b-9846-47506f7df6c4
+      - cf485098-168b-49dd-a41b-329b46d86654
     status: 200 OK
     code: 200
     duration: ""
@@ -521,45 +543,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_U524UoQxPW61DoYs
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_T2WNv0C7oMze53tS
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_U524UoQxPW61DoYs","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_T2WNv0C7oMze53tS","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.82\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-kp0bb6ldt3ov-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-kp0bb6ldt3ov\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_pIuWN0BEJCv5SLNY\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.202\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-6jc7qudt1ltc-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-6jc7qudt1ltc\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_hHGjRZT6jYfTfQku\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595144}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738859846},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2167"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:31 GMT
+      - Thu, 06 Feb 2025 16:37:33 GMT
       Etag:
-      - W/"044c0c57cba45a7af33d1511ec929338"
-      Server:
-      - Caddy
+      - W/"e2de15a3d52f8d9c74ddb1d91496ec76"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "987"
       X-Request-Id:
-      - f1e1e4f1-2fc7-4e34-9714-817673533398
+      - ad7e444c-615f-46f3-b975-aa72ec5d1b2f
     status: 200 OK
     code: 200
     duration: ""
@@ -570,45 +592,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_U524UoQxPW61DoYs
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_T2WNv0C7oMze53tS
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_U524UoQxPW61DoYs","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_T2WNv0C7oMze53tS","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.82\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-kp0bb6ldt3ov-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-kp0bb6ldt3ov\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_pIuWN0BEJCv5SLNY\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.202\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-6jc7qudt1ltc-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-6jc7qudt1ltc\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_hHGjRZT6jYfTfQku\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595144}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738859846},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2167"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:41 GMT
+      - Thu, 06 Feb 2025 16:37:43 GMT
       Etag:
-      - W/"044c0c57cba45a7af33d1511ec929338"
-      Server:
-      - Caddy
+      - W/"e2de15a3d52f8d9c74ddb1d91496ec76"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "914"
+      - "986"
       X-Request-Id:
-      - 724ebbb5-2449-4a38-a3e1-0d2dd321ac24
+      - 5bdc4057-26d1-41bd-8bb9-5296a147e4eb
     status: 200 OK
     code: 200
     duration: ""
@@ -619,51 +641,51 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_U524UoQxPW61DoYs
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_T2WNv0C7oMze53tS
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_U524UoQxPW61DoYs","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_T2WNv0C7oMze53tS","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.16\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.82\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-kp0bb6ldt3ov-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-kp0bb6ldt3ov\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_pIuWN0BEJCv5SLNY\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.202\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-basic-6jc7qudt1ltc-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-basic-6jc7qudt1ltc\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_hHGjRZT6jYfTfQku\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595144}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1738859846},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2167"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:51 GMT
+      - Thu, 06 Feb 2025 16:37:53 GMT
       Etag:
-      - W/"4b22959acca4c08a21ab5b4c869ff581"
-      Server:
-      - Caddy
+      - W/"9eb08d1fbac70f542fe4d903aee389c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "907"
+      - "985"
       X-Request-Id:
-      - 26a9ec4b-d00b-481c-b617-b33f28183d95
+      - 8ae5fad1-9665-438b-b5e5-ec6947adf38d
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -671,46 +693,47 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595145,"initial_root_password":"yYFdeUxtfCdZQ2Uj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859851,"initial_root_password":"IdysxnWXmvMwxAvQ","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:51 GMT
+      - Thu, 06 Feb 2025 16:37:53 GMT
       Etag:
-      - W/"9d10bd1f6045ab61fc863920f5a883b2"
-      Server:
-      - Caddy
+      - W/"7029afbf6190b47b474f75eb0a9b3ef2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "906"
+      - "984"
       X-Request-Id:
-      - 1b5fc8f8-7f08-432d-a156-378ca99a883c
+      - 68470de9-4662-442a-87b7-176924570ea3
     status: 200 OK
     code: 200
     duration: ""
@@ -721,46 +744,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595145,"initial_root_password":"yYFdeUxtfCdZQ2Uj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859851,"initial_root_password":"IdysxnWXmvMwxAvQ","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:55 GMT
       Etag:
-      - W/"9d10bd1f6045ab61fc863920f5a883b2"
-      Server:
-      - Caddy
+      - W/"7029afbf6190b47b474f75eb0a9b3ef2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "891"
+      - "983"
       X-Request-Id:
-      - 75506bc4-f874-497b-acc8-183fde983373
+      - 5bdc6c8b-e6ea-4e8d-97c5-6c82b4e18cde
     status: 200 OK
     code: 200
     duration: ""
@@ -771,46 +795,131 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595145,"initial_root_password":"yYFdeUxtfCdZQ2Uj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859851,"initial_root_password":"IdysxnWXmvMwxAvQ","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:37:55 GMT
+      Etag:
+      - W/"7029afbf6190b47b474f75eb0a9b3ef2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 62ece86d-4f5a-4875-a16a-e507fe4186d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_2vwsF7WBKg2RqFYF","name":"Public
+      Network on tf-acc-test-basic-6jc7qudt1ltc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3122"
+      - "437"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:55 GMT
       Etag:
-      - W/"9d10bd1f6045ab61fc863920f5a883b2"
-      Server:
-      - Caddy
+      - W/"bce246c42a00c27911d55e06c31d4579"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "890"
+      - "981"
       X-Request-Id:
-      - 27958031-b39b-4426-aae7-50e42ee3237e
+      - 15282f4b-8f24-42df-b436-d9707311b1c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_2vwsF7WBKg2RqFYF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_2vwsF7WBKg2RqFYF","virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc"},"name":"Public
+      Network on tf-acc-test-basic-6jc7qudt1ltc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:c3:65:81:8e","state":"attached","ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "565"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:37:55 GMT
+      Etag:
+      - W/"367bb1999f065294714382cf212cccfd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - 032e2d32-bde1-4277-9a3c-3a17a00ac2dd
     status: 200 OK
     code: 200
     duration: ""
@@ -821,38 +930,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_2vwsF7WBKg2RqFYF
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_EWop3L7d10w01lwN","name":"Public
-      Network on tf-acc-test-basic-kp0bb6ldt3ov","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_2vwsF7WBKg2RqFYF","virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc"},"name":"Public
+      Network on tf-acc-test-basic-6jc7qudt1ltc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:c3:65:81:8e","state":"attached","ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "413"
+      - "565"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:55 GMT
       Etag:
-      - W/"4c1e97acca1b1437557bb68c36c873de"
-      Server:
-      - Caddy
+      - W/"367bb1999f065294714382cf212cccfd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "889"
+      - "979"
       X-Request-Id:
-      - d3fd822c-b82d-4568-aa0a-e3e202a0cea9
+      - d3a7b7e9-3f44-4ce6-ae6a-142ea50b6ff8
     status: 200 OK
     code: 200
     duration: ""
@@ -863,88 +974,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_EWop3L7d10w01lwN
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_EWop3L7d10w01lwN","virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov"},"name":"Public
-      Network on tf-acc-test-basic-kp0bb6ldt3ov","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:60:cd:3e:b0:94","state":"attached","ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "542"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
-      Etag:
-      - W/"dda2016cff9229189d5ed1bbbf262fd3"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "888"
-      X-Request-Id:
-      - 52a29b98-066c-48d8-8284-b90cde216294
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595145,"initial_root_password":"yYFdeUxtfCdZQ2Uj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859851,"initial_root_password":"IdysxnWXmvMwxAvQ","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:56 GMT
       Etag:
-      - W/"9d10bd1f6045ab61fc863920f5a883b2"
-      Server:
-      - Caddy
+      - W/"7029afbf6190b47b474f75eb0a9b3ef2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "887"
+      - "978"
       X-Request-Id:
-      - 0654bdca-d124-43a6-82d8-d90f907e9531
+      - 20816a1a-5f9d-4e27-9db2-2c6e9da4343b
     status: 200 OK
     code: 200
     duration: ""
@@ -955,36 +1025,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_pIuWN0BEJCv5SLNY
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_hHGjRZT6jYfTfQku
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "144"
+      - "167"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:56 GMT
       Etag:
-      - W/"7409480a46bd0c05a524299e74610065"
-      Server:
-      - Caddy
+      - W/"eac886d80b16dcff10bac4b8418566e6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "886"
+      - "975"
       X-Request-Id:
-      - a57e51da-179b-4489-b061-44fb48dd844e
+      - 2e5df480-4f05-4f52-8ae0-88ec67c39829
     status: 200 OK
     code: 200
     duration: ""
@@ -995,38 +1067,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_7Bh60E8rzVXXhogw
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov"}}}'
+    body: '{"ip_address":{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "729"
+      - "744"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:56 GMT
       Etag:
-      - W/"037bfd255d1ea7ac61e0de04bf5cb6b2"
-      Server:
-      - Caddy
+      - W/"00dbd5be6a757e22c1654bcd3f72fba3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "885"
+      - "977"
       X-Request-Id:
-      - bccaf802-9895-404b-b8ec-92d427685197
+      - 0e7f9f34-0fa9-49ca-97e3-aa1bc59ba156
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,38 +1111,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GxsiO1h6yadD4mCe
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov"}}}'
+    body: '{"ip_address":{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "729"
+      - "744"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:56 GMT
       Etag:
-      - W/"b21087a1a4b60ed519fdb2cb3dfb3053"
-      Server:
-      - Caddy
+      - W/"a5b7cdb68082a3dd50210ef41f4fde61"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "884"
+      - "977"
       X-Request-Id:
-      - 65545979-d0d4-48b3-8200-081902426cb7
+      - 14aee7d5-c4fa-4865-9367-3b6b8fe95381
     status: 200 OK
     code: 200
     duration: ""
@@ -1079,46 +1155,131 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595145,"initial_root_password":"yYFdeUxtfCdZQ2Uj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859851,"initial_root_password":"IdysxnWXmvMwxAvQ","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:37:56 GMT
+      Etag:
+      - W/"7029afbf6190b47b474f75eb0a9b3ef2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 6dcc14a2-4bf8-4c27-bbbc-5d9c3db9c4c3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_2vwsF7WBKg2RqFYF","name":"Public
+      Network on tf-acc-test-basic-6jc7qudt1ltc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3122"
+      - "437"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:56 GMT
       Etag:
-      - W/"9d10bd1f6045ab61fc863920f5a883b2"
-      Server:
-      - Caddy
+      - W/"bce246c42a00c27911d55e06c31d4579"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "883"
+      - "973"
       X-Request-Id:
-      - 0d5f4fd9-bf3d-4f48-9832-507feccde6c6
+      - 1e2d8d0f-6bae-45c6-9852-eab08e2babe4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_2vwsF7WBKg2RqFYF
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_2vwsF7WBKg2RqFYF","virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc"},"name":"Public
+      Network on tf-acc-test-basic-6jc7qudt1ltc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:c3:65:81:8e","state":"attached","ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "565"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:37:56 GMT
+      Etag:
+      - W/"367bb1999f065294714382cf212cccfd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 8aaa120f-8463-48f3-8583-f643454dcaef
     status: 200 OK
     code: 200
     duration: ""
@@ -1129,38 +1290,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_2vwsF7WBKg2RqFYF
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_EWop3L7d10w01lwN","name":"Public
-      Network on tf-acc-test-basic-kp0bb6ldt3ov","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_2vwsF7WBKg2RqFYF","virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc"},"name":"Public
+      Network on tf-acc-test-basic-6jc7qudt1ltc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:c3:65:81:8e","state":"attached","ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "413"
+      - "565"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:56 GMT
       Etag:
-      - W/"4c1e97acca1b1437557bb68c36c873de"
-      Server:
-      - Caddy
+      - W/"367bb1999f065294714382cf212cccfd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "882"
+      - "971"
       X-Request-Id:
-      - ced3dd5e-f308-44a3-ab7f-192f7ef2b1e0
+      - eb0429a6-fc33-4988-b1fc-a2760b26c1b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1171,88 +1334,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_EWop3L7d10w01lwN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_EWop3L7d10w01lwN","virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov"},"name":"Public
-      Network on tf-acc-test-basic-kp0bb6ldt3ov","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:60:cd:3e:b0:94","state":"attached","ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "542"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
-      Etag:
-      - W/"dda2016cff9229189d5ed1bbbf262fd3"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "881"
-      X-Request-Id:
-      - 2375db17-5c45-4c71-ae35-abe5d3a4607d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595145,"initial_root_password":"yYFdeUxtfCdZQ2Uj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859851,"initial_root_password":"IdysxnWXmvMwxAvQ","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:56 GMT
       Etag:
-      - W/"9d10bd1f6045ab61fc863920f5a883b2"
-      Server:
-      - Caddy
+      - W/"7029afbf6190b47b474f75eb0a9b3ef2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "880"
+      - "970"
       X-Request-Id:
-      - b8b93fea-509d-4f14-af9c-01a6b9fdbcdb
+      - 826f440d-1d69-44e6-8eed-aa400db7fa44
     status: 200 OK
     code: 200
     duration: ""
@@ -1263,14 +1385,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: POST
   response:
-    body: '{"task":{"id":"task_7qC03fn3y7fXqz21","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_7q3kwhF5xZ7Yg2L5","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1280,19 +1404,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:54 GMT
+      - Thu, 06 Feb 2025 16:37:56 GMT
       Etag:
-      - W/"39efeaf41a3d042948638a0d57700bd1"
-      Server:
-      - Caddy
+      - W/"e84afd503d2c2da39d41075332d10f58"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "879"
+      - "969"
       X-Request-Id:
-      - 7791d23e-fcc7-461a-ab3a-159e9e4712e3
+      - 128e2af8-c930-4385-a829-4cf756408aa6
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,36 +1427,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7qC03fn3y7fXqz21
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_7q3kwhF5xZ7Yg2L5
     method: GET
   response:
-    body: '{"task":{"id":"task_7qC03fn3y7fXqz21","name":"Stop virtual machine","status":"pending","created_at":1679595174,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_7q3kwhF5xZ7Yg2L5","name":"Stop virtual machine","status":"running","created_at":1738859876,"started_at":1738859877,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "162"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:55 GMT
+      - Thu, 06 Feb 2025 16:37:57 GMT
       Etag:
-      - W/"732bb75bb3e18d266b01eaeb31b6ebcc"
-      Server:
-      - Caddy
+      - W/"87ef97edd95ce6411deaa6c317d679c9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "876"
+      - "968"
       X-Request-Id:
-      - 5ed2aff8-15cd-4fd7-9685-7b6c70cbd6d3
+      - 71e09b94-ec85-449b-af3f-6ce1dc430ab7
     status: 200 OK
     code: 200
     duration: ""
@@ -1343,94 +1469,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7qC03fn3y7fXqz21
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_7q3kwhF5xZ7Yg2L5
     method: GET
   response:
-    body: '{"task":{"id":"task_7qC03fn3y7fXqz21","name":"Stop virtual machine","status":"pending","created_at":1679595174,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_7q3kwhF5xZ7Yg2L5","name":"Stop virtual machine","status":"completed","created_at":1738859876,"started_at":1738859877,"finished_at":1738859878,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
-      Etag:
-      - W/"732bb75bb3e18d266b01eaeb31b6ebcc"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - c973d851-e8a7-4bfe-8539-63c8ba0aad32
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7qC03fn3y7fXqz21
-    method: GET
-  response:
-    body: '{"task":{"id":"task_7qC03fn3y7fXqz21","name":"Stop virtual machine","status":"running","created_at":1679595174,"started_at":1679595189,"finished_at":null,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "170"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:10 GMT
-      Etag:
-      - W/"93c49e9e68fa11742dbbfc187eafd5aa"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "976"
-      X-Request-Id:
-      - 29a3c27a-6758-489c-bf23-eec39790485c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_7qC03fn3y7fXqz21
-    method: GET
-  response:
-    body: '{"task":{"id":"task_7qC03fn3y7fXqz21","name":"Stop virtual machine","status":"completed","created_at":1679595174,"started_at":1679595189,"finished_at":1679595191,"progress":100}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1440,19 +1488,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:20 GMT
+      - Thu, 06 Feb 2025 16:38:02 GMT
       Etag:
-      - W/"74be213b2f8d61037ae38ac13577e95c"
-      Server:
-      - Caddy
+      - W/"92c15ec6b84516106c13923209d065c1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "999"
       X-Request-Id:
-      - 5593e6b9-b36e-469f-8c8a-dabd57aea444
+      - 21bbc53a-1222-4826-8ff1-5e0c085fd029
     status: 200 OK
     code: 200
     duration: ""
@@ -1463,46 +1511,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595145,"initial_root_password":"yYFdeUxtfCdZQ2Uj","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859851,"initial_root_password":"IdysxnWXmvMwxAvQ","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3122"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:21 GMT
+      - Thu, 06 Feb 2025 16:38:03 GMT
       Etag:
-      - W/"ff9f09bc6c0802632a254a4437499795"
-      Server:
-      - Caddy
+      - W/"36c446cb09594d8e24859187cd983f88"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "998"
       X-Request-Id:
-      - da4e5918-93f2-4203-a6f6-00d152b261d4
+      - 559f93f5-fde6-46ed-8c59-1cd90e0cd50f
     status: 200 OK
     code: 200
     duration: ""
@@ -1513,46 +1562,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_H0CicrEKboCIInN2","keep_until":1679768001,"object_id":"vm_W5VKa2lIiuChZEce","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_W5VKa2lIiuChZEce","name":"tf-acc-test-basic-kp0bb6ldt3ov","hostname":"tf-acc-test-basic-kp0bb6ldt3ov-host","fqdn":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595145,"initial_root_password":"yYFdeUxtfCdZQ2Uj","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_N0yRJZMJMsHqFlGw","keep_until":1739032683,"object_id":"vm_GQCPIorurOzDYHo2","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_GQCPIorurOzDYHo2","name":"tf-acc-test-basic-6jc7qudt1ltc","hostname":"tf-acc-test-basic-6jc7qudt1ltc-host","fqdn":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859851,"initial_root_password":"IdysxnWXmvMwxAvQ","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_Ntu5DTZickqN6c9T","address":"185.199.222.16","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.16/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"},{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-basic-kp0bb6ldt3ov-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_W5VKa2lIiuChZEce","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_GxsiO1h6yadD4mCe","address":"185.44.254.202","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.202/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"},{"id":"ip_7Bh60E8rzVXXhogw","address":"185.44.255.215","reverse_dns":"tf-acc-test-basic-6jc7qudt1ltc-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_GQCPIorurOzDYHo2","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3257"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:22 GMT
+      - Thu, 06 Feb 2025 16:38:03 GMT
       Etag:
-      - W/"8e68bc78e03b0654ad0ab69160ca87b3"
-      Server:
-      - Caddy
+      - W/"d9d105e003c9a4bf3b55fd44b7c953ec"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "997"
       X-Request-Id:
-      - 86d99015-bbd1-498c-8e40-aa5ab65b1438
+      - 40da4798-83ae-47f1-bdfb-4190ce4b7835
     status: 200 OK
     code: 200
     duration: ""
@@ -1563,14 +1613,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_GxsiO1h6yadD4mCe
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1580,19 +1632,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:22 GMT
+      - Thu, 06 Feb 2025 16:38:04 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "996"
       X-Request-Id:
-      - 208257fa-b266-4bd5-b3d2-15be25e20dd8
+      - 0506b5bc-9625-458d-8b2c-2956bc7695d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,14 +1655,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_7Bh60E8rzVXXhogw
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1620,19 +1674,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:22 GMT
+      - Thu, 06 Feb 2025 16:38:05 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "949"
+      - "995"
       X-Request-Id:
-      - eca6ccaf-a76f-486e-8b09-e847dce8ab76
+      - 339d3f17-eef7-4a46-bdd0-69b916d9b4b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1643,14 +1697,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_GQCPIorurOzDYHo2
     method: DELETE
   response:
-    body: '{"task":{"id":"task_Jlqt9jP2ob8A2N7S","name":"Purge items from trash","status":"pending","created_at":1679595202,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_cZoF8LrWP38SBKXB","name":"Purge items from trash","status":"pending","created_at":1738859885,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1660,19 +1716,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:22 GMT
+      - Thu, 06 Feb 2025 16:38:05 GMT
       Etag:
-      - W/"e499bbf019ce30f370fb093f6a812ddb"
-      Server:
-      - Caddy
+      - W/"7b15cad2edeafd8d84801c3de7793b50"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "947"
+      - "994"
       X-Request-Id:
-      - f049ad1d-2a43-4210-86bf-77ec34026072
+      - 8f6238bf-4ce9-4a3d-a3e0-dcdc2b9cd54e
     status: 200 OK
     code: 200
     duration: ""
@@ -1683,14 +1739,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_H0CicrEKboCIInN2","keep_until":1679768001,"object_id":"vm_W5VKa2lIiuChZEce","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_N0yRJZMJMsHqFlGw","keep_until":1739032683,"object_id":"vm_GQCPIorurOzDYHo2","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1700,19 +1758,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:23 GMT
+      - Thu, 06 Feb 2025 16:38:06 GMT
       Etag:
-      - W/"7b3cc82a793e0c5756b0115f2b8d43ae"
-      Server:
-      - Caddy
+      - W/"48388025c621f674149558078163def9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "941"
+      - "993"
       X-Request-Id:
-      - 12f49a54-aa19-4367-9ac6-ce13e54a9a05
+      - 0a1c4811-9bc1-4485-9889-be19996574e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1723,14 +1781,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_H0CicrEKboCIInN2","keep_until":1679768001,"object_id":"vm_W5VKa2lIiuChZEce","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_N0yRJZMJMsHqFlGw","keep_until":1739032683,"object_id":"vm_GQCPIorurOzDYHo2","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1740,19 +1800,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:28 GMT
+      - Thu, 06 Feb 2025 16:38:11 GMT
       Etag:
-      - W/"7b3cc82a793e0c5756b0115f2b8d43ae"
-      Server:
-      - Caddy
+      - W/"48388025c621f674149558078163def9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "894"
+      - "992"
       X-Request-Id:
-      - 9b6300bb-17c0-42fc-bf88-e640da43a8ec
+      - 351dec3b-1323-4878-9462-67e45fd001e1
     status: 200 OK
     code: 200
     duration: ""
@@ -1763,55 +1823,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_W5VKa2lIiuChZEce
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_H0CicrEKboCIInN2","keep_until":1679768001,"object_id":"vm_W5VKa2lIiuChZEce","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:38 GMT
-      Etag:
-      - W/"7b3cc82a793e0c5756b0115f2b8d43ae"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "770"
-      X-Request-Id:
-      - 245fae1d-1dce-49f9-ac37-ae50746e193a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1821,19 +1843,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:38:21 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "608"
+      - "991"
       X-Request-Id:
-      - 192e206f-8716-4c83-85df-73e8891326f8
+      - 61a7def8-39d9-42bd-85e2-6220aef90eb7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1844,36 +1866,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_pIuWN0BEJCv5SLNY
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_hHGjRZT6jYfTfQku
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_pIuWN0BEJCv5SLNY","name":"tf-acc-test-basic-kp0bb6ldt3ov-group","segregate":true,"created_at":1679595137}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_hHGjRZT6jYfTfQku","name":"tf-acc-test-basic-6jc7qudt1ltc-group","segregate":true,"auto_segregate":false,"created_at":1738859845}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "144"
+      - "167"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:48 GMT
+      - Thu, 06 Feb 2025 16:38:21 GMT
       Etag:
-      - W/"7409480a46bd0c05a524299e74610065"
-      Server:
-      - Caddy
+      - W/"eac886d80b16dcff10bac4b8418566e6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "607"
+      - "990"
       X-Request-Id:
-      - b3d6dcab-6662-473a-a726-b2782a145622
+      - eb329e78-7c31-4cd6-b11a-e23acaa3c8cb
     status: 200 OK
     code: 200
     duration: ""
@@ -1884,14 +1908,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_7Bh60E8rzVXXhogw
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1901,19 +1927,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:49 GMT
+      - Thu, 06 Feb 2025 16:38:21 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "607"
+      - "990"
       X-Request-Id:
-      - 92aaf718-cbf2-4e99-8fe4-f1e1ecffe7d7
+      - d436195e-c4c6-43ac-b0c8-a91944cb50d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1924,14 +1950,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GxsiO1h6yadD4mCe
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1941,19 +1969,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:49 GMT
+      - Thu, 06 Feb 2025 16:38:21 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "605"
+      - "990"
       X-Request-Id:
-      - cd8aaa5f-63f4-4495-ae55-42c0bb28f6fb
+      - 94af36a2-e30a-4384-9d60-269674f9e389
     status: 200 OK
     code: 200
     duration: ""
@@ -1964,15 +1992,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1982,19 +2012,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:49 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:38:21 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "604"
+      - "987"
       X-Request-Id:
-      - e8039dfa-7adf-42ea-bf72-0d46b5567eeb
+      - 91cd0380-1a30-4a5e-a7f6-c4b3956f53f8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2005,15 +2035,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_W5VKa2lIiuChZEce
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_GQCPIorurOzDYHo2
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2023,19 +2055,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:49 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:38:21 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "603"
+      - "986"
       X-Request-Id:
-      - 60cded64-bfd3-4d60-88aa-9db12b4755e0
+      - b30e1c7f-f942-40a6-a321-830ded6baae4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2046,15 +2078,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Ntu5DTZickqN6c9T
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_7Bh60E8rzVXXhogw
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2064,19 +2098,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:49 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:38:21 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "602"
+      - "985"
       X-Request-Id:
-      - edf1803b-c687-45f7-bb95-fd3aeb7aa2a8
+      - 4f38c0d3-44f9-4357-a394-eafe00a7ef99
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2087,15 +2121,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GxsiO1h6yadD4mCe
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2105,19 +2141,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:49 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:38:21 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "601"
+      - "984"
       X-Request-Id:
-      - 1cab7f03-d4d3-47a8-b022-62d0fa7a47c9
+      - a8924425-0d46-4075-8839-d60f461e9914
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_custom_disks.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_custom_disks.cassette.rand_id
@@ -1,1 +1,1 @@
-60oecmg99jo4
+rbf4a6hltk1i

--- a/internal/provider/testdata/VirtualMachine_custom_disks.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_custom_disks.cassette.yaml
@@ -8,36 +8,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:59 GMT
+      - Thu, 06 Feb 2025 16:38:43 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "755"
+      - "983"
       X-Request-Id:
-      - 06eeeb6d-82bf-4122-806a-f2d33405d629
+      - d5d8f5ea-018c-4d4a-af4a-6aaac8e5876c
     status: 200 OK
     code: 200
     duration: ""
@@ -48,42 +50,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:59 GMT
+      - Thu, 06 Feb 2025 16:38:43 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "753"
+      - "983"
       X-Request-Id:
-      - 6627e229-0d4e-48ea-8ef5-375f647d54ed
+      - 8de991d4-c0ea-4c30-a5f3-13096cac35eb
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -91,292 +95,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "151"
+      - "174"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:59 GMT
+      - Thu, 06 Feb 2025 16:38:43 GMT
       Etag:
-      - W/"1addb9255ff4b9701d57f7d0e1ffe550"
-      Server:
-      - Caddy
+      - W/"3c56d481916727b9a0c60c26f020f739"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "755"
-      X-Request-Id:
-      - b5240f24-d1c4-4541-aeb2-b9291b90bebd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_CfcJPNyc3V7z2tXV
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "151"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:59 GMT
-      Etag:
-      - W/"1addb9255ff4b9701d57f7d0e1ffe550"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "750"
-      X-Request-Id:
-      - 5d5170f5-ae81-4839-87a3-9d6edcf9f0da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
-    method: POST
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "549"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:59 GMT
-      Etag:
-      - W/"137b10129b421fd5b21a6014fed1266d"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "752"
-      X-Request-Id:
-      - 8bbd14a4-1e2a-4730-ad4a-6ee2700cad8d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:59 GMT
-      Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "749"
-      X-Request-Id:
-      - 1cc36026-a6db-43ee-9f6d-b87f1b4e9275
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
-    method: POST
-  response:
-    body: '{"ip_address":{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"185-199-222-119.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "552"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:03 GMT
-      Etag:
-      - W/"623d37a13a3700137b770cc5f4589b01"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "752"
-      X-Request-Id:
-      - a5e7f868-0507-4197-b2ca-445799f0a221
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GFrUx6wamsDhc6Gr
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"185-199-222-119.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "570"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:03 GMT
-      Etag:
-      - W/"0d1a5d5aefb0b0a2c1907cac5e6055d6"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "982"
-      X-Request-Id:
-      - 59243721-4c67-42c4-a71c-338cc25bcd04
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "567"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:03 GMT
-      Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "981"
       X-Request-Id:
-      - 077371e6-31bd-41a2-9770-2e4f4c9ae9f8
+      - a496d247-deb4-42cb-ac09-3947493d5d08
     status: 200 OK
     code: 200
     duration: ""
@@ -387,44 +137,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GFrUx6wamsDhc6Gr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_0684zL75GSDRG59e
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"185-199-222-119.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "174"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:03 GMT
+      - Thu, 06 Feb 2025 16:38:43 GMT
       Etag:
-      - W/"0d1a5d5aefb0b0a2c1907cac5e6055d6"
-      Server:
-      - Caddy
+      - W/"3c56d481916727b9a0c60c26f020f739"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "980"
+      - "978"
       X-Request-Id:
-      - bc3dad4d-ed03-4d31-ab95-a3dc31f3cfc7
+      - 41528ea5-e8ae-4756-9133-bb4e39c48120
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><SystemDisks><Disk><Name>System</Name><Size>20</Size></Disk><Disk><Name>Data</Name><Size>10</Size></Disk><Disk><Name>Disk #3</Name><Size>10</Size></Disk></SystemDisks><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_hc3GUyhBe6toov2e</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_GFrUx6wamsDhc6Gr</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-custom-disks-60oecmg99jo4-host</Hostname></Hostname><Name>tf-acc-test-custom-disks-60oecmg99jo4</Name><Description>A web server.</Description><Group>vmgrp_CfcJPNyc3V7z2tXV</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
     form: {}
     headers:
       Accept:
@@ -432,36 +182,308 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"task":{"id":"task_PsJmiouIKSXPBKea","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_r3jxoJdKbPPETejg","state":"pending"},"virtual_machine_build":{"id":"vmbuild_r3jxoJdKbPPETejg","state":"pending"},"hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host"}'
+    body: '{"ip_address":{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"185-44-255-61.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "281"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:03 GMT
+      - Thu, 06 Feb 2025 16:38:43 GMT
       Etag:
-      - W/"3258239bc9a64a3c16607190f582e20c"
-      Server:
-      - Caddy
+      - W/"05b80b8f27d750e739196ff889284380"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - e9c16e9f-bbc9-47b2-9ab5-f63f0be5a280
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BSxwzRIsOu4xO3P
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"185-44-255-61.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "576"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:38:43 GMT
+      Etag:
+      - W/"46854eec9f27a5b2bb4123dd60efc0c7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - 5f8a6dc8-f59b-4702-bc18-3fc2e93237c9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"network":{"id":"netw_gVRkZdSKczfNg34P"},"version":"ipv4"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
+    method: POST
+  response:
+    body: '{"ip_address":{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"185-44-255-250.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "561"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:38:43 GMT
+      Etag:
+      - W/"20a460f28ad88e7a2e9fbbfba6f74315"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - 72bf70af-4fdf-45ba-a536-ab1bd39859b7
+      - d89a0451-58d1-46c3-8885-6d1c847b8a0c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WIJgMVT5VcIFI6br
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"185-44-255-250.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "579"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:38:43 GMT
+      Etag:
+      - W/"1a848845b5471cf15a3cb45a186bd08a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - ae651cb1-6200-4541-894a-89a5a353c056
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WIJgMVT5VcIFI6br
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"185-44-255-250.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "579"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:38:43 GMT
+      Etag:
+      - W/"1a848845b5471cf15a3cb45a186bd08a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 992536dd-9476-4ef6-9034-6bf81cd27988
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BSxwzRIsOu4xO3P
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"185-44-255-61.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "576"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:38:43 GMT
+      Etag:
+      - W/"46854eec9f27a5b2bb4123dd60efc0c7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - ad7afe63-ef7c-44a4-8461-d44c15a7bec6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><SystemDisks><Disk><Name>System</Name><Size>20</Size></Disk><Disk><Name>Data</Name><Size>10</Size></Disk><Disk><Name>Disk #3</Name><Size>10</Size></Disk></SystemDisks><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_WIJgMVT5VcIFI6br</IPAddress></IPAddressAllocation><IPAddressAllocation type=\"existing\"><IPAddress>ip_3BSxwzRIsOu4xO3P</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-custom-disks-rbf4a6hltk1i-host</Hostname></Hostname><Name>tf-acc-test-custom-disks-rbf4a6hltk1i</Name><Description>A web server.</Description><Group>vmgrp_0684zL75GSDRG59e</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
+    method: POST
+  response:
+    body: '{"task":{"id":"task_6ZQqY2Too6Rt4VBv","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_JQMY9t1Ts2iYJwGX","state":"pending"},"virtual_machine_build":{"id":"vmbuild_JQMY9t1Ts2iYJwGX","state":"pending"},"hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "298"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:38:43 GMT
+      Etag:
+      - W/"62f0d5e9b8036a5353db634fb75da7ba"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 1a55c48c-ab98-40ea-bce6-cb1136490dba
     status: 201 Created
     code: 201
     duration: ""
@@ -472,96 +494,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_r3jxoJdKbPPETejg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JQMY9t1Ts2iYJwGX
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_r3jxoJdKbPPETejg","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_JQMY9t1Ts2iYJwGX","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.119\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-60oecmg99jo4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-60oecmg99jo4\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_CfcJPNyc3V7z2tXV\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-rbf4a6hltk1i-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-rbf4a6hltk1i\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0684zL75GSDRG59e\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679595123}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738859923},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2431"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:05 GMT
+      - Thu, 06 Feb 2025 16:38:45 GMT
       Etag:
-      - W/"1d88b8d638cf601c7c12825b46cc7a8e"
-      Server:
-      - Caddy
+      - W/"043db973d14f12d83f19bd1a577a6500"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "975"
-      X-Request-Id:
-      - 7c305365-ccb1-4ba9-ab9d-dfcba6901698
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_r3jxoJdKbPPETejg
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_r3jxoJdKbPPETejg","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
-      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.119\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-60oecmg99jo4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-60oecmg99jo4\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_CfcJPNyc3V7z2tXV\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595123}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2662"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:10 GMT
-      Etag:
-      - W/"8587383dfb27e154bbc97491c7ba1663"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "972"
       X-Request-Id:
-      - 4330bc61-aacd-4810-87a4-e7bb38a93eb1
+      - a8a8f522-4642-497b-9d78-c083cf3cbd52
     status: 200 OK
     code: 200
     duration: ""
@@ -572,46 +544,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_r3jxoJdKbPPETejg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JQMY9t1Ts2iYJwGX
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_r3jxoJdKbPPETejg","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_JQMY9t1Ts2iYJwGX","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.119\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-60oecmg99jo4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-60oecmg99jo4\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_CfcJPNyc3V7z2tXV\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-rbf4a6hltk1i-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-rbf4a6hltk1i\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0684zL75GSDRG59e\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595123}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738859923},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2662"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:20 GMT
+      - Thu, 06 Feb 2025 16:38:51 GMT
       Etag:
-      - W/"8587383dfb27e154bbc97491c7ba1663"
-      Server:
-      - Caddy
+      - W/"043db973d14f12d83f19bd1a577a6500"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "952"
+      - "971"
       X-Request-Id:
-      - 1d36f82b-47ff-424a-b402-f488c532d9aa
+      - a0d44fc1-040c-4a8f-830b-c583b2b54436
     status: 200 OK
     code: 200
     duration: ""
@@ -622,52 +594,152 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_r3jxoJdKbPPETejg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JQMY9t1Ts2iYJwGX
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_r3jxoJdKbPPETejg","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_JQMY9t1Ts2iYJwGX","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
       #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.119\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-60oecmg99jo4-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-60oecmg99jo4\u003c/Name\u003e\n  \u003cDescription\u003eA
-      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_CfcJPNyc3V7z2tXV\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-rbf4a6hltk1i-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-rbf4a6hltk1i\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0684zL75GSDRG59e\u003c/Group\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595123}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738859923},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2662"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:30 GMT
+      - Thu, 06 Feb 2025 16:39:01 GMT
       Etag:
-      - W/"68aa944b84920986838f509f5178d2c8"
-      Server:
-      - Caddy
+      - W/"ca6714a40e7943ef3b0ec3108c804078"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "943"
+      - "999"
       X-Request-Id:
-      - dca232f8-ee5e-4198-8384-a5df7cedf259
+      - ee7ea8d7-f333-4d06-a541-78ec476156bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JQMY9t1Ts2iYJwGX
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_JQMY9t1Ts2iYJwGX","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
+      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-rbf4a6hltk1i-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-rbf4a6hltk1i\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0684zL75GSDRG59e\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738859923},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:39:11 GMT
+      Etag:
+      - W/"ca6714a40e7943ef3b0ec3108c804078"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 4edac3aa-1635-4491-943c-07a469e8cd43
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_JQMY9t1Ts2iYJwGX
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_JQMY9t1Ts2iYJwGX","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cSystemDisks\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eSystem\u003c/Name\u003e\n      \u003cSize\u003e20\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eData\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n    \u003cDisk\u003e\n      \u003cName\u003eDisk
+      #3\u003c/Name\u003e\n      \u003cSize\u003e10\u003c/Size\u003e\n    \u003c/Disk\u003e\n  \u003c/SystemDisks\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.250\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-custom-disks-rbf4a6hltk1i-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-custom-disks-rbf4a6hltk1i\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cGroup\u003evmgrp_0684zL75GSDRG59e\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738859923},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:39:21 GMT
+      Etag:
+      - W/"4086b5b3fbc40e7c3b1f2d3ae5451fa6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 8c374c87-d766-47f6-a4e8-fda6f6963505
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -675,46 +747,47 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595124,"initial_root_password":"6RwkR1uImGDQgaNt","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859931,"initial_root_password":"ZmAxITlIDcQKJKRG","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:30 GMT
+      - Thu, 06 Feb 2025 16:39:21 GMT
       Etag:
-      - W/"b66dc56c9c8fb3031e395bf683b0413b"
-      Server:
-      - Caddy
+      - W/"eb8f34b0c29c0e65e3b33b1472aa5df2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "942"
+      - "996"
       X-Request-Id:
-      - de6dbdaa-ce33-45a9-a132-2f457029b9b4
+      - 432c78a8-6c98-4cf6-970d-bb319f72ea37
     status: 200 OK
     code: 200
     duration: ""
@@ -725,46 +798,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595124,"initial_root_password":"6RwkR1uImGDQgaNt","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859931,"initial_root_password":"ZmAxITlIDcQKJKRG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"b66dc56c9c8fb3031e395bf683b0413b"
-      Server:
-      - Caddy
+      - W/"eae7be9b05eced5ecfde75bf3a300503"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "938"
+      - "995"
       X-Request-Id:
-      - dd2cf0e1-c9fd-40e0-85e2-c1e60dbb5076
+      - 1d134cca-4704-485b-bc77-7a10bf01cd6f
     status: 200 OK
     code: 200
     duration: ""
@@ -775,46 +849,131 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595124,"initial_root_password":"6RwkR1uImGDQgaNt","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859931,"initial_root_password":"ZmAxITlIDcQKJKRG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:39:23 GMT
+      Etag:
+      - W/"eae7be9b05eced5ecfde75bf3a300503"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 9908be95-9e00-4d31-af9f-7501b3101154
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_pkiw2ADU1zQRif49","name":"Public
+      Network on tf-acc-test-custom-disks-rbf4a6hltk1i","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3166"
+      - "443"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"b66dc56c9c8fb3031e395bf683b0413b"
-      Server:
-      - Caddy
+      - W/"d809bc5f0cd32953b9e29a13b3104561"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "937"
+      - "993"
       X-Request-Id:
-      - 51c5d8b6-cfd5-4c0b-b9dc-021fb66f774d
+      - 7e8989cc-cd53-40c5-80b4-63f2557e58c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_pkiw2ADU1zQRif49
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_pkiw2ADU1zQRif49","virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i"},"name":"Public
+      Network on tf-acc-test-custom-disks-rbf4a6hltk1i","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:75:3f:3b:ed:66","state":"detached","ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "578"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:39:23 GMT
+      Etag:
+      - W/"fb91cf2d4686f2fb3c736e6353508cd1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - baa80a20-6ef1-4252-b264-60338ec524c3
     status: 200 OK
     code: 200
     duration: ""
@@ -825,38 +984,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_pkiw2ADU1zQRif49
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rfTejz5be0RmEU33","name":"Public
-      Network on tf-acc-test-custom-disks-60oecmg99jo4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_pkiw2ADU1zQRif49","virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i"},"name":"Public
+      Network on tf-acc-test-custom-disks-rbf4a6hltk1i","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:75:3f:3b:ed:66","state":"detached","ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "421"
+      - "578"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"47f1ffd12650813e8d2b134f84b73bdc"
-      Server:
-      - Caddy
+      - W/"fb91cf2d4686f2fb3c736e6353508cd1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "936"
+      - "991"
       X-Request-Id:
-      - e1789672-e346-4014-b20f-0275c5a72330
+      - 994f17c3-8809-4464-9906-82fdbc0f5b68
     status: 200 OK
     code: 200
     duration: ""
@@ -867,88 +1028,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rfTejz5be0RmEU33
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rfTejz5be0RmEU33","virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4"},"name":"Public
-      Network on tf-acc-test-custom-disks-60oecmg99jo4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:35:6b:39:4d:eb","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "557"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
-      Etag:
-      - W/"088af8ae8e8cc9563c1c4e9c32a5f677"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "935"
-      X-Request-Id:
-      - 4648d46c-6468-4bf2-9a1c-7d56fc1de4ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595124,"initial_root_password":"6RwkR1uImGDQgaNt","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859931,"initial_root_password":"ZmAxITlIDcQKJKRG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"b66dc56c9c8fb3031e395bf683b0413b"
-      Server:
-      - Caddy
+      - W/"eae7be9b05eced5ecfde75bf3a300503"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "934"
+      - "990"
       X-Request-Id:
-      - 7a12980e-8347-4231-95d2-00064b0b85d4
+      - 8164f3e5-382f-4db3-bf6e-c55b039d6ada
     status: 200 OK
     code: 200
     duration: ""
@@ -959,36 +1079,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_CfcJPNyc3V7z2tXV
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_0684zL75GSDRG59e
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "151"
+      - "174"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"1addb9255ff4b9701d57f7d0e1ffe550"
-      Server:
-      - Caddy
+      - W/"3c56d481916727b9a0c60c26f020f739"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "932"
+      - "988"
       X-Request-Id:
-      - fe50518b-e19a-4cf1-a733-ad6b4be647ac
+      - d169ad36-826f-48a4-b721-afee2cbb8982
     status: 200 OK
     code: 200
     duration: ""
@@ -999,38 +1121,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BSxwzRIsOu4xO3P
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4"}}}'
+    body: '{"ip_address":{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "743"
+      - "756"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"0b28269dcf97e040f617c197940e384c"
-      Server:
-      - Caddy
+      - W/"fd0dcdb2c7a134aab386ca0adccdcb9f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "933"
+      - "989"
       X-Request-Id:
-      - 1760f96c-70b4-4ec4-a270-7ea196fc81c5
+      - fca6668e-403f-4bcb-a342-e9424d77154e
     status: 200 OK
     code: 200
     duration: ""
@@ -1041,38 +1165,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GFrUx6wamsDhc6Gr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WIJgMVT5VcIFI6br
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4"}}}'
+    body: '{"ip_address":{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "745"
+      - "758"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"85d45b8fe7643538f56812adf20cf3c1"
-      Server:
-      - Caddy
+      - W/"d47570ac2e6840d3fec79a6b69c53890"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "932"
+      - "988"
       X-Request-Id:
-      - 5131d984-68e1-4f3f-8c88-0681f75cad66
+      - e2e6c63f-e494-4e5f-be74-0ab7d78d6406
     status: 200 OK
     code: 200
     duration: ""
@@ -1083,46 +1209,131 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595124,"initial_root_password":"6RwkR1uImGDQgaNt","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859931,"initial_root_password":"ZmAxITlIDcQKJKRG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:39:23 GMT
+      Etag:
+      - W/"eae7be9b05eced5ecfde75bf3a300503"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 57384b7b-29f4-4cf4-8266-35b56480d04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_pkiw2ADU1zQRif49","name":"Public
+      Network on tf-acc-test-custom-disks-rbf4a6hltk1i","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "3166"
+      - "443"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"b66dc56c9c8fb3031e395bf683b0413b"
-      Server:
-      - Caddy
+      - W/"d809bc5f0cd32953b9e29a13b3104561"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "930"
+      - "985"
       X-Request-Id:
-      - b881c254-3c9c-4321-a006-b8727a16a799
+      - 10c61e80-5909-41d6-ba81-e00fc5a6b334
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_pkiw2ADU1zQRif49
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_pkiw2ADU1zQRif49","virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i"},"name":"Public
+      Network on tf-acc-test-custom-disks-rbf4a6hltk1i","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:75:3f:3b:ed:66","state":"attached","ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "578"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:39:23 GMT
+      Etag:
+      - W/"57d17d581286aa270cc36dbe9ac51226"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 0e13f73a-3cae-4d34-af49-868e16af27d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1133,38 +1344,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_pkiw2ADU1zQRif49
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rfTejz5be0RmEU33","name":"Public
-      Network on tf-acc-test-custom-disks-60oecmg99jo4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_pkiw2ADU1zQRif49","virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i"},"name":"Public
+      Network on tf-acc-test-custom-disks-rbf4a6hltk1i","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:75:3f:3b:ed:66","state":"attached","ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "421"
+      - "578"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:32 GMT
+      - Thu, 06 Feb 2025 16:39:23 GMT
       Etag:
-      - W/"47f1ffd12650813e8d2b134f84b73bdc"
-      Server:
-      - Caddy
+      - W/"57d17d581286aa270cc36dbe9ac51226"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "929"
+      - "983"
       X-Request-Id:
-      - ebece1db-cc6f-42e6-8e58-2fe986bd80d6
+      - 4d43a866-10b4-4866-975e-51dbdc2953da
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,88 +1388,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rfTejz5be0RmEU33
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rfTejz5be0RmEU33","virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4"},"name":"Public
-      Network on tf-acc-test-custom-disks-60oecmg99jo4","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:35:6b:39:4d:eb","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "557"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:33 GMT
-      Etag:
-      - W/"088af8ae8e8cc9563c1c4e9c32a5f677"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "928"
-      X-Request-Id:
-      - 0d42ca14-cbd9-47dd-92a3-0d414e9c434f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595124,"initial_root_password":"6RwkR1uImGDQgaNt","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859931,"initial_root_password":"ZmAxITlIDcQKJKRG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:33 GMT
+      - Thu, 06 Feb 2025 16:39:24 GMT
       Etag:
-      - W/"b66dc56c9c8fb3031e395bf683b0413b"
-      Server:
-      - Caddy
+      - W/"eae7be9b05eced5ecfde75bf3a300503"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "927"
+      - "982"
       X-Request-Id:
-      - 41c0c434-a58c-4c7e-bbfc-4bf51cc5d19d
+      - 578fec4f-aeb2-4cc1-a1e9-385333fd82f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,14 +1439,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: POST
   response:
-    body: '{"task":{"id":"task_YVrA8RtO6AZUjEn5","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_2h5uxnRfCEwDwjZL","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1284,19 +1458,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:33 GMT
+      - Thu, 06 Feb 2025 16:39:24 GMT
       Etag:
-      - W/"c84067e3e4ce9d3fe816b3c6be5b3604"
-      Server:
-      - Caddy
+      - W/"be569e879fa6b9fd72c57255829d9927"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "926"
+      - "981"
       X-Request-Id:
-      - 0ea50e03-c32b-43da-ae40-6c3dec2925aa
+      - 86781c39-295d-4977-9172-7b0747c861cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1307,14 +1481,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_YVrA8RtO6AZUjEn5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_2h5uxnRfCEwDwjZL
     method: GET
   response:
-    body: '{"task":{"id":"task_YVrA8RtO6AZUjEn5","name":"Stop virtual machine","status":"pending","created_at":1679595153,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_2h5uxnRfCEwDwjZL","name":"Stop virtual machine","status":"pending","created_at":1738859964,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1324,19 +1500,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:34 GMT
+      - Thu, 06 Feb 2025 16:39:25 GMT
       Etag:
-      - W/"2a2a9147b55c5c4b8e63f30211ab69ec"
-      Server:
-      - Caddy
+      - W/"56041eed9da1a68faf0319f094f27ad6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "925"
+      - "980"
       X-Request-Id:
-      - daa716d7-8804-4a38-a137-94b1d717930c
+      - 943d9d12-3bc5-46ba-b1c6-7bbc2f179c0b
     status: 200 OK
     code: 200
     duration: ""
@@ -1347,14 +1523,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_YVrA8RtO6AZUjEn5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_2h5uxnRfCEwDwjZL
     method: GET
   response:
-    body: '{"task":{"id":"task_YVrA8RtO6AZUjEn5","name":"Stop virtual machine","status":"pending","created_at":1679595153,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_2h5uxnRfCEwDwjZL","name":"Stop virtual machine","status":"pending","created_at":1738859964,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1364,19 +1542,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:39 GMT
+      - Thu, 06 Feb 2025 16:39:30 GMT
       Etag:
-      - W/"2a2a9147b55c5c4b8e63f30211ab69ec"
-      Server:
-      - Caddy
+      - W/"56041eed9da1a68faf0319f094f27ad6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "918"
+      - "979"
       X-Request-Id:
-      - 0e5aac8d-5467-4e6e-bf56-e4b49d3163b3
+      - d4315646-48b1-4832-ac2a-455fdf60a987
     status: 200 OK
     code: 200
     duration: ""
@@ -1387,36 +1565,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_YVrA8RtO6AZUjEn5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_2h5uxnRfCEwDwjZL
     method: GET
   response:
-    body: '{"task":{"id":"task_YVrA8RtO6AZUjEn5","name":"Stop virtual machine","status":"running","created_at":1679595153,"started_at":1679595168,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_2h5uxnRfCEwDwjZL","name":"Stop virtual machine","status":"pending","created_at":1738859964,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "162"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:49 GMT
+      - Thu, 06 Feb 2025 16:39:40 GMT
       Etag:
-      - W/"08d4f632af26b484f610fffc94c5ed8b"
-      Server:
-      - Caddy
+      - W/"56041eed9da1a68faf0319f094f27ad6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "908"
+      - "978"
       X-Request-Id:
-      - c9a648bc-5050-416d-95f7-1a35c1f51c79
+      - d6e76cfb-bd1e-42be-bcae-aae5a1f1a716
     status: 200 OK
     code: 200
     duration: ""
@@ -1427,14 +1607,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_YVrA8RtO6AZUjEn5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_2h5uxnRfCEwDwjZL
     method: GET
   response:
-    body: '{"task":{"id":"task_YVrA8RtO6AZUjEn5","name":"Stop virtual machine","status":"completed","created_at":1679595153,"started_at":1679595168,"finished_at":1679595173,"progress":100}}'
+    body: '{"task":{"id":"task_2h5uxnRfCEwDwjZL","name":"Stop virtual machine","status":"completed","created_at":1738859964,"started_at":1738859983,"finished_at":1738859985,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1444,19 +1626,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:59 GMT
+      - Thu, 06 Feb 2025 16:39:50 GMT
       Etag:
-      - W/"1662873191d9aa9d7ce1df6b3e7892fd"
-      Server:
-      - Caddy
+      - W/"8fcbff43d49b725b3bd3ae4a64cbf07d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "874"
+      - "977"
       X-Request-Id:
-      - 993391e8-4c93-4ea8-9c05-81d82a7b8b5a
+      - d4fc6909-4f97-414d-8221-1751ddcc486d
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,46 +1649,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595124,"initial_root_password":"6RwkR1uImGDQgaNt","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859931,"initial_root_password":"ZmAxITlIDcQKJKRG","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3166"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
+      - Thu, 06 Feb 2025 16:39:51 GMT
       Etag:
-      - W/"465c28e3f50d97056e26dc3f0126c5a2"
-      Server:
-      - Caddy
+      - W/"b2e5fcef6a3520edda22fc2e375328a0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "976"
       X-Request-Id:
-      - b087e21e-623c-4768-a30b-6ea0f1a72009
+      - 56bce34b-f9f9-4b6f-a92f-19af3282fd96
     status: 200 OK
     code: 200
     duration: ""
@@ -1517,46 +1700,47 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_h0oQmxn9mhkcO3Jx","keep_until":1679767980,"object_id":"vm_SHTGtn5WGvpqYxRB","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_SHTGtn5WGvpqYxRB","name":"tf-acc-test-custom-disks-60oecmg99jo4","hostname":"tf-acc-test-custom-disks-60oecmg99jo4-host","fqdn":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595124,"initial_root_password":"6RwkR1uImGDQgaNt","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_REI0fNojrp13x0Dt","keep_until":1739032791,"object_id":"vm_zpGuyZkkBASSY2PR","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_zpGuyZkkBASSY2PR","name":"tf-acc-test-custom-disks-rbf4a6hltk1i","hostname":"tf-acc-test-custom-disks-rbf4a6hltk1i-host","fqdn":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738859931,"initial_root_password":"ZmAxITlIDcQKJKRG","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"},{"id":"ip_GFrUx6wamsDhc6Gr","address":"185.199.222.119","reverse_dns":"tf-acc-test-custom-disks-60oecmg99jo4-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.119/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_SHTGtn5WGvpqYxRB","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_3BSxwzRIsOu4xO3P","address":"185.44.255.61","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"},{"id":"ip_WIJgMVT5VcIFI6br","address":"185.44.255.250","reverse_dns":"tf-acc-test-custom-disks-rbf4a6hltk1i-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.250/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zpGuyZkkBASSY2PR","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "3301"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
+      - Thu, 06 Feb 2025 16:39:51 GMT
       Etag:
-      - W/"4d21485dedbec6c94f9c9e49087c66a7"
-      Server:
-      - Caddy
+      - W/"73e4b934b7c2647f70ea466b27754c38"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "975"
       X-Request-Id:
-      - 0a87600c-158f-4a21-9511-eca2c0346bbb
+      - a866d7ef-1c82-4373-bcaa-d7949179557b
     status: 200 OK
     code: 200
     duration: ""
@@ -1567,14 +1751,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_WIJgMVT5VcIFI6br
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1584,19 +1770,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:01 GMT
+      - Thu, 06 Feb 2025 16:39:52 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "974"
       X-Request-Id:
-      - ce55974e-abda-4448-919e-7eed41d71395
+      - 45be2549-fe5c-472c-b304-e9fa7418944f
     status: 200 OK
     code: 200
     duration: ""
@@ -1607,14 +1793,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_GFrUx6wamsDhc6Gr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_3BSxwzRIsOu4xO3P
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1624,19 +1812,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:01 GMT
+      - Thu, 06 Feb 2025 16:39:52 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "973"
       X-Request-Id:
-      - d1aaf2c9-9cb9-46e8-ac03-d51fb1ee4964
+      - c6f6295d-e4a2-4e7a-b481-e34686c5c283
     status: 200 OK
     code: 200
     duration: ""
@@ -1647,14 +1835,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zpGuyZkkBASSY2PR
     method: DELETE
   response:
-    body: '{"task":{"id":"task_LWbIB7gFr81VUFC1","name":"Purge items from trash","status":"pending","created_at":1679595181,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_ZfOxsTeMCjnquB9t","name":"Purge items from trash","status":"pending","created_at":1738859992,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1664,19 +1854,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:01 GMT
+      - Thu, 06 Feb 2025 16:39:52 GMT
       Etag:
-      - W/"01ac46d1656a5435f3b394d01f3a51a4"
-      Server:
-      - Caddy
+      - W/"e2d3c5e4c15b1752c15cde41d937ef2f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "972"
       X-Request-Id:
-      - e47c1551-8996-47ec-8f9b-a15e866b14c5
+      - d730a149-af53-4149-a4b3-6677a56383a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1687,14 +1877,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_h0oQmxn9mhkcO3Jx","keep_until":1679767980,"object_id":"vm_SHTGtn5WGvpqYxRB","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_REI0fNojrp13x0Dt","keep_until":1739032791,"object_id":"vm_zpGuyZkkBASSY2PR","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1704,19 +1896,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:02 GMT
+      - Thu, 06 Feb 2025 16:39:53 GMT
       Etag:
-      - W/"dae7565a7b9b3101db702d0cf76148d9"
-      Server:
-      - Caddy
+      - W/"91461d87e3686d4565d708553c6b51c9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "981"
+      - "971"
       X-Request-Id:
-      - c5d939fe-9522-49fc-9862-22dd17f210cb
+      - 4de63b8d-2777-492a-a517-868d69c78d8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1727,95 +1919,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_SHTGtn5WGvpqYxRB
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_h0oQmxn9mhkcO3Jx","keep_until":1679767980,"object_id":"vm_SHTGtn5WGvpqYxRB","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:07 GMT
-      Etag:
-      - W/"dae7565a7b9b3101db702d0cf76148d9"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - 99df4a72-f6dd-4ac7-9a9c-3305c6100fc0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_SHTGtn5WGvpqYxRB
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_h0oQmxn9mhkcO3Jx","keep_until":1679767980,"object_id":"vm_SHTGtn5WGvpqYxRB","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:17 GMT
-      Etag:
-      - W/"dae7565a7b9b3101db702d0cf76148d9"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - 4e5654cc-16d1-41c1-b868-2c964b7984c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1825,19 +1939,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:39:58 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "970"
       X-Request-Id:
-      - e2a93669-9320-43d2-aca8-90e4e07c20d3
+      - 7b4f0fe8-3fa1-4ec9-8c6c-719ef4b2827a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1848,36 +1962,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_CfcJPNyc3V7z2tXV
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_0684zL75GSDRG59e
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_CfcJPNyc3V7z2tXV","name":"tf-acc-test-custom-disks-60oecmg99jo4-group","segregate":true,"created_at":1679595119}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_0684zL75GSDRG59e","name":"tf-acc-test-custom-disks-rbf4a6hltk1i-group","segregate":true,"auto_segregate":false,"created_at":1738859923}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "151"
+      - "174"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
+      - Thu, 06 Feb 2025 16:39:58 GMT
       Etag:
-      - W/"1addb9255ff4b9701d57f7d0e1ffe550"
-      Server:
-      - Caddy
+      - W/"3c56d481916727b9a0c60c26f020f739"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "919"
+      - "968"
       X-Request-Id:
-      - 68aa5a1f-02d3-4c80-a37f-9f314a04f22f
+      - 62b9df01-fd74-4b63-bc29-0920a4ea4544
     status: 200 OK
     code: 200
     duration: ""
@@ -1888,14 +2004,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BSxwzRIsOu4xO3P
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1905,19 +2023,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
+      - Thu, 06 Feb 2025 16:39:58 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "918"
+      - "969"
       X-Request-Id:
-      - 313c26e0-f351-41bc-bdd1-933512de38c4
+      - bd7cf99a-26d0-439c-9671-94011c60c411
     status: 200 OK
     code: 200
     duration: ""
@@ -1928,14 +2046,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GFrUx6wamsDhc6Gr
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WIJgMVT5VcIFI6br
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1945,19 +2065,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
+      - Thu, 06 Feb 2025 16:39:58 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "968"
       X-Request-Id:
-      - 23422ac0-aa05-4337-b3a9-fe502064f633
+      - f8fa422c-ec8a-43bd-b613-8b35a55d207a
     status: 200 OK
     code: 200
     duration: ""
@@ -1968,15 +2088,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1986,19 +2108,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:39:59 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "914"
+      - "966"
       X-Request-Id:
-      - a8fd0478-8b6e-4f39-8fcd-51a42e9c56ad
+      - d6835280-7839-4689-93fe-cf5e8e9a8988
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2009,15 +2131,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_SHTGtn5WGvpqYxRB
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zpGuyZkkBASSY2PR
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2027,19 +2151,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:39:59 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "913"
+      - "965"
       X-Request-Id:
-      - 17207bec-9a88-4174-8d29-23b4fcff65ef
+      - 1a900c31-6a70-4936-8d45-0450bc9b64e3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2050,15 +2174,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_3BSxwzRIsOu4xO3P
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2068,19 +2194,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:39:59 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "911"
+      - "964"
       X-Request-Id:
-      - f374645d-1d83-45bb-8d48-160b4303b4cf
+      - 870e9bd7-975e-44ff-a5db-83e3e51fac91
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2091,15 +2217,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_GFrUx6wamsDhc6Gr
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_WIJgMVT5VcIFI6br
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2109,19 +2237,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:39:59 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "910"
+      - "963"
       X-Request-Id:
-      - 2ff3658e-109d-4a61-8c2e-89d703620894
+      - d959665a-a92c-4ead-8ce3-378ab0c58f22
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_minimal.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_minimal.cassette.yaml
@@ -8,36 +8,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:37 GMT
+      - Thu, 06 Feb 2025 16:35:42 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "920"
+      - "999"
       X-Request-Id:
-      - b129e251-a94a-47f6-9b98-2af2d132c9e1
+      - 30d1a9ef-6d41-4bcd-ac9c-acdb3e8484e7
     status: 200 OK
     code: 200
     duration: ""
@@ -51,38 +53,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"185-44-253-210.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:40 GMT
+      - Thu, 06 Feb 2025 16:35:43 GMT
       Etag:
-      - W/"3a687f736929f55327502ce877b5ad62"
-      Server:
-      - Caddy
+      - W/"ac48af471949ea932bc69f28e701a904"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "919"
+      - "998"
       X-Request-Id:
-      - 49cc245b-9fce-4c72-bd99-712d2ad10b6d
+      - 5cec80f0-230a-47d6-862d-65ea82b71878
     status: 200 OK
     code: 200
     duration: ""
@@ -93,38 +97,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Q3k1LZddqvzMH21b
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"185-44-253-210.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:40 GMT
+      - Thu, 06 Feb 2025 16:35:43 GMT
       Etag:
-      - W/"b5edb1f478fa37e762d80d507cfdce5d"
-      Server:
-      - Caddy
+      - W/"7b30581a66dbe2a255d47bb0ec3cbbee"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "997"
       X-Request-Id:
-      - 1c3903d6-ad64-4acc-a3a8-a4188662b715
+      - 6405fd1d-1648-4fb1-818e-0b9086138ee8
     status: 200 OK
     code: 200
     duration: ""
@@ -135,44 +141,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Q3k1LZddqvzMH21b
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"185-199-222-126.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"185-44-253-210.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:40 GMT
+      - Thu, 06 Feb 2025 16:35:43 GMT
       Etag:
-      - W/"b5edb1f478fa37e762d80d507cfdce5d"
-      Server:
-      - Caddy
+      - W/"7b30581a66dbe2a255d47bb0ec3cbbee"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "916"
+      - "996"
       X-Request-Id:
-      - e60add15-8d58-4d1e-a01c-0bfdc5f36333
+      - 00e01513-99c9-4e02-ba18-c2247231f749
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_ThTjuc3gzLUgUUVg</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-northern-kind-tungsten</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_Q3k1LZddqvzMH21b</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-turquoise-young-sunflower</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -180,36 +188,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_p7n63YkUVtw1GFqS","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_EycIGMBvk9SUpGjM","state":"pending"},"virtual_machine_build":{"id":"vmbuild_EycIGMBvk9SUpGjM","state":"pending"},"hostname":"tf-acc-test-northern-kind-tungsten"}'
+    body: '{"task":{"id":"task_2j1QaAhJ3Bu1cVKr","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_fYvd3dOJZWBgpoY8","state":"pending"},"virtual_machine_build":{"id":"vmbuild_fYvd3dOJZWBgpoY8","state":"pending"},"hostname":"tf-acc-test-turquoise-young-sunflower","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "273"
+      - "293"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:40 GMT
+      - Thu, 06 Feb 2025 16:35:43 GMT
       Etag:
-      - W/"46efb059c5a656ece9c6848a9c5dabde"
-      Server:
-      - Caddy
+      - W/"8fca57910dd179b98b1089a81d7403db"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "915"
+      - "995"
       X-Request-Id:
-      - 8a485774-82a3-4bdc-900d-9c3da500cb52
+      - 11a440f7-736c-46b4-8839-4d94d5149b7a
     status: 201 Created
     code: 201
     duration: ""
@@ -220,43 +230,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_EycIGMBvk9SUpGjM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_fYvd3dOJZWBgpoY8
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_EycIGMBvk9SUpGjM","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_fYvd3dOJZWBgpoY8","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-northern-kind-tungsten\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.210\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-turquoise-young-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1679595160}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738859743},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1385"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:43 GMT
+      - Thu, 06 Feb 2025 16:35:45 GMT
       Etag:
-      - W/"bf186bd09887da270fd675a6ce058869"
-      Server:
-      - Caddy
+      - W/"773218ebc17e0cf39905a9abaf0f4645"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "913"
+      - "994"
       X-Request-Id:
-      - 7fb0b8af-68d1-4428-a6cc-b79ec162e386
+      - aadd7b2b-c9d8-4037-b335-30703e70a4bc
     status: 200 OK
     code: 200
     duration: ""
@@ -267,357 +277,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_EycIGMBvk9SUpGjM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_fYvd3dOJZWBgpoY8
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_EycIGMBvk9SUpGjM","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_fYvd3dOJZWBgpoY8","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-northern-kind-tungsten\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.210\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-turquoise-young-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595160}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738859743},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1597"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:48 GMT
+      - Thu, 06 Feb 2025 16:35:50 GMT
       Etag:
-      - W/"c2377d9e493c38190d3a2daf7dbd2885"
-      Server:
-      - Caddy
+      - W/"2cf13cf15dfb4838321dabf302c2e821"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "909"
-      X-Request-Id:
-      - 7275c9e1-f5de-4b3f-ade6-ada2caf2f618
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_EycIGMBvk9SUpGjM
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_EycIGMBvk9SUpGjM","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.126\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-northern-kind-tungsten\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1679595160}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1598"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:58 GMT
-      Etag:
-      - W/"2c0f32e4e5586f56ac54bd412c43f804"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "875"
-      X-Request-Id:
-      - 729c4112-1df0-4a9e-95a4-1606d3c31fce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595162,"initial_root_password":"2BYlyiEeGC8jfbuv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Ro3aniKAKM6ZOlzo","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
-      Etag:
-      - W/"f888d5ac9c61e903da301e6eea29a377"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - 509ef812-1f45-4891-bb80-575a2b7965e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595162,"initial_root_password":"2BYlyiEeGC8jfbuv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Ro3aniKAKM6ZOlzo","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
-      Etag:
-      - W/"f888d5ac9c61e903da301e6eea29a377"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - 69fb417a-296f-40af-80c1-9894c635d54f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_etPA2B8wn3hZlEwI","name":"Public
-      Network on tf-acc-test-northern-kind-tungsten","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "362"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
-      Etag:
-      - W/"e81a797879b2aaae89dab053d1001aec"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - dcc0add1-725d-4ebe-a069-3f2f99c639df
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_etPA2B8wn3hZlEwI
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_etPA2B8wn3hZlEwI","virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten"},"name":"Public
-      Network on tf-acc-test-northern-kind-tungsten","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:07:03:be:66:b6","state":"detached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "497"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
-      Etag:
-      - W/"ba329306d24d3721fc231a5aa8456914"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 8fa2dda9-7055-451a-a426-27108aec695d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595162,"initial_root_password":"2BYlyiEeGC8jfbuv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Ro3aniKAKM6ZOlzo","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
-      Etag:
-      - W/"f888d5ac9c61e903da301e6eea29a377"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - e7b3ff48-d445-4ea5-a3de-00be5b84db64
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Ro3aniKAKM6ZOlzo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "734"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
-      Etag:
-      - W/"691d21760cce10c497f32b3a5e2dc77c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "993"
       X-Request-Id:
-      - 11a58f33-21e1-4f64-ad1c-bba3d38f58e1
+      - e6d729c6-2d1e-450b-a81b-ec7894c227cc
     status: 200 OK
     code: 200
     duration: ""
@@ -628,43 +324,361 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_fYvd3dOJZWBgpoY8
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595162,"initial_root_password":"2BYlyiEeGC8jfbuv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Ro3aniKAKM6ZOlzo","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_fYvd3dOJZWBgpoY8","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.210\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-turquoise-young-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738859743},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:00 GMT
+      Etag:
+      - W/"2cf13cf15dfb4838321dabf302c2e821"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - f12b94e8-a2bf-4bf3-a13f-52450d47f5d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_fYvd3dOJZWBgpoY8
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_fYvd3dOJZWBgpoY8","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.210\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-turquoise-young-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738859743},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:10 GMT
+      Etag:
+      - W/"2cf13cf15dfb4838321dabf302c2e821"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 70f52a84-38ad-42d0-942a-e1da886d3a10
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_fYvd3dOJZWBgpoY8
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_fYvd3dOJZWBgpoY8","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.210\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-turquoise-young-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1738859743},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:20 GMT
+      Etag:
+      - W/"a7ad88f090ccc83d15b4a350dd8e346f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - af72eab7-9e90-4fb3-8596-87e497cddbeb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1738859748,"initial_root_password":"D7HXvAwBiAyOlm8R","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_BKvJyKMNpd8nJQUB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:22 GMT
+      Etag:
+      - W/"14df705a3882896e8ea709d760099da9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 15f20c31-a649-4d9f-b854-adad654519a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1738859748,"initial_root_password":"D7HXvAwBiAyOlm8R","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_BKvJyKMNpd8nJQUB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:22 GMT
+      Etag:
+      - W/"14df705a3882896e8ea709d760099da9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 36e23171-cfbb-43b0-8a9f-8610178406a9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_l5YUc44t2vgcIQjn","name":"Public
+      Network on tf-acc-test-turquoise-young-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2212"
+      - "388"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
+      - Thu, 06 Feb 2025 16:36:22 GMT
       Etag:
-      - W/"f888d5ac9c61e903da301e6eea29a377"
-      Server:
-      - Caddy
+      - W/"ba55a10e48cdcaecc97b8b3147f8b83e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 96561069-8cb3-4df2-ae1d-7f310416841f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_l5YUc44t2vgcIQjn
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_l5YUc44t2vgcIQjn","virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower"},"name":"Public
+      Network on tf-acc-test-turquoise-young-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ac:f0:af:4d:c0","state":"attached","ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "525"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:22 GMT
+      Etag:
+      - W/"bfac499942efa2624f1e31385d41b399"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 8c9c3f62-b594-4522-8cac-7e7e977d1411
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_l5YUc44t2vgcIQjn
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_l5YUc44t2vgcIQjn","virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower"},"name":"Public
+      Network on tf-acc-test-turquoise-young-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ac:f0:af:4d:c0","state":"attached","ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "525"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:22 GMT
+      Etag:
+      - W/"bfac499942efa2624f1e31385d41b399"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "992"
       X-Request-Id:
-      - 3c4f3674-858a-4d65-8eb9-5984a320780d
+      - 490ee133-68b5-49fd-a557-0e5c5e5ee9d8
     status: 200 OK
     code: 200
     duration: ""
@@ -675,38 +689,88 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_etPA2B8wn3hZlEwI","name":"Public
-      Network on tf-acc-test-northern-kind-tungsten","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1738859748,"initial_root_password":"D7HXvAwBiAyOlm8R","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_BKvJyKMNpd8nJQUB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:22 GMT
+      Etag:
+      - W/"14df705a3882896e8ea709d760099da9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - a08c147f-deae-4c90-9b96-4bd9b29d613c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Q3k1LZddqvzMH21b
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_BKvJyKMNpd8nJQUB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "362"
+      - "753"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
+      - Thu, 06 Feb 2025 16:36:22 GMT
       Etag:
-      - W/"e81a797879b2aaae89dab053d1001aec"
-      Server:
-      - Caddy
+      - W/"99ee07b8b7f11e1c6afc00057e168e5a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "990"
       X-Request-Id:
-      - 08188e03-71fb-4530-a3f4-f051368d83b6
+      - 7fff395a-ddbd-4191-a917-e257f60d829a
     status: 200 OK
     code: 200
     duration: ""
@@ -717,38 +781,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_etPA2B8wn3hZlEwI
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_etPA2B8wn3hZlEwI","virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten"},"name":"Public
-      Network on tf-acc-test-northern-kind-tungsten","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:07:03:be:66:b6","state":"attached","ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1738859748,"initial_root_password":"D7HXvAwBiAyOlm8R","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_BKvJyKMNpd8nJQUB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "497"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
+      - Thu, 06 Feb 2025 16:36:23 GMT
       Etag:
-      - W/"93f3e1acb223065a18aead3ec421ff21"
-      Server:
-      - Caddy
+      - W/"14df705a3882896e8ea709d760099da9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "989"
       X-Request-Id:
-      - 8e951c46-4ac3-4f64-a026-2360e4f4a792
+      - 5a12fe20-384f-4bbe-9148-7140d0fd2102
     status: 200 OK
     code: 200
     duration: ""
@@ -756,46 +826,83 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595162,"initial_root_password":"2BYlyiEeGC8jfbuv","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Ro3aniKAKM6ZOlzo","allocation_type":"VirtualMachine"}]}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_l5YUc44t2vgcIQjn","name":"Public
+      Network on tf-acc-test-turquoise-young-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2212"
+      - "388"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
+      - Thu, 06 Feb 2025 16:36:23 GMT
       Etag:
-      - W/"f888d5ac9c61e903da301e6eea29a377"
-      Server:
-      - Caddy
+      - W/"ba55a10e48cdcaecc97b8b3147f8b83e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 9cd351d9-b48c-4cb9-a8e1-da0b087cceed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_l5YUc44t2vgcIQjn
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_l5YUc44t2vgcIQjn","virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower"},"name":"Public
+      Network on tf-acc-test-turquoise-young-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ac:f0:af:4d:c0","state":"attached","ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "525"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:23 GMT
+      Etag:
+      - W/"bfac499942efa2624f1e31385d41b399"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - d632a6af-00b4-4e1b-8798-2c945fd047b2
+      - e77b75b5-0008-48e5-9a26-88630d3b05bb
     status: 200 OK
     code: 200
     duration: ""
@@ -806,14 +913,108 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_l5YUc44t2vgcIQjn
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_l5YUc44t2vgcIQjn","virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower"},"name":"Public
+      Network on tf-acc-test-turquoise-young-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ac:f0:af:4d:c0","state":"attached","ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "525"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:23 GMT
+      Etag:
+      - W/"bfac499942efa2624f1e31385d41b399"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 54dc226c-b1b0-475b-b4f4-af26194a25a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1738859748,"initial_root_password":"D7HXvAwBiAyOlm8R","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_BKvJyKMNpd8nJQUB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:23 GMT
+      Etag:
+      - W/"14df705a3882896e8ea709d760099da9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 8ee0b7d4-b6a2-43a5-bbf0-d95eedb3f5fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
     method: POST
   response:
-    body: '{"task":{"id":"task_hP7aZjT0xFZQ20rf","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_Bn9HSqoV1ZCPJnr9","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -823,19 +1024,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:00 GMT
+      - Thu, 06 Feb 2025 16:36:23 GMT
       Etag:
-      - W/"fda48be5d78b22f313817ceba70d7113"
-      Server:
-      - Caddy
+      - W/"fad0336adf4f566fc1dc841adc0d2488"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "984"
       X-Request-Id:
-      - d21f2e1c-4c5a-4759-8950-22eea81e1d7a
+      - 513a177f-0f97-4b78-bc58-d7dc199a76b9
     status: 200 OK
     code: 200
     duration: ""
@@ -846,14 +1047,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_hP7aZjT0xFZQ20rf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_Bn9HSqoV1ZCPJnr9
     method: GET
   response:
-    body: '{"task":{"id":"task_hP7aZjT0xFZQ20rf","name":"Stop virtual machine","status":"pending","created_at":1679595180,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_Bn9HSqoV1ZCPJnr9","name":"Stop virtual machine","status":"pending","created_at":1738859783,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -863,19 +1066,61 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:01 GMT
+      - Thu, 06 Feb 2025 16:36:24 GMT
       Etag:
-      - W/"c4bf3dcdb303f71d6b24f57919209f38"
-      Server:
-      - Caddy
+      - W/"3e1bceed10c5bbdd862ee51791e3323d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - d7988df0-79ed-4a5d-852d-99257e873cae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_Bn9HSqoV1ZCPJnr9
+    method: GET
+  response:
+    body: '{"task":{"id":"task_Bn9HSqoV1ZCPJnr9","name":"Stop virtual machine","status":"pending","created_at":1738859783,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:36:29 GMT
+      Etag:
+      - W/"3e1bceed10c5bbdd862ee51791e3323d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "982"
       X-Request-Id:
-      - 5eea82ab-62bd-47d6-bc1b-3145bd8514a6
+      - 2759a91c-984f-4a20-8706-bff2f059e2b6
     status: 200 OK
     code: 200
     duration: ""
@@ -886,54 +1131,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_hP7aZjT0xFZQ20rf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_Bn9HSqoV1ZCPJnr9
     method: GET
   response:
-    body: '{"task":{"id":"task_hP7aZjT0xFZQ20rf","name":"Stop virtual machine","status":"pending","created_at":1679595180,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_Bn9HSqoV1ZCPJnr9","name":"Stop virtual machine","status":"running","created_at":1738859783,"started_at":1738859799,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:07 GMT
-      Etag:
-      - W/"c4bf3dcdb303f71d6b24f57919209f38"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - 0650d5ff-6aa3-429f-a241-0b826d1e48a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_hP7aZjT0xFZQ20rf
-    method: GET
-  response:
-    body: '{"task":{"id":"task_hP7aZjT0xFZQ20rf","name":"Stop virtual machine","status":"running","created_at":1679595180,"started_at":1679595196,"finished_at":null,"progress":5}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -943,19 +1150,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:17 GMT
+      - Thu, 06 Feb 2025 16:36:39 GMT
       Etag:
-      - W/"d06b8f2a4fbc7d8f60461dd42a3a5bc8"
-      Server:
-      - Caddy
+      - W/"ce32868fcdcfa07ca83a457c6eada623"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "981"
       X-Request-Id:
-      - 219f10f8-ee57-405d-9f5c-233931279d44
+      - abf71dba-4e41-4b77-8d09-8b0adb95b97b
     status: 200 OK
     code: 200
     duration: ""
@@ -966,14 +1173,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_hP7aZjT0xFZQ20rf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_Bn9HSqoV1ZCPJnr9
     method: GET
   response:
-    body: '{"task":{"id":"task_hP7aZjT0xFZQ20rf","name":"Stop virtual machine","status":"completed","created_at":1679595180,"started_at":1679595196,"finished_at":1679595200,"progress":100}}'
+    body: '{"task":{"id":"task_Bn9HSqoV1ZCPJnr9","name":"Stop virtual machine","status":"completed","created_at":1738859783,"started_at":1738859799,"finished_at":1738859801,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -983,19 +1192,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:27 GMT
+      - Thu, 06 Feb 2025 16:36:49 GMT
       Etag:
-      - W/"803ae96fcfbab7e240eee2f6a76b166f"
-      Server:
-      - Caddy
+      - W/"1ad95964dd5441a21da8166ec56fde16"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "925"
+      - "980"
       X-Request-Id:
-      - 4b37079c-4550-4bfc-9bd0-6781f0e7f81d
+      - 98307a79-7a07-4a97-a688-27ecaca4ec1d
     status: 200 OK
     code: 200
     duration: ""
@@ -1006,43 +1215,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595162,"initial_root_password":"2BYlyiEeGC8jfbuv","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1738859748,"initial_root_password":"D7HXvAwBiAyOlm8R","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Ro3aniKAKM6ZOlzo","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_BKvJyKMNpd8nJQUB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:28 GMT
+      - Thu, 06 Feb 2025 16:36:50 GMT
       Etag:
-      - W/"1b1ba1b2798534bda04d04e5379d2748"
-      Server:
-      - Caddy
+      - W/"3292a6da3d0eed1fe497bccc3e7e34d4"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "907"
+      - "979"
       X-Request-Id:
-      - f137955c-6321-4add-bd3d-e208fa8ab096
+      - 2457b11a-410c-4f11-82ea-09ff1040a206
     status: 200 OK
     code: 200
     duration: ""
@@ -1053,43 +1263,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_iTuN3l60rss15ne1","keep_until":1679768008,"object_id":"vm_Ro3aniKAKM6ZOlzo","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_Ro3aniKAKM6ZOlzo","name":"tf-acc-test-northern-kind-tungsten","hostname":"tf-acc-test-northern-kind-tungsten","fqdn":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595162,"initial_root_password":"2BYlyiEeGC8jfbuv","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_7RB8Cxwn3pTalXrj","keep_until":1739032610,"object_id":"vm_BKvJyKMNpd8nJQUB","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_BKvJyKMNpd8nJQUB","name":"tf-acc-test-turquoise-young-sunflower","hostname":"tf-acc-test-turquoise-young-sunflower","fqdn":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1738859748,"initial_root_password":"D7HXvAwBiAyOlm8R","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_ThTjuc3gzLUgUUVg","address":"185.199.222.126","reverse_dns":"tf-acc-test-northern-kind-tungsten.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.126/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Ro3aniKAKM6ZOlzo","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Q3k1LZddqvzMH21b","address":"185.44.253.210","reverse_dns":"tf-acc-test-turquoise-young-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.210/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_BKvJyKMNpd8nJQUB","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2347"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:28 GMT
+      - Thu, 06 Feb 2025 16:36:50 GMT
       Etag:
-      - W/"3657c2c2b7cd3f5cb73637957205f7f8"
-      Server:
-      - Caddy
+      - W/"57d5ffa13660a806c21ada2c92fa1d45"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "906"
+      - "978"
       X-Request-Id:
-      - b5df8618-ee0e-42e7-95c7-14adb1904de4
+      - ee78f468-0adc-45cb-a42b-35046e1fb4ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1100,14 +1311,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Q3k1LZddqvzMH21b
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1117,19 +1330,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:28 GMT
+      - Thu, 06 Feb 2025 16:36:51 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "905"
+      - "977"
       X-Request-Id:
-      - f541d1ac-9675-4a93-9d1d-f7153354bbb0
+      - 553a3c81-274f-4229-aaa7-b98eaa13fd88
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,14 +1353,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_BKvJyKMNpd8nJQUB
     method: DELETE
   response:
-    body: '{"task":{"id":"task_Jmh2iX0H1oiZlr6Y","name":"Purge items from trash","status":"pending","created_at":1679595208,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_QqgxD2b9Gw6TUlxr","name":"Purge items from trash","status":"pending","created_at":1738859811,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1157,19 +1372,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:28 GMT
+      - Thu, 06 Feb 2025 16:36:51 GMT
       Etag:
-      - W/"af72faabeb19381a9443cb2810fc79b6"
-      Server:
-      - Caddy
+      - W/"af49ea67f6ba6bb44e752feac7fdf3c1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "902"
+      - "976"
       X-Request-Id:
-      - ebd61195-f544-4d69-97fe-0a20ec720f33
+      - 626cab35-165c-4a0d-adb0-7cc569519cff
     status: 200 OK
     code: 200
     duration: ""
@@ -1180,14 +1395,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_BKvJyKMNpd8nJQUB
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_iTuN3l60rss15ne1","keep_until":1679768008,"object_id":"vm_Ro3aniKAKM6ZOlzo","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_7RB8Cxwn3pTalXrj","keep_until":1739032610,"object_id":"vm_BKvJyKMNpd8nJQUB","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1197,19 +1414,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:29 GMT
+      - Thu, 06 Feb 2025 16:36:52 GMT
       Etag:
-      - W/"2b745bc8536cc91621c9155fbb44b0ef"
-      Server:
-      - Caddy
+      - W/"2c13004aa541c44dbd6fd2653369555f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "885"
+      - "975"
       X-Request-Id:
-      - d6996fb0-3de2-48ec-b198-6a6d20a6d474
+      - 506ce60d-a456-4acd-ad58-18d689b194c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1220,95 +1437,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Ro3aniKAKM6ZOlzo
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_iTuN3l60rss15ne1","keep_until":1679768008,"object_id":"vm_Ro3aniKAKM6ZOlzo","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:34 GMT
-      Etag:
-      - W/"2b745bc8536cc91621c9155fbb44b0ef"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "829"
-      X-Request-Id:
-      - 5316583c-c0b7-4718-b60c-ec2a9c33b84a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Ro3aniKAKM6ZOlzo
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_iTuN3l60rss15ne1","keep_until":1679768008,"object_id":"vm_Ro3aniKAKM6ZOlzo","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:13:44 GMT
-      Etag:
-      - W/"2b745bc8536cc91621c9155fbb44b0ef"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "693"
-      X-Request-Id:
-      - 41993695-9dcc-4c4a-bfb7-dc44536c38c9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_BKvJyKMNpd8nJQUB
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1318,19 +1457,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:54 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:36:57 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "574"
+      - "974"
       X-Request-Id:
-      - ce5fa882-637a-4581-9e1b-2c93dd479f7f
+      - 0cc46ee7-ef83-453f-9c07-99cd2acc5a9a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1341,14 +1480,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Q3k1LZddqvzMH21b
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1358,19 +1499,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:54 GMT
+      - Thu, 06 Feb 2025 16:36:58 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "573"
+      - "973"
       X-Request-Id:
-      - 8c354132-efab-408d-9831-946e2ef926db
+      - 6be1a613-41c8-488e-b5be-0ad48308238e
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,15 +1522,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_BKvJyKMNpd8nJQUB
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1399,19 +1542,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:54 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:36:58 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "572"
+      - "972"
       X-Request-Id:
-      - c2a16688-ada6-470e-a7db-642e2a006563
+      - 45fc21be-bde0-4f43-ab06-8150319adef3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1422,15 +1565,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Ro3aniKAKM6ZOlzo
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_BKvJyKMNpd8nJQUB
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1440,19 +1585,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:54 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:36:58 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "570"
+      - "971"
       X-Request-Id:
-      - 397eb594-eba0-45c2-b682-6c6a254ea322
+      - 389264ed-5e7c-474d-a8d0-7d6c8ac9ee6e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1463,15 +1608,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ThTjuc3gzLUgUUVg
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Q3k1LZddqvzMH21b
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1481,19 +1628,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:13:54 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:36:58 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "569"
+      - "970"
       X-Request-Id:
-      - e7999120-899f-488e-a4ca-9da3aafe69b5
+      - 613ab133-0369-4b9f-9f30-20f7025a9bce
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update.cassette.rand_id
@@ -1,1 +1,1 @@
-8durwqaz071e
+w0tmzsvxwnrm

--- a/internal/provider/testdata/VirtualMachine_update.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update.cassette.yaml
@@ -8,36 +8,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:14 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "925"
+      - "999"
       X-Request-Id:
-      - 0a3c7794-8e59-4f36-9906-36f3c7754a38
+      - 0e06a25a-c06c-4eef-a922-c546065433ba
     status: 200 OK
     code: 200
     duration: ""
@@ -51,38 +53,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"185-44-254-55.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:19 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"02acb1d6e39d2dd3d1fdd50d084a43c8"
-      Server:
-      - Caddy
+      - W/"fc0226d5f20a8abdf68a6cfc018149dd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "923"
+      - "994"
       X-Request-Id:
-      - b250c07d-8fe4-4fd1-92a9-4e445305b2f5
+      - 8b433fcd-1310-4a14-a39d-584d012a8f84
     status: 200 OK
     code: 200
     duration: ""
@@ -93,38 +97,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ewais9hxfzjWUnPe
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"185-44-254-55.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:19 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"302278f172a97bb1f106ca9e8f0749c2"
-      Server:
-      - Caddy
+      - W/"175978a6e75e534effe59b86d5b6cc89"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "914"
+      - "989"
       X-Request-Id:
-      - 8b7df1ec-ffa8-495e-bd95-6ea6ce53f875
+      - aa8fc21d-c03d-41d9-90c3-ff61116f828e
     status: 200 OK
     code: 200
     duration: ""
@@ -135,44 +141,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ewais9hxfzjWUnPe
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"185-199-222-28.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"185-44-254-55.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:19 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"302278f172a97bb1f106ca9e8f0749c2"
-      Server:
-      - Caddy
+      - W/"175978a6e75e534effe59b86d5b6cc89"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "913"
+      - "988"
       X-Request-Id:
-      - eb517600-5067-44c1-923f-88091ac5b856
+      - ac361a0e-c48d-4077-80f1-42e31b80b483
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_KbfXZm6mJYp6AdZf</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-8durwqaz071e-host</Hostname></Hostname><Name>tf-acc-test-update-8durwqaz071e</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><SpeedProfile by=\"permalink\">1gbps</SpeedProfile><IPAddressAllocation type=\"existing\"><IPAddress>ip_ewais9hxfzjWUnPe</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-update-w0tmzsvxwnrm-host</Hostname></Hostname><Name>tf-acc-test-update-w0tmzsvxwnrm</Name><Description>A web server.</Description><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag><Tag>public</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -180,36 +188,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_4u4VtcXiqy2gpEHO","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_UCbrX1fLEvKw8xQz","state":"pending"},"virtual_machine_build":{"id":"vmbuild_UCbrX1fLEvKw8xQz","state":"pending"},"hostname":"tf-acc-test-update-8durwqaz071e-host"}'
+    body: '{"task":{"id":"task_p938P8MONzUFdxpQ","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_LnOoZR1WhpKAyWbk","state":"pending"},"virtual_machine_build":{"id":"vmbuild_LnOoZR1WhpKAyWbk","state":"pending"},"hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "275"
+      - "292"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:19 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"97844bc36284f9a2962fe04160ef87ab"
-      Server:
-      - Caddy
+      - W/"7333fc300fd0df18a86630655d6a29cb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "912"
+      - "987"
       X-Request-Id:
-      - 3fed6a00-5675-450c-b4ec-e9ff5fd138e7
+      - 109328ea-ddae-4703-9fc8-fb25adde2bc4
     status: 201 Created
     code: 201
     duration: ""
@@ -220,43 +230,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_UCbrX1fLEvKw8xQz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LnOoZR1WhpKAyWbk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_UCbrX1fLEvKw8xQz","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_LnOoZR1WhpKAyWbk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-8durwqaz071e-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-8durwqaz071e\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-w0tmzsvxwnrm-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-w0tmzsvxwnrm\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595079}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:21 GMT
+      - Thu, 06 Feb 2025 16:40:21 GMT
       Etag:
-      - W/"380b59b9ec0f0aacbf44cff48b63f69f"
-      Server:
-      - Caddy
+      - W/"2ee396ef861dd37982c52c08cc1e77b2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "910"
+      - "976"
       X-Request-Id:
-      - 786ea2c1-a4ed-46a3-b599-76c6d11fe330
+      - aa32bdf1-1dcd-4014-b187-f7e62b799e82
     status: 200 OK
     code: 200
     duration: ""
@@ -267,43 +277,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_UCbrX1fLEvKw8xQz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LnOoZR1WhpKAyWbk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_UCbrX1fLEvKw8xQz","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_LnOoZR1WhpKAyWbk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-8durwqaz071e-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-8durwqaz071e\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-w0tmzsvxwnrm-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-w0tmzsvxwnrm\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595079}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:26 GMT
+      - Thu, 06 Feb 2025 16:40:26 GMT
       Etag:
-      - W/"380b59b9ec0f0aacbf44cff48b63f69f"
-      Server:
-      - Caddy
+      - W/"853a7bff2c0cd1dbe20bb9821f2106f6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "908"
+      - "972"
       X-Request-Id:
-      - e7478407-3925-4b87-abba-a4d9993e075a
+      - 6e4ff735-cf0b-473b-aab8-a06851ab0279
     status: 200 OK
     code: 200
     duration: ""
@@ -314,49 +324,96 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_UCbrX1fLEvKw8xQz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LnOoZR1WhpKAyWbk
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_UCbrX1fLEvKw8xQz","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_LnOoZR1WhpKAyWbk","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.28\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-8durwqaz071e-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-8durwqaz071e\u003c/Name\u003e\n  \u003cDescription\u003eA
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-w0tmzsvxwnrm-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-w0tmzsvxwnrm\u003c/Name\u003e\n  \u003cDescription\u003eA
       web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
-      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595079}}'
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1932"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:36 GMT
+      - Thu, 06 Feb 2025 16:40:36 GMT
       Etag:
-      - W/"5b754457e294599783776ae6552d1ea2"
-      Server:
-      - Caddy
+      - W/"853a7bff2c0cd1dbe20bb9821f2106f6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "883"
+      - "968"
       X-Request-Id:
-      - fbb9abb0-f943-49ea-8cb9-58f9643b3542
+      - f0a948ca-c407-4280-aa51-4c10802d02db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_LnOoZR1WhpKAyWbk
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_LnOoZR1WhpKAyWbk","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cSpeedProfile\u003ensp_Y8YS65yTivlCAjIY\u003c/SpeedProfile\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-update-w0tmzsvxwnrm-host\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-w0tmzsvxwnrm\u003c/Name\u003e\n  \u003cDescription\u003eA
+      web server.\u003c/Description\u003e\n  \u003cAuthorizedKeys continuous_management=\"no\"\u003e\n    \u003cUsers
+      all=\"yes\"/\u003e\n    \u003cSSHKeys all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n    \u003cTag\u003epublic\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738860019},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:46 GMT
+      Etag:
+      - W/"80ffb23ef3958448f473a51c50830b8b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - e6f84355-e486-463f-b76f-48ed616313af
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN"},"properties":{"tag_names":["web","public"]}}
+      {"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd"},"properties":{"tag_names":["web","public"]}}
     form: {}
     headers:
       Accept:
@@ -364,44 +421,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:36 GMT
+      - Thu, 06 Feb 2025 16:40:46 GMT
       Etag:
-      - W/"ff2e17344a4555e0d96a915bd8062b0e"
-      Server:
-      - Caddy
+      - W/"5ffd749d8fe7ae3c5f4cfd8c4deb43f6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "882"
+      - "963"
       X-Request-Id:
-      - 1aab8f4c-af98-4e47-bd71-aac3ccbe2687
+      - 27d0ecbd-1583-4436-a8fc-f2542d9f5d06
     status: 200 OK
     code: 200
     duration: ""
@@ -412,44 +470,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:38 GMT
+      - Thu, 06 Feb 2025 16:40:48 GMT
       Etag:
-      - W/"ff2e17344a4555e0d96a915bd8062b0e"
-      Server:
-      - Caddy
+      - W/"5ffd749d8fe7ae3c5f4cfd8c4deb43f6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "881"
+      - "960"
       X-Request-Id:
-      - caea24ef-d5e2-4376-a141-1c7311ab00ee
+      - 0c25c6ab-13fa-4f8a-a643-7fa8fa19affd
     status: 200 OK
     code: 200
     duration: ""
@@ -460,44 +519,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:38 GMT
+      - Thu, 06 Feb 2025 16:40:53 GMT
       Etag:
-      - W/"ff2e17344a4555e0d96a915bd8062b0e"
-      Server:
-      - Caddy
+      - W/"aa42f137b35c2664158fd9973edc9514"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "880"
+      - "958"
       X-Request-Id:
-      - 042b302b-2afc-4dcc-ac26-5e671a17df1a
+      - 34d89f36-7d0d-48c5-bb5f-65741c04105f
     status: 200 OK
     code: 200
     duration: ""
@@ -508,128 +568,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGDnBMgiJ4GZRiRz","name":"Public
-      Network on tf-acc-test-update-8durwqaz071e","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "358"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:38 GMT
-      Etag:
-      - W/"8908ffb7e0846ffd9c9068d02121a330"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "879"
-      X-Request-Id:
-      - bf501677-ca49-445a-9d30-380267bbfab3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGDnBMgiJ4GZRiRz
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGDnBMgiJ4GZRiRz","virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e"},"name":"Public
-      Network on tf-acc-test-update-8durwqaz071e","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:55:b8:d2:95:ff","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "488"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:38 GMT
-      Etag:
-      - W/"5e3bfbb94e9cb66fcc4bc1dabfbde506"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "878"
-      X-Request-Id:
-      - 82c8173c-c1da-4001-b743-b492946363ad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:54 GMT
+      Etag:
+      - W/"aa42f137b35c2664158fd9973edc9514"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 486783b9-d47a-4e26-aba2-56af2461fb6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_n3YWwNc9eJRrkF0R","name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2413"
+      - "381"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:38 GMT
+      - Thu, 06 Feb 2025 16:40:54 GMT
       Etag:
-      - W/"ff2e17344a4555e0d96a915bd8062b0e"
-      Server:
-      - Caddy
+      - W/"65d4f543c16d0faad3873e6b2f5682f2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "877"
+      - "953"
       X-Request-Id:
-      - fd96b3df-da6c-4015-9658-7ab1bc94f69c
+      - e0aa3709-ddce-4ec7-9b0d-23e3e213916a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "510"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:54 GMT
+      Etag:
+      - W/"bfd65552638ff94f7f39fd49455e28d4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "951"
+      X-Request-Id:
+      - 5628e571-99cd-444f-926a-5b6bf09a3cfa
     status: 200 OK
     code: 200
     duration: ""
@@ -640,38 +701,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "731"
+      - "510"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:40:54 GMT
       Etag:
-      - W/"28ea22e56de53dafc1ff88dc4ef25712"
-      Server:
-      - Caddy
+      - W/"bfd65552638ff94f7f39fd49455e28d4"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "876"
+      - "949"
       X-Request-Id:
-      - ffc79908-1d03-4d45-8ecd-9da4123d2880
+      - 394fc07a-558b-4588-8c99-4f073e4e93a3
     status: 200 OK
     code: 200
     duration: ""
@@ -682,44 +745,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2413"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:40:54 GMT
       Etag:
-      - W/"ff2e17344a4555e0d96a915bd8062b0e"
-      Server:
-      - Caddy
+      - W/"aa42f137b35c2664158fd9973edc9514"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "875"
+      - "947"
       X-Request-Id:
-      - 0e54e809-3a31-41b3-9f3c-af12c5351936
+      - eb93d107-1f7b-4dd1-9910-5fab3f330cd2
     status: 200 OK
     code: 200
     duration: ""
@@ -730,38 +794,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ewais9hxfzjWUnPe
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGDnBMgiJ4GZRiRz","name":"Public
-      Network on tf-acc-test-update-8durwqaz071e","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}]}]}'
+    body: '{"ip_address":{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "358"
+      - "744"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"8908ffb7e0846ffd9c9068d02121a330"
-      Server:
-      - Caddy
+      - W/"babcfa9a17eceb8488eac313ca8a0477"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "874"
+      - "945"
       X-Request-Id:
-      - e791da02-1dfd-433a-924b-41e42889e530
+      - b3ed1ba7-e36f-4c1d-a751-51599277465e
     status: 200 OK
     code: 200
     duration: ""
@@ -772,128 +838,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGDnBMgiJ4GZRiRz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGDnBMgiJ4GZRiRz","virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e"},"name":"Public
-      Network on tf-acc-test-update-8durwqaz071e","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:55:b8:d2:95:ff","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "488"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
-      Etag:
-      - W/"5e3bfbb94e9cb66fcc4bc1dabfbde506"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "873"
-      X-Request-Id:
-      - 857c3c45-6a0e-45c4-b755-344fcd988efb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "731"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
-      Etag:
-      - W/"28ea22e56de53dafc1ff88dc4ef25712"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "872"
-      X-Request-Id:
-      - f32dd991-2cac-4c37-ae36-8b759fa16b1a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e","hostname":"tf-acc-test-update-8durwqaz071e-host","fqdn":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","description":"A
-      web server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:55 GMT
+      Etag:
+      - W/"aa42f137b35c2664158fd9973edc9514"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - 1a5ea3a6-4f0e-4644-9824-8fce850c406a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_n3YWwNc9eJRrkF0R","name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2413"
+      - "381"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"ff2e17344a4555e0d96a915bd8062b0e"
-      Server:
-      - Caddy
+      - W/"65d4f543c16d0faad3873e6b2f5682f2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "871"
+      - "941"
       X-Request-Id:
-      - fca02e1b-193e-403e-9512-5714b9f278a9
+      - 721468d6-5d4e-4b43-9d5a-b8cadbd059a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "510"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:55 GMT
+      Etag:
+      - W/"bfd65552638ff94f7f39fd49455e28d4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "933"
+      X-Request-Id:
+      - 770ea78c-6231-4f55-b5a9-81c47833e359
     status: 200 OK
     code: 200
     duration: ""
@@ -904,38 +971,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGDnBMgiJ4GZRiRz","name":"Public
-      Network on tf-acc-test-update-8durwqaz071e","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "358"
+      - "510"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"8908ffb7e0846ffd9c9068d02121a330"
-      Server:
-      - Caddy
+      - W/"bfd65552638ff94f7f39fd49455e28d4"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "869"
+      - "932"
       X-Request-Id:
-      - 70caf4c7-0729-4e9c-b8e6-d5f53f998bfd
+      - 260f0739-1fba-4181-9fe8-db560dcb527c
     status: 200 OK
     code: 200
     duration: ""
@@ -946,38 +1015,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGDnBMgiJ4GZRiRz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ewais9hxfzjWUnPe
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGDnBMgiJ4GZRiRz","virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e"},"name":"Public
-      Network on tf-acc-test-update-8durwqaz071e","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:55:b8:d2:95:ff","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    body: '{"ip_address":{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "488"
+      - "744"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"5e3bfbb94e9cb66fcc4bc1dabfbde506"
-      Server:
-      - Caddy
+      - W/"babcfa9a17eceb8488eac313ca8a0477"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "868"
+      - "930"
       X-Request-Id:
-      - 34148f23-db4b-440d-8319-c163ab7e1db6
+      - 6cdea904-edc5-44e2-b9e8-70cb8f997fc4
     status: 200 OK
     code: 200
     duration: ""
@@ -988,44 +1059,223 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGDnBMgiJ4GZRiRz","name":"Public
-      Network on tf-acc-test-update-8durwqaz071e","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","description":"A
+      web server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_YuRGuWJE432q8wxT","name":"public","color":"pink","created_at":1610021329}],"tag_names":["web","public"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"aa42f137b35c2664158fd9973edc9514"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "929"
+      X-Request-Id:
+      - 676efa9b-6bf1-4cfc-b013-f36d56f0a697
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_n3YWwNc9eJRrkF0R","name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "359"
+      - "381"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"001aa19e407f929dab606f41e7bc9fd1"
-      Server:
-      - Caddy
+      - W/"65d4f543c16d0faad3873e6b2f5682f2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "863"
+      - "928"
       X-Request-Id:
-      - 967842cb-89bd-4225-a224-2513fe81f18a
+      - eebd1c16-4244-4710-8877-681adf312588
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "510"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"bfd65552638ff94f7f39fd49455e28d4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "926"
+      X-Request-Id:
+      - 67a8444b-bf8e-40c0-9891-22d84ba4c8bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "510"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"bfd65552638ff94f7f39fd49455e28d4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "924"
+      X-Request-Id:
+      - a85a86f5-1fa4-493f-beb7-5ab9252faede
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_n3YWwNc9eJRrkF0R","name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "381"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"65d4f543c16d0faad3873e6b2f5682f2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "920"
+      X-Request-Id:
+      - 60c0dc45-2e34-47aa-86f1-77c424062b1b
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_cGDnBMgiJ4GZRiRz"},"speed_profile":{"permalink":"10gbps"}}
+      {"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R"},"speed_profile":{"permalink":"10gbps"}}
     form: {}
     headers:
       Accept:
@@ -1033,15 +1283,17 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/update_speed_profile
     method: PATCH
   response:
-    body: '{"task":{"id":"task_w0mSC2FRJubTc4YA","name":"Change network interface
-      speed profile","status":"pending","created_at":1679595099,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_ftygpT9w5f8Gliew","name":"Change network interface
+      speed profile","status":"pending","created_at":1738860056,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1051,19 +1303,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"28b6fdeee3b795aa7fbfe7874732762e"
-      Server:
-      - Caddy
+      - W/"fd227ecd29f67218102d1d5cb16175e7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "862"
+      - "919"
       X-Request-Id:
-      - 9ea3ae37-24f6-4d02-85fc-4d284655bcda
+      - ae873a51-269c-44bb-96be-ee965da326a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1074,15 +1326,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_w0mSC2FRJubTc4YA
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ftygpT9w5f8Gliew
     method: GET
   response:
-    body: '{"task":{"id":"task_w0mSC2FRJubTc4YA","name":"Change network interface
-      speed profile","status":"running","created_at":1679595099,"started_at":1679595100,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_ftygpT9w5f8Gliew","name":"Change network interface
+      speed profile","status":"running","created_at":1738860056,"started_at":1738860057,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1092,19 +1346,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:40:57 GMT
       Etag:
-      - W/"72ac4f39933a4afdcb61e6c991d09f21"
-      Server:
-      - Caddy
+      - W/"9263fe4cba37351b712b891c2b7fb9db"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "846"
+      - "909"
       X-Request-Id:
-      - 4d923380-ec44-4c61-8d55-f59e33c6eeb0
+      - 97370085-6245-4087-888e-8d1a34f085a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1115,15 +1369,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_w0mSC2FRJubTc4YA
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ftygpT9w5f8Gliew
     method: GET
   response:
-    body: '{"task":{"id":"task_w0mSC2FRJubTc4YA","name":"Change network interface
-      speed profile","status":"completed","created_at":1679595099,"started_at":1679595100,"finished_at":1679595101,"progress":100}}'
+    body: '{"task":{"id":"task_ftygpT9w5f8Gliew","name":"Change network interface
+      speed profile","status":"completed","created_at":1738860056,"started_at":1738860057,"finished_at":1738860058,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1133,25 +1389,25 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:45 GMT
+      - Thu, 06 Feb 2025 16:41:02 GMT
       Etag:
-      - W/"30732ff7a4ec7783e1f6f12272dd0982"
-      Server:
-      - Caddy
+      - W/"2c77eec78540f4178d39d1fa74533aaf"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "796"
+      - "964"
       X-Request-Id:
-      - 6ed170ba-1848-4550-ba43-a4364e0091b4
+      - 8e9f00ec-7672-46cc-8c3e-f30213942547
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN"},"properties":{"name":"tf-acc-test-update-8durwqaz071e-diff","hostname":"tf-acc-test-update-8durwqaz071e-host-diff","description":"A app server.","tag_names":["lb","app","web"]}}
+      {"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd"},"properties":{"name":"tf-acc-test-update-w0tmzsvxwnrm-diff","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host-diff","description":"A app server.","tag_names":["lb","app","web"]}}
     form: {}
     headers:
       Accept:
@@ -1159,44 +1415,45 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff","hostname":"tf-acc-test-update-8durwqaz071e-host-diff","fqdn":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host-diff","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"d5f3d254766feb5d5034aefd8a7b09c3"
-      Server:
-      - Caddy
+      - W/"3768405196f8b87cfa0f6592e11c2826"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "795"
+      - "963"
       X-Request-Id:
-      - b768e9a0-d03c-4b22-abcf-cd4b50df84bf
+      - 3f44959f-08ef-4c1e-bc13-8e357d4af8b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,44 +1464,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff","hostname":"tf-acc-test-update-8durwqaz071e-host-diff","fqdn":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host-diff","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:03 GMT
+      Etag:
+      - W/"3768405196f8b87cfa0f6592e11c2826"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - 4209a299-b5e8-4774-b029-4cda85e1b7a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_n3YWwNc9eJRrkF0R","name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2528"
+      - "386"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"d5f3d254766feb5d5034aefd8a7b09c3"
-      Server:
-      - Caddy
+      - W/"e2a119cd0802ac7a651052b4793c2849"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "794"
+      - "959"
       X-Request-Id:
-      - bcfec9b7-0650-420c-9fb0-e228bb380630
+      - ea5ef841-d7f8-42bb-b16a-ad7d1ae6bb6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:03 GMT
+      Etag:
+      - W/"7c0b3efac0b451df9ba48290e261870c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - 527d6fd0-de0a-4e20-90d6-bc47491acf7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1255,38 +1597,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGDnBMgiJ4GZRiRz","name":"Public
-      Network on tf-acc-test-update-8durwqaz071e-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "363"
+      - "522"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"eb509d3530f680d25951f4e1475d8723"
-      Server:
-      - Caddy
+      - W/"7c0b3efac0b451df9ba48290e261870c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "793"
+      - "956"
       X-Request-Id:
-      - 2732a741-a488-45a0-b298-fe4eb25b49a8
+      - b8c7e1fb-4299-4dd8-b913-7ce3bc60eace
     status: 200 OK
     code: 200
     duration: ""
@@ -1297,86 +1641,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGDnBMgiJ4GZRiRz
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGDnBMgiJ4GZRiRz","virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff"},"name":"Public
-      Network on tf-acc-test-update-8durwqaz071e-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:55:b8:d2:95:ff","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "500"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
-      Etag:
-      - W/"de99608332b58205029b5bcc3b1f3019"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "792"
-      X-Request-Id:
-      - 31fe258b-8c7d-4aec-ad4b-fe9105346af0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff","hostname":"tf-acc-test-update-8durwqaz071e-host-diff","fqdn":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host-diff","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"d5f3d254766feb5d5034aefd8a7b09c3"
-      Server:
-      - Caddy
+      - W/"3768405196f8b87cfa0f6592e11c2826"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "791"
+      - "951"
       X-Request-Id:
-      - d233f3d6-8311-4f33-b111-c5e42b58af66
+      - b7c632d5-0661-4529-bae3-5286f1b1247c
     status: 200 OK
     code: 200
     duration: ""
@@ -1387,38 +1690,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ewais9hxfzjWUnPe
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff"}}}'
+    body: '{"ip_address":{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "741"
+      - "754"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"0ad4e6dd3a39f5df67d029d32c1a2776"
-      Server:
-      - Caddy
+      - W/"9dd0d52f6f3b18f1aa9e378d1c6eb739"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "790"
+      - "949"
       X-Request-Id:
-      - 4c5720a5-9afb-40c7-b728-1d6e692740ee
+      - d078cb6b-df6f-4cf2-b25c-4c1f219e91b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1429,44 +1734,129 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff","hostname":"tf-acc-test-update-8durwqaz071e-host-diff","fqdn":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host-diff","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:03 GMT
+      Etag:
+      - W/"3768405196f8b87cfa0f6592e11c2826"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - d849fdf0-57ff-40f7-b2dc-01dc50c49e63
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_n3YWwNc9eJRrkF0R","name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2528"
+      - "386"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"d5f3d254766feb5d5034aefd8a7b09c3"
-      Server:
-      - Caddy
+      - W/"e2a119cd0802ac7a651052b4793c2849"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "789"
+      - "945"
       X-Request-Id:
-      - 61fad9ed-2de5-43d6-ae23-b80512c74d28
+      - 433726d9-fb7c-49be-814c-1507cd1b2da6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "522"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:03 GMT
+      Etag:
+      - W/"7c0b3efac0b451df9ba48290e261870c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - bbe77de7-f932-4341-a943-e895aaa12d08
     status: 200 OK
     code: 200
     duration: ""
@@ -1477,38 +1867,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_n3YWwNc9eJRrkF0R
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_cGDnBMgiJ4GZRiRz","name":"Public
-      Network on tf-acc-test-update-8durwqaz071e-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_n3YWwNc9eJRrkF0R","virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff"},"name":"Public
+      Network on tf-acc-test-update-w0tmzsvxwnrm-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4c:ab:d2:d6:88","state":"attached","ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "363"
+      - "522"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"eb509d3530f680d25951f4e1475d8723"
-      Server:
-      - Caddy
+      - W/"7c0b3efac0b451df9ba48290e261870c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "788"
+      - "941"
       X-Request-Id:
-      - 430d0c21-ca79-4ab5-aafe-4d7b4f506e10
+      - 285b4317-b944-4922-b64e-7f6e55d41175
     status: 200 OK
     code: 200
     duration: ""
@@ -1519,86 +1911,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_cGDnBMgiJ4GZRiRz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_cGDnBMgiJ4GZRiRz","virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff"},"name":"Public
-      Network on tf-acc-test-update-8durwqaz071e-diff","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:55:b8:d2:95:ff","state":"attached","ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "500"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:47 GMT
-      Etag:
-      - W/"de99608332b58205029b5bcc3b1f3019"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "787"
-      X-Request-Id:
-      - 184ea8c8-04f3-4f10-a01e-50146b20144a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff","hostname":"tf-acc-test-update-8durwqaz071e-host-diff","fqdn":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host-diff","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:48 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"d5f3d254766feb5d5034aefd8a7b09c3"
-      Server:
-      - Caddy
+      - W/"3768405196f8b87cfa0f6592e11c2826"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "786"
+      - "939"
       X-Request-Id:
-      - 963ca80e-dac2-4670-b54e-bdd3d5c5cde4
+      - 4f386a33-692e-4a26-8c80-a42d8779a999
     status: 200 OK
     code: 200
     duration: ""
@@ -1609,14 +1960,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: POST
   response:
-    body: '{"task":{"id":"task_6XoKHfeQEVPhURoc","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_OVfuQE9bKyyH5K1M","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1626,19 +1979,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:48 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"5777df2e7a4e7a32ccdb9b883e3689f1"
-      Server:
-      - Caddy
+      - W/"4a9e25f7a074b8413a7c77fc1da109bc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "785"
+      - "937"
       X-Request-Id:
-      - cbb49c1f-7924-475a-9e44-462347f0d5d9
+      - 6d8bedf9-9f2a-45b2-8018-75512a2c200d
     status: 200 OK
     code: 200
     duration: ""
@@ -1649,14 +2002,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_6XoKHfeQEVPhURoc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_OVfuQE9bKyyH5K1M
     method: GET
   response:
-    body: '{"task":{"id":"task_6XoKHfeQEVPhURoc","name":"Stop virtual machine","status":"running","created_at":1679595108,"started_at":1679595108,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_OVfuQE9bKyyH5K1M","name":"Stop virtual machine","status":"running","created_at":1738860064,"started_at":1738860064,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1666,19 +2021,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:49 GMT
+      - Thu, 06 Feb 2025 16:41:05 GMT
       Etag:
-      - W/"fb5e7af6ef32adad40e73c5a349ab472"
-      Server:
-      - Caddy
+      - W/"fac3dfc89aad6bf44af67864f6b981b0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "781"
+      - "922"
       X-Request-Id:
-      - 9b1a4bff-4548-4557-8a04-b16deb03427a
+      - 64dee5e5-107e-4cc9-8c0e-0fda8d0ff4c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1689,14 +2044,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_6XoKHfeQEVPhURoc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_OVfuQE9bKyyH5K1M
     method: GET
   response:
-    body: '{"task":{"id":"task_6XoKHfeQEVPhURoc","name":"Stop virtual machine","status":"completed","created_at":1679595108,"started_at":1679595108,"finished_at":1679595111,"progress":100}}'
+    body: '{"task":{"id":"task_OVfuQE9bKyyH5K1M","name":"Stop virtual machine","status":"completed","created_at":1738860064,"started_at":1738860064,"finished_at":1738860067,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1706,19 +2063,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:54 GMT
+      - Thu, 06 Feb 2025 16:41:10 GMT
       Etag:
-      - W/"401440669526e131bfcba6a760a7601b"
-      Server:
-      - Caddy
+      - W/"5f8f18545fc91d9128d1df5f2456693e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "770"
+      - "874"
       X-Request-Id:
-      - 23b555e6-2235-4d68-9450-c9dd03483f6b
+      - 354ed584-017d-4164-88eb-30546aebd193
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,44 +2086,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff","hostname":"tf-acc-test-update-8durwqaz071e-host-diff","fqdn":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host-diff","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2528"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:55 GMT
+      - Thu, 06 Feb 2025 16:41:11 GMT
       Etag:
-      - W/"ff88223ced02b0dd3eea672faad13ba1"
-      Server:
-      - Caddy
+      - W/"88143956d71e44511bd253de3f873944"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "769"
+      - "871"
       X-Request-Id:
-      - aa1f5413-a544-478d-9297-6e9d3e4d2028
+      - 7ee15a27-2238-497b-a1fd-d6823118752d
     status: 200 OK
     code: 200
     duration: ""
@@ -1777,44 +2135,45 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_S5qHgInFlzomdCtw","keep_until":1679767915,"object_id":"vm_zYSIpF4x3foa5juN","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_zYSIpF4x3foa5juN","name":"tf-acc-test-update-8durwqaz071e-diff","hostname":"tf-acc-test-update-8durwqaz071e-host-diff","fqdn":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","description":"A
-      app server.","created_at":1679595080,"initial_root_password":"ZoRymnkyd6wD8tUz","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_eXdvl8PAqMgsOgeM","keep_until":1739032871,"object_id":"vm_31AM1CwiDMiz4dwd","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_31AM1CwiDMiz4dwd","name":"tf-acc-test-update-w0tmzsvxwnrm-diff","hostname":"tf-acc-test-update-w0tmzsvxwnrm-host-diff","fqdn":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","description":"A
+      app server.","created_at":1738860024,"initial_root_password":"sG8D2pHpfTQpbKiw","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_KbfXZm6mJYp6AdZf","address":"185.199.222.28","reverse_dns":"tf-acc-test-update-8durwqaz071e-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.28/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zYSIpF4x3foa5juN","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_ewais9hxfzjWUnPe","address":"185.44.254.55","reverse_dns":"tf-acc-test-update-w0tmzsvxwnrm-host-diff.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_31AM1CwiDMiz4dwd","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2663"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:55 GMT
+      - Thu, 06 Feb 2025 16:41:11 GMT
       Etag:
-      - W/"664792f7548840fc6cf104b2db4600f7"
-      Server:
-      - Caddy
+      - W/"59478f82319e10970583bb3987577145"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "768"
+      - "869"
       X-Request-Id:
-      - 6cb04191-6104-4023-81fd-b8faaa0e664e
+      - 62b2f5db-afa9-4306-ab2c-b987d44a7f01
     status: 200 OK
     code: 200
     duration: ""
@@ -1825,14 +2184,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_ewais9hxfzjWUnPe
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1842,19 +2203,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:55 GMT
+      - Thu, 06 Feb 2025 16:41:11 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "767"
+      - "867"
       X-Request-Id:
-      - 9c40b8ea-922b-4bd5-9bf2-b1c3c8478970
+      - 0c5e7779-c87c-45a9-b00f-a9a435422149
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,14 +2226,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_31AM1CwiDMiz4dwd
     method: DELETE
   response:
-    body: '{"task":{"id":"task_49fhMNKv18RBCS9i","name":"Purge items from trash","status":"pending","created_at":1679595115,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_bzFZMHv3RCyEQuAR","name":"Purge items from trash","status":"pending","created_at":1738860072,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1882,19 +2245,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:55 GMT
+      - Thu, 06 Feb 2025 16:41:12 GMT
       Etag:
-      - W/"564075c9482a17d6aea9bfde3e2abcbf"
-      Server:
-      - Caddy
+      - W/"1e072de9db01c0b22d027ca8941e1903"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "766"
+      - "865"
       X-Request-Id:
-      - d5702b6c-b43e-407d-97ea-6f7e8f6875a9
+      - 5bf0bf01-7080-4419-a32e-f3c3c0958dee
     status: 200 OK
     code: 200
     duration: ""
@@ -1905,14 +2268,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_S5qHgInFlzomdCtw","keep_until":1679767915,"object_id":"vm_zYSIpF4x3foa5juN","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_eXdvl8PAqMgsOgeM","keep_until":1739032871,"object_id":"vm_31AM1CwiDMiz4dwd","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1922,19 +2287,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:56 GMT
+      - Thu, 06 Feb 2025 16:41:13 GMT
       Etag:
-      - W/"bf9f53e36866c87cbb2bd278d2e5fffa"
-      Server:
-      - Caddy
+      - W/"bb7b54184f35aa542ca85481990fda67"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "763"
+      - "863"
       X-Request-Id:
-      - e6c22e2c-667f-4bc6-a4c5-f3af9968e4ba
+      - 59308d81-fe00-4b6b-ac4b-56d35682edda
     status: 200 OK
     code: 200
     duration: ""
@@ -1945,14 +2310,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_S5qHgInFlzomdCtw","keep_until":1679767915,"object_id":"vm_zYSIpF4x3foa5juN","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_eXdvl8PAqMgsOgeM","keep_until":1739032871,"object_id":"vm_31AM1CwiDMiz4dwd","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1962,19 +2329,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:01 GMT
+      - Thu, 06 Feb 2025 16:41:18 GMT
       Etag:
-      - W/"bf9f53e36866c87cbb2bd278d2e5fffa"
-      Server:
-      - Caddy
+      - W/"bb7b54184f35aa542ca85481990fda67"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "856"
       X-Request-Id:
-      - 15424657-ed42-475a-b747-cc36c5ff666e
+      - 97d8988a-3941-44b9-a158-80fa746adc6c
     status: 200 OK
     code: 200
     duration: ""
@@ -1985,95 +2352,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zYSIpF4x3foa5juN
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_S5qHgInFlzomdCtw","keep_until":1679767915,"object_id":"vm_zYSIpF4x3foa5juN","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:11 GMT
-      Etag:
-      - W/"bf9f53e36866c87cbb2bd278d2e5fffa"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "967"
-      X-Request-Id:
-      - fce48eb5-783c-44c0-b1a3-4a49f72f1ce9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zYSIpF4x3foa5juN
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_S5qHgInFlzomdCtw","keep_until":1679767915,"object_id":"vm_zYSIpF4x3foa5juN","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:12:21 GMT
-      Etag:
-      - W/"bf9f53e36866c87cbb2bd278d2e5fffa"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - ae07fad8-edfc-41de-bb43-469847741cca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2083,19 +2372,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:31 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:28 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "940"
+      - "851"
       X-Request-Id:
-      - fb2b09b0-4a2a-4efb-b0a0-f75af86806ee
+      - 53549ca7-430e-4f3b-8df0-2092334e1d67
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2106,14 +2395,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ewais9hxfzjWUnPe
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2123,19 +2414,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:36 GMT
+      - Thu, 06 Feb 2025 16:41:28 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "939"
+      - "850"
       X-Request-Id:
-      - bc2a0f9b-d116-4142-ab60-3aebe6ca606a
+      - 693d8066-b8fb-49ee-a699-a32729cd7d31
     status: 200 OK
     code: 200
     duration: ""
@@ -2146,15 +2437,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2164,19 +2457,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:36 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:28 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "924"
+      - "849"
       X-Request-Id:
-      - 540f3b52-45e6-4355-a8d0-6de67932b99b
+      - 2cb1754a-5362-47bf-93b7-2e2beb3b34c3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2187,15 +2480,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zYSIpF4x3foa5juN
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_31AM1CwiDMiz4dwd
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2205,19 +2500,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:36 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:28 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "923"
+      - "848"
       X-Request-Id:
-      - 8a1106da-12de-4b3c-9368-b4645b4d4870
+      - c03b5e7e-a81c-4cb5-bf2b-492bf1e68036
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2228,15 +2523,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_KbfXZm6mJYp6AdZf
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_ewais9hxfzjWUnPe
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2246,19 +2543,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:36 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:28 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "922"
+      - "847"
       X-Request-Id:
-      - 59fdf491-aaff-4422-b631-a246a741e4d4
+      - 13725654-3451-4cdf-9b17-b097a32980de
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_group.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_group.cassette.rand_id
@@ -1,1 +1,1 @@
-qbwxtt4kqtwu
+bar22cofqkj6

--- a/internal/provider/testdata/VirtualMachine_update_group.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_group.cassette.yaml
@@ -8,42 +8,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "637"
+      - "995"
       X-Request-Id:
-      - b27235fe-b5d9-4175-9b33-78fc0df17f68
+      - 8425a099-80e1-4924-a051-3643bdb76050
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true}}
+      {"organization":{"sub_domain":"terraform-acc-test"},"properties":{"name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true}}
     form: {}
     headers:
       Accept:
@@ -51,36 +53,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "145"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"17330d9aae638c95535bbde7f0e6abb5"
-      Server:
-      - Caddy
+      - W/"2928361355a7690e9313b54b0cd2081e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "637"
+      - "997"
       X-Request-Id:
-      - 7d0a1463-6def-4ca4-83d3-925a4f45f8b4
+      - 220da374-59a6-419d-aea1-1dafa05e7568
     status: 200 OK
     code: 200
     duration: ""
@@ -91,36 +95,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_RpUyvZzOaFtW7cr3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_G0hxFF6646peAwHk
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "145"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"17330d9aae638c95535bbde7f0e6abb5"
-      Server:
-      - Caddy
+      - W/"2928361355a7690e9313b54b0cd2081e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "634"
+      - "990"
       X-Request-Id:
-      - 192608f8-92d4-4b5d-8a9a-8db40f204d07
+      - b9b27f20-fac0-4352-9240-98f795d2ab91
     status: 200 OK
     code: 200
     duration: ""
@@ -134,38 +140,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"185-44-252-93.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"137b10129b421fd5b21a6014fed1266d"
-      Server:
-      - Caddy
+      - W/"defd09d5f94440978c8eafa0d5965ba5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "635"
+      - "993"
       X-Request-Id:
-      - b7e14e65-db49-48bc-9b09-bc90e489020c
+      - 4c1ace76-8411-441f-b58b-f4386fc3cc3b
     status: 200 OK
     code: 200
     duration: ""
@@ -176,38 +184,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"185-44-252-93.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"edf8c0bac5599989162fe9dd2e018057"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "633"
+      - "986"
       X-Request-Id:
-      - 53788a9e-45a5-46f4-9689-f81188d17e8f
+      - 69e5e5f1-36d8-4e6a-ad4c-037f2f8806d7
     status: 200 OK
     code: 200
     duration: ""
@@ -218,44 +228,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"185-44-252-93.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"edf8c0bac5599989162fe9dd2e018057"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "632"
+      - "985"
       X-Request-Id:
-      - 1f2d5fdb-82ee-41c7-8504-8eea41cbb066
+      - a9826238-e26e-41e2-a0c1-e8411409dcd7
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_hc3GUyhBe6toov2e</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-rainbow-better-woodpecker</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_T9HFO8cKRx7BgJr1</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-silent-intimidating-eagle</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -263,36 +275,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_NDWjk0oQuYsOuuTo","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_f5oTQJ7eif6FsKsQ","state":"pending"},"virtual_machine_build":{"id":"vmbuild_f5oTQJ7eif6FsKsQ","state":"pending"},"hostname":"tf-acc-test-rainbow-better-woodpecker"}'
+    body: '{"task":{"id":"task_lkmEpSFLCkop42h1","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_c3BWi6ynxF5vdFlx","state":"pending"},"virtual_machine_build":{"id":"vmbuild_c3BWi6ynxF5vdFlx","state":"pending"},"hostname":"tf-acc-test-silent-intimidating-eagle","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "276"
+      - "293"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"0b7296a2555dcf5c9d315b863bb66e77"
-      Server:
-      - Caddy
+      - W/"03d9c007b165c17dfae8b4613c4f0118"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "631"
+      - "984"
       X-Request-Id:
-      - 395af4a3-e7c8-46a0-967a-43b44269b3d8
+      - 64e63ce3-1c0c-49c6-a358-a7d7081788e8
     status: 201 Created
     code: 201
     duration: ""
@@ -303,43 +317,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_f5oTQJ7eif6FsKsQ
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_c3BWi6ynxF5vdFlx
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_f5oTQJ7eif6FsKsQ","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_c3BWi6ynxF5vdFlx","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-rainbow-better-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-silent-intimidating-eagle\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595051}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1608"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:54 GMT
+      - Thu, 06 Feb 2025 16:40:21 GMT
       Etag:
-      - W/"206ab2539a62ed5fe2935a4dd3253327"
-      Server:
-      - Caddy
+      - W/"1363a77c15a36dbc07f41aa13fbc7123"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "629"
+      - "977"
       X-Request-Id:
-      - 1ae5136d-e4c6-4cf5-8668-8689ef8f9278
+      - f376a6ae-9f71-4f43-9a4d-5a53631398e2
     status: 200 OK
     code: 200
     duration: ""
@@ -350,43 +364,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_f5oTQJ7eif6FsKsQ
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_c3BWi6ynxF5vdFlx
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_f5oTQJ7eif6FsKsQ","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_c3BWi6ynxF5vdFlx","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-rainbow-better-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-silent-intimidating-eagle\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595051}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1608"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:59 GMT
+      - Thu, 06 Feb 2025 16:40:26 GMT
       Etag:
-      - W/"206ab2539a62ed5fe2935a4dd3253327"
-      Server:
-      - Caddy
+      - W/"1363a77c15a36dbc07f41aa13fbc7123"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "620"
+      - "973"
       X-Request-Id:
-      - f17215af-18fb-4dbe-919f-175398c082c6
+      - b4c62a33-fb8f-43b4-89a0-34ea31e35f36
     status: 200 OK
     code: 200
     duration: ""
@@ -397,179 +411,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_f5oTQJ7eif6FsKsQ
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_c3BWi6ynxF5vdFlx
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_f5oTQJ7eif6FsKsQ","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_c3BWi6ynxF5vdFlx","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-rainbow-better-woodpecker\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-silent-intimidating-eagle\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595051}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1608"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:09 GMT
+      - Thu, 06 Feb 2025 16:40:36 GMT
       Etag:
-      - W/"68937db3740c3e77b048a7b18ecbf91a"
-      Server:
-      - Caddy
+      - W/"dad8930f242eae8f2d03c39fb7917889"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - 37d72445-f7d5-42ae-96f8-08d316ce8be2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - f4be76e2-84c8-4c03-acc0-efe8a282efbe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "970"
-      X-Request-Id:
-      - 88a6354e-c4ce-4553-a7ae-591e1494ba95
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rsQhpA9zoGrcRCp9","name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"5b214aec7c6d68ff813f51877c7a1d37"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "969"
       X-Request-Id:
-      - 2405389a-848f-41f5-a2e1-c184988ee7f6
+      - 21178301-6f30-49e2-880d-30f7484cf1f3
     status: 200 OK
     code: 200
     duration: ""
@@ -580,38 +458,2178 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rsQhpA9zoGrcRCp9
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_c3BWi6ynxF5vdFlx
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rsQhpA9zoGrcRCp9","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"},"name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:4a:44:27:9f:b4","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_c3BWi6ynxF5vdFlx","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-silent-intimidating-eagle\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:46 GMT
+      Etag:
+      - W/"dad8930f242eae8f2d03c39fb7917889"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - c533a349-46b7-4538-9806-82cd73b0f03d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_c3BWi6ynxF5vdFlx
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_c3BWi6ynxF5vdFlx","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-silent-intimidating-eagle\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738860019},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"5d8168464b1559aa694a774e37d7a451"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "911"
+      X-Request-Id:
+      - 694e1942-03f8-4ff8-8c60-fa046e254363
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:58 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "907"
+      X-Request-Id:
+      - bafd331e-44cd-4811-ae86-ee17c52c813d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:58 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "906"
+      X-Request-Id:
+      - 0c612317-1ec6-4252-a631-de52054d518f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yjXnACKprQKcmHO0","name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "502"
+      - "387"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
+      - Thu, 06 Feb 2025 16:40:58 GMT
       Etag:
-      - W/"5fb3047d935dbc1558adc069786cdb9f"
-      Server:
-      - Caddy
+      - W/"f7e796f28c08d79af08eaa4206a797d0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "905"
+      X-Request-Id:
+      - 9165e49e-ab26-46c6-8ee3-d8675d0ab97e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"detached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:58 GMT
+      Etag:
+      - W/"cc3d1145722b337014786bcc164b7c03"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "904"
+      X-Request-Id:
+      - 9c576e20-77f4-4150-a390-6df10d0212f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"detached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:58 GMT
+      Etag:
+      - W/"cc3d1145722b337014786bcc164b7c03"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "903"
+      X-Request-Id:
+      - 0b5352cb-735b-49ec-b0f8-ae6fcbf33b7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "902"
+      X-Request-Id:
+      - ce7e562c-cb57-4f5c-a8a3-3a66e8a5d141
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_G0hxFF6646peAwHk
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"2928361355a7690e9313b54b0cd2081e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "901"
+      X-Request-Id:
+      - bc79fbab-4ece-46fb-937a-f7c64f4de64f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "751"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"4b61fd28134d01acb81c69554fa6a08a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "900"
+      X-Request-Id:
+      - a9629cca-9208-4e12-817e-0c8e18e2b225
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "899"
+      X-Request-Id:
+      - d9e9a443-3311-423a-aedc-9316cd2e9a3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yjXnACKprQKcmHO0","name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "387"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"f7e796f28c08d79af08eaa4206a797d0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "897"
+      X-Request-Id:
+      - 6fece71b-0fd2-4d80-94b5-519ec86b7690
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"detached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"cc3d1145722b337014786bcc164b7c03"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "896"
+      X-Request-Id:
+      - cdc24d6c-fcf5-4944-be87-367a0bc63896
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"detached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"cc3d1145722b337014786bcc164b7c03"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "895"
+      X-Request-Id:
+      - 5cdcbd0c-3621-4d26-9a4b-db39207bcb2b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "751"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"4b61fd28134d01acb81c69554fa6a08a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "894"
+      X-Request-Id:
+      - 1d949233-bbb5-4204-908c-5d4b24d5b2ae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_G0hxFF6646peAwHk
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"2928361355a7690e9313b54b0cd2081e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "893"
+      X-Request-Id:
+      - 09527363-fdef-4232-94bd-df7b3c3c4e73
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:59 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "892"
+      X-Request-Id:
+      - 5007b83d-4a5b-4dfd-a813-09e902704872
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yjXnACKprQKcmHO0","name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "387"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"f7e796f28c08d79af08eaa4206a797d0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - f76a11af-11ac-480a-a85a-c6b2595123b2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 2c6987a6-967e-42ba-ae33-51cd7cc01a0f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 26190763-ac35-4c21-bd40-22bd78de5d42
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45"},"properties":{"group":{"id":"vmgrp_G0hxFF6646peAwHk"}}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"9a862f5ec355cd1f80b44d10088fc549"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - e1130628-e5c3-4ea3-b68b-de32b822f3de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"9a862f5ec355cd1f80b44d10088fc549"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - dabc5081-b920-43eb-9694-501416cc1479
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yjXnACKprQKcmHO0","name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "387"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"f7e796f28c08d79af08eaa4206a797d0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - f3f17d94-4031-4d49-b4bc-79c9f33c1dcc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 173607dc-38dc-4d72-a487-402e7d0c3beb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 93549a85-e225-46b5-9cec-66f14cc9424f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"9a862f5ec355cd1f80b44d10088fc549"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 602479b8-77fd-45f7-8c6c-b0a1391db333
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_G0hxFF6646peAwHk
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"2928361355a7690e9313b54b0cd2081e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 61f296d7-cbf3-4470-bfb9-366620dc59d1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "751"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"4b61fd28134d01acb81c69554fa6a08a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 84de9abc-5d6f-4a9c-ad03-446d6026cc04
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"9a862f5ec355cd1f80b44d10088fc549"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 8ce119c0-3e4f-459b-8483-bc6030bbba65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yjXnACKprQKcmHO0","name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "387"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"f7e796f28c08d79af08eaa4206a797d0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 444d98c5-aa0c-4afd-9dc8-605f9319c802
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - e7a57ffe-5355-499c-9a25-1f7ecc5cc714
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:00 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 096891d6-5603-4445-9069-ff5e29160988
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_G0hxFF6646peAwHk
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"2928361355a7690e9313b54b0cd2081e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - e8287fc7-c9b0-4aad-90bf-9c79dd0eb562
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "751"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"4b61fd28134d01acb81c69554fa6a08a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 696e3907-bfd0-42bf-a8ed-78cbd21d69de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"9a862f5ec355cd1f80b44d10088fc549"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 805dd7c5-b13a-4fff-99ee-b48f0ab44aaa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yjXnACKprQKcmHO0","name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "387"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"f7e796f28c08d79af08eaa4206a797d0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 91fdc011-de2e-408c-9222-29e8edd6605c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - 7271ec8c-28af-454d-9936-d0a933a6c197
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 9c17aa60-d898-42f5-88e9-582d277e8a77
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_G0hxFF6646peAwHk
+    method: DELETE
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_G0hxFF6646peAwHk","name":"tf-acc-test-update-group-bar22cofqkj6","segregate":true,"auto_segregate":false,"created_at":1738860019}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"2928361355a7690e9313b54b0cd2081e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 8876be0c-b31f-4169-9bd9-7a2a284b3261
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45"},"properties":{"group":null}}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_
+    method: PATCH
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - 16301816-b246-4c24-a763-6e42e46c8d5d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - cbd82fff-1668-4791-ab43-ea237c17c0a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yjXnACKprQKcmHO0","name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "387"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"f7e796f28c08d79af08eaa4206a797d0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 8b755c88-a3b4-402f-a220-b8c5cd4cd52e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 5793d521-264f-4757-b1eb-9ba70fa7bc43
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 0242cd24-2d92-403a-8317-ad0288b00c03
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:01 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 3038571d-5560-46b1-8bf2-c11a21513259
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "751"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:02 GMT
+      Etag:
+      - W/"4b61fd28134d01acb81c69554fa6a08a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 97c5971b-e411-4853-ac6d-469c8cb5063e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:02 GMT
+      Etag:
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - 3addd05f-efa9-40dc-8d93-9ecc6450e224
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_yjXnACKprQKcmHO0","name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "387"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:02 GMT
+      Etag:
+      - W/"f7e796f28c08d79af08eaa4206a797d0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 13ccdd9a-bf86-45fc-8da5-108b66f2a650
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "524"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:02 GMT
+      Etag:
+      - W/"cf4a6f2245a2149def57cf18317a9516"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "968"
       X-Request-Id:
-      - 2c3b5982-3a75-4a2a-ae4a-599ab977212d
+      - 74b4999b-d985-4d97-a445-4ab19a8cf3e8
     status: 200 OK
     code: 200
     duration: ""
@@ -622,43 +2640,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_yjXnACKprQKcmHO0
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_yjXnACKprQKcmHO0","virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle"},"name":"Public
+      Network on tf-acc-test-silent-intimidating-eagle","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:45:55:ec:64:7d","state":"attached","ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2222"
+      - "524"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
+      - Thu, 06 Feb 2025 16:41:02 GMT
       Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
+      - W/"cf4a6f2245a2149def57cf18317a9516"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "967"
       X-Request-Id:
-      - 5f922eac-6f05-4265-8e01-2b368fd33e85
+      - 2af336ca-3a79-4e96-974b-268be55a5bac
     status: 200 OK
     code: 200
     duration: ""
@@ -669,36 +2684,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_RpUyvZzOaFtW7cr3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051}}'
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
+      - Thu, 06 Feb 2025 16:41:02 GMT
       Etag:
-      - W/"17330d9aae638c95535bbde7f0e6abb5"
-      Server:
-      - Caddy
+      - W/"d3c6fa6ed70207d888b75f773eda7287"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "966"
       X-Request-Id:
-      - 28d4eff7-900f-42d8-807b-7f2bea04d703
+      - a3744c99-0bad-4053-978f-479d007fbea5
     status: 200 OK
     code: 200
     duration: ""
@@ -709,1542 +2732,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "738"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"33c8bada425e1a98b265bc282a7235b7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "966"
-      X-Request-Id:
-      - 571915fa-6416-4f43-8e85-bdc5e0de8617
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "964"
-      X-Request-Id:
-      - c5c0c275-7ace-4b42-b7d5-6cc1cd6f389e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rsQhpA9zoGrcRCp9","name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"5b214aec7c6d68ff813f51877c7a1d37"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "963"
-      X-Request-Id:
-      - 48931253-121f-4902-baa9-96a95d277a28
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rsQhpA9zoGrcRCp9
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rsQhpA9zoGrcRCp9","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"},"name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:4a:44:27:9f:b4","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "502"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"5fb3047d935dbc1558adc069786cdb9f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "962"
-      X-Request-Id:
-      - b4695257-e69b-4add-be22-9b5602a7e8e4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_RpUyvZzOaFtW7cr3
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"17330d9aae638c95535bbde7f0e6abb5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "961"
-      X-Request-Id:
-      - 0b1b0cce-d2a8-4776-80cb-3963c5ad6ad9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "738"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"33c8bada425e1a98b265bc282a7235b7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "960"
-      X-Request-Id:
-      - 6bc6b8b6-3423-4aa1-bf35-860e14dea33f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "959"
-      X-Request-Id:
-      - ab99bca0-c246-47e9-b6dc-24f78bb2bdef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rsQhpA9zoGrcRCp9","name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"5b214aec7c6d68ff813f51877c7a1d37"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "958"
-      X-Request-Id:
-      - 2754cfed-9439-4374-aced-1a13822e72ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rsQhpA9zoGrcRCp9
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rsQhpA9zoGrcRCp9","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"},"name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:4a:44:27:9f:b4","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "502"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:11 GMT
-      Etag:
-      - W/"5fb3047d935dbc1558adc069786cdb9f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "957"
-      X-Request-Id:
-      - dd4cab01-0e42-4096-827c-c17acac98231
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E"},"properties":{"group":{"id":"vmgrp_RpUyvZzOaFtW7cr3"}}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"abb939a31e3fdb994c4e0043268aa41c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "953"
-      X-Request-Id:
-      - 0e007f98-59bb-4c60-ba55-c58b76fe7e64
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"abb939a31e3fdb994c4e0043268aa41c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - f7069b65-3185-49dd-81ef-7f70fd46c750
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rsQhpA9zoGrcRCp9","name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"5b214aec7c6d68ff813f51877c7a1d37"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "951"
-      X-Request-Id:
-      - 2b511e00-8e7f-49e9-9d44-43e6d5d47d2f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rsQhpA9zoGrcRCp9
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rsQhpA9zoGrcRCp9","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"},"name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:4a:44:27:9f:b4","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "502"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"5fb3047d935dbc1558adc069786cdb9f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - 472f4356-1e2e-46eb-ad65-1010bb38d659
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"abb939a31e3fdb994c4e0043268aa41c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "949"
-      X-Request-Id:
-      - 355c11c6-2840-4716-9a6d-7d4aa49d8ba3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_RpUyvZzOaFtW7cr3
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"17330d9aae638c95535bbde7f0e6abb5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "947"
-      X-Request-Id:
-      - 6b9a7f3e-35ab-47bd-83a3-98cf78776759
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "738"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"33c8bada425e1a98b265bc282a7235b7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "948"
-      X-Request-Id:
-      - bbfd2be5-89b0-4e37-8960-ba3d1707954f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"abb939a31e3fdb994c4e0043268aa41c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "946"
-      X-Request-Id:
-      - 2099ed2d-b06c-420b-8ebb-cc3b42517c90
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rsQhpA9zoGrcRCp9","name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"5b214aec7c6d68ff813f51877c7a1d37"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "945"
-      X-Request-Id:
-      - 1f38a8ad-615c-4d80-9784-9fd8f92df3a7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rsQhpA9zoGrcRCp9
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rsQhpA9zoGrcRCp9","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"},"name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:4a:44:27:9f:b4","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "502"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:12 GMT
-      Etag:
-      - W/"5fb3047d935dbc1558adc069786cdb9f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "944"
-      X-Request-Id:
-      - c0a27037-e8c2-435d-98c0-0919d0fdf19b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_RpUyvZzOaFtW7cr3
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"17330d9aae638c95535bbde7f0e6abb5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "942"
-      X-Request-Id:
-      - dab64ee3-9718-4694-9561-789c4d08a528
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "738"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"33c8bada425e1a98b265bc282a7235b7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "943"
-      X-Request-Id:
-      - 8492b745-e7b2-4ac3-94c4-1c424e26a160
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2337"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"abb939a31e3fdb994c4e0043268aa41c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "941"
-      X-Request-Id:
-      - 70f0ac20-fcdf-4c49-81a5-e0e79849dacc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rsQhpA9zoGrcRCp9","name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"5b214aec7c6d68ff813f51877c7a1d37"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "940"
-      X-Request-Id:
-      - 37c02535-3198-4201-a486-85831698317a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rsQhpA9zoGrcRCp9
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rsQhpA9zoGrcRCp9","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"},"name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:4a:44:27:9f:b4","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "502"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"5fb3047d935dbc1558adc069786cdb9f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "939"
-      X-Request-Id:
-      - 78eb034f-9b64-416b-9404-68298cce6843
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_RpUyvZzOaFtW7cr3
-    method: DELETE
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_RpUyvZzOaFtW7cr3","name":"tf-acc-test-update-group-qbwxtt4kqtwu","segregate":true,"created_at":1679595051}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "145"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"17330d9aae638c95535bbde7f0e6abb5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "938"
-      X-Request-Id:
-      - af7e7c3a-fe5b-4474-b521-d26010c45f59
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E"},"properties":{"group":null}}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_
-    method: PATCH
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "937"
-      X-Request-Id:
-      - cbd8cd55-5b65-4d66-96d2-8d07dd0a4919
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "934"
-      X-Request-Id:
-      - 3d89d2d8-23f2-4ccf-b9d6-be3aa908c047
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rsQhpA9zoGrcRCp9","name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"5b214aec7c6d68ff813f51877c7a1d37"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "932"
-      X-Request-Id:
-      - a72a8469-653d-4194-b412-7a274357b5b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rsQhpA9zoGrcRCp9
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rsQhpA9zoGrcRCp9","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"},"name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:4a:44:27:9f:b4","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "502"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:13 GMT
-      Etag:
-      - W/"5fb3047d935dbc1558adc069786cdb9f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "931"
-      X-Request-Id:
-      - 194679f1-8bb6-4af8-8ea3-638a1029e504
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:14 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "930"
-      X-Request-Id:
-      - 06261f15-3a3b-423b-93a6-8ebb73cee899
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "738"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:14 GMT
-      Etag:
-      - W/"33c8bada425e1a98b265bc282a7235b7"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "928"
-      X-Request-Id:
-      - ef0535ba-422d-4658-b715-56786c942b8a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:14 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "927"
-      X-Request-Id:
-      - ef58642b-7d05-4d6e-887c-a07af64cb730
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rsQhpA9zoGrcRCp9","name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "364"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:14 GMT
-      Etag:
-      - W/"5b214aec7c6d68ff813f51877c7a1d37"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "926"
-      X-Request-Id:
-      - 02e9228a-f961-4644-b8a0-a599271487d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rsQhpA9zoGrcRCp9
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_rsQhpA9zoGrcRCp9","virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker"},"name":"Public
-      Network on tf-acc-test-rainbow-better-woodpecker","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:4a:44:27:9f:b4","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "502"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:14 GMT
-      Etag:
-      - W/"5fb3047d935dbc1558adc069786cdb9f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "924"
-      X-Request-Id:
-      - dcdf593a-bb16-44be-9b67-30f574d02a2b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:14 GMT
-      Etag:
-      - W/"505863c7b39b663be6278a6f9e72d095"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "922"
-      X-Request-Id:
-      - 40ca38e7-0296-4008-b08d-477ff6e55310
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
     method: POST
   response:
-    body: '{"task":{"id":"task_XoShHj8yi981Imhz","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_isIdzldqgEN2ajqa","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2254,19 +2751,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:14 GMT
+      - Thu, 06 Feb 2025 16:41:02 GMT
       Etag:
-      - W/"414576d224a068d90f340ebd9ca8b8e2"
-      Server:
-      - Caddy
+      - W/"0766c40d6e2d41f963556d8aa3974028"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "921"
+      - "965"
       X-Request-Id:
-      - 9a5e6efe-7fbc-45a8-a3f7-7751bbf2a713
+      - 6414f8dd-9e47-4066-9181-4dda2d0daf3b
     status: 200 OK
     code: 200
     duration: ""
@@ -2277,14 +2774,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_XoShHj8yi981Imhz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_isIdzldqgEN2ajqa
     method: GET
   response:
-    body: '{"task":{"id":"task_XoShHj8yi981Imhz","name":"Stop virtual machine","status":"pending","created_at":1679595074,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_isIdzldqgEN2ajqa","name":"Stop virtual machine","status":"pending","created_at":1738860062,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2294,19 +2793,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:15 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"924c615fddadc8f8e543119180b18523"
-      Server:
-      - Caddy
+      - W/"8cf2f5d5321d928d5ccba120c4c15c0c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "954"
       X-Request-Id:
-      - f2249b0e-a675-4cae-bd69-fa4eafb1c6a1
+      - dc05c51d-3650-45dd-b558-1b3838e233bc
     status: 200 OK
     code: 200
     duration: ""
@@ -2317,14 +2816,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_XoShHj8yi981Imhz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_isIdzldqgEN2ajqa
     method: GET
   response:
-    body: '{"task":{"id":"task_XoShHj8yi981Imhz","name":"Stop virtual machine","status":"pending","created_at":1679595074,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_isIdzldqgEN2ajqa","name":"Stop virtual machine","status":"pending","created_at":1738860062,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2334,19 +2835,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:20 GMT
+      - Thu, 06 Feb 2025 16:41:08 GMT
       Etag:
-      - W/"924c615fddadc8f8e543119180b18523"
-      Server:
-      - Caddy
+      - W/"8cf2f5d5321d928d5ccba120c4c15c0c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "911"
+      - "890"
       X-Request-Id:
-      - dfc6af83-53e5-4170-8ea6-c5d22c902aef
+      - d10c120a-767c-431b-a4c5-b4c6181e57bb
     status: 200 OK
     code: 200
     duration: ""
@@ -2357,36 +2858,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_XoShHj8yi981Imhz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_isIdzldqgEN2ajqa
     method: GET
   response:
-    body: '{"task":{"id":"task_XoShHj8yi981Imhz","name":"Stop virtual machine","status":"running","created_at":1679595074,"started_at":1679595089,"finished_at":null,"progress":100}}'
+    body: '{"task":{"id":"task_isIdzldqgEN2ajqa","name":"Stop virtual machine","status":"pending","created_at":1738860062,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "170"
+      - "162"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:30 GMT
+      - Thu, 06 Feb 2025 16:41:18 GMT
       Etag:
-      - W/"216eae2d66e2fe22115677eaf7d3e5f6"
-      Server:
-      - Caddy
+      - W/"8cf2f5d5321d928d5ccba120c4c15c0c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "906"
+      - "855"
       X-Request-Id:
-      - 311e17cd-025d-477f-a1a3-a0079d9988ef
+      - e2f44366-c197-410c-955f-bcf0bce86060
     status: 200 OK
     code: 200
     duration: ""
@@ -2397,14 +2900,58 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_XoShHj8yi981Imhz
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_isIdzldqgEN2ajqa
     method: GET
   response:
-    body: '{"task":{"id":"task_XoShHj8yi981Imhz","name":"Stop virtual machine","status":"completed","created_at":1679595074,"started_at":1679595089,"finished_at":1679595092,"progress":100}}'
+    body: '{"task":{"id":"task_isIdzldqgEN2ajqa","name":"Stop virtual machine","status":"running","created_at":1738860062,"started_at":1738860087,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:28 GMT
+      Etag:
+      - W/"8b327a861328d052ff9efd495508406c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "846"
+      X-Request-Id:
+      - 6e855438-c086-416e-869e-396c552203b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_isIdzldqgEN2ajqa
+    method: GET
+  response:
+    body: '{"task":{"id":"task_isIdzldqgEN2ajqa","name":"Stop virtual machine","status":"completed","created_at":1738860062,"started_at":1738860087,"finished_at":1738860090,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2414,19 +2961,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:38 GMT
       Etag:
-      - W/"ee939bf723c5e8c3691a740b0e0d963e"
-      Server:
-      - Caddy
+      - W/"9e1174f2c5bb4ef881602bd5dcff9e44"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "849"
+      - "843"
       X-Request-Id:
-      - bd62062a-18f6-4e69-bf50-7a232f58e97b
+      - 91699956-88de-48ad-9138-bdb4f297358b
     status: 200 OK
     code: 200
     duration: ""
@@ -2437,43 +2984,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2222"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:41 GMT
+      - Thu, 06 Feb 2025 16:41:39 GMT
       Etag:
-      - W/"a04958426167bddd31893415a3d543d0"
-      Server:
-      - Caddy
+      - W/"efe2a2d3c9fbe74b0f6114eff4c6d477"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "833"
+      - "837"
       X-Request-Id:
-      - 8aa2c9c6-d870-4c54-a218-cd30cb576551
+      - 477eb3f3-bcc8-4d1a-afa2-1cd84aefa19e
     status: 200 OK
     code: 200
     duration: ""
@@ -2484,43 +3032,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_PmLBgUUm0U8eAydU","keep_until":1679767901,"object_id":"vm_hiRYQT5BbjbLyC2E","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_hiRYQT5BbjbLyC2E","name":"tf-acc-test-rainbow-better-woodpecker","hostname":"tf-acc-test-rainbow-better-woodpecker","fqdn":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595053,"initial_root_password":"YXkbg5J50gkRGmtQ","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_qFScXjHQeyNQOnoG","keep_until":1739032899,"object_id":"vm_FcDj8Af1kqFuhR45","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_FcDj8Af1kqFuhR45","name":"tf-acc-test-silent-intimidating-eagle","hostname":"tf-acc-test-silent-intimidating-eagle","fqdn":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860030,"initial_root_password":"jPzouVxLoDnceWZI","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-rainbow-better-woodpecker.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_hiRYQT5BbjbLyC2E","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_T9HFO8cKRx7BgJr1","address":"185.44.252.93","reverse_dns":"tf-acc-test-silent-intimidating-eagle.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_FcDj8Af1kqFuhR45","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2357"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:39 GMT
       Etag:
-      - W/"e78121f77f63422a50143919ddf9934e"
-      Server:
-      - Caddy
+      - W/"5d491f3faf5ba0de4935832a2d5b0dcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "830"
+      - "836"
       X-Request-Id:
-      - 555fec08-b6e9-45e1-848a-1a9aac46fd14
+      - 2f2e1e42-acfc-4993-9a18-38f4e3eb6139
     status: 200 OK
     code: 200
     duration: ""
@@ -2531,14 +3080,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2548,19 +3099,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:40 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "823"
+      - "835"
       X-Request-Id:
-      - 2b2431c5-f6a4-41d5-82b5-4e348f663a9e
+      - 727f2171-fd01-4455-8107-eae4343d085e
     status: 200 OK
     code: 200
     duration: ""
@@ -2571,14 +3122,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_FcDj8Af1kqFuhR45
     method: DELETE
   response:
-    body: '{"task":{"id":"task_2jUDmF4r0mbI2vEs","name":"Purge items from trash","status":"pending","created_at":1679595102,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_XomZ40nk07Ea8ROu","name":"Purge items from trash","status":"pending","created_at":1738860100,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2588,19 +3141,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:40 GMT
       Etag:
-      - W/"5fb91890839c6594c0013d7c985c08a8"
-      Server:
-      - Caddy
+      - W/"ad7f001138c3ee546502f27a85cd52ed"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "810"
+      - "834"
       X-Request-Id:
-      - ec2fba1e-7017-4207-93f8-38fc29490961
+      - 0cd0a05a-a11c-4353-986f-3c00032e45c7
     status: 200 OK
     code: 200
     duration: ""
@@ -2611,14 +3164,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_FcDj8Af1kqFuhR45
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_PmLBgUUm0U8eAydU","keep_until":1679767901,"object_id":"vm_hiRYQT5BbjbLyC2E","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_qFScXjHQeyNQOnoG","keep_until":1739032899,"object_id":"vm_FcDj8Af1kqFuhR45","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2628,19 +3183,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:43 GMT
+      - Thu, 06 Feb 2025 16:41:41 GMT
       Etag:
-      - W/"864788569ba46512a66912b634cce43d"
-      Server:
-      - Caddy
+      - W/"cc1b5a0d2c9333c09bef2954d3eee4d7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "799"
+      - "833"
       X-Request-Id:
-      - cbbf34de-e2e8-4d25-b631-366a5c51bfbc
+      - 48597ca5-b906-4f8e-9216-cbe8b9d58a4d
     status: 200 OK
     code: 200
     duration: ""
@@ -2651,14 +3206,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_FcDj8Af1kqFuhR45
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_PmLBgUUm0U8eAydU","keep_until":1679767901,"object_id":"vm_hiRYQT5BbjbLyC2E","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_qFScXjHQeyNQOnoG","keep_until":1739032899,"object_id":"vm_FcDj8Af1kqFuhR45","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2668,19 +3225,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:48 GMT
+      - Thu, 06 Feb 2025 16:41:46 GMT
       Etag:
-      - W/"864788569ba46512a66912b634cce43d"
-      Server:
-      - Caddy
+      - W/"cc1b5a0d2c9333c09bef2954d3eee4d7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "784"
+      - "826"
       X-Request-Id:
-      - a771741b-79d1-402f-a0e5-56d7bc3d14b8
+      - c4d834f5-f728-4fc2-901a-289655549ddc
     status: 200 OK
     code: 200
     duration: ""
@@ -2691,15 +3248,59 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_FcDj8Af1kqFuhR45
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_qFScXjHQeyNQOnoG","keep_until":1739032899,"object_id":"vm_FcDj8Af1kqFuhR45","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:56 GMT
+      Etag:
+      - W/"cc1b5a0d2c9333c09bef2954d3eee4d7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "825"
+      X-Request-Id:
+      - ffe6d688-14eb-4970-9988-f8308d192e74
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_FcDj8Af1kqFuhR45
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2709,19 +3310,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:58 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:42:06 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "760"
+      - "999"
       X-Request-Id:
-      - 5c45ca7a-bd8b-4b42-8f14-a3a4d48055f4
+      - 81a72088-6f36-4633-b3b9-7921049c1bc5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2732,14 +3333,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2749,19 +3352,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:58 GMT
+      - Thu, 06 Feb 2025 16:42:06 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "759"
+      - "998"
       X-Request-Id:
-      - 5166eb7b-ea63-43ba-95e4-da4bcfb2bce6
+      - 660cd299-db23-4786-ab5d-3f6071e37b4a
     status: 200 OK
     code: 200
     duration: ""
@@ -2772,15 +3375,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_FcDj8Af1kqFuhR45
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2790,19 +3395,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:58 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:42:06 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "758"
+      - "997"
       X-Request-Id:
-      - 8c647f99-4058-4e6b-93b1-bf17c59dda04
+      - 897cd8d7-5c99-4579-ad46-66919d031377
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2813,15 +3418,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_hiRYQT5BbjbLyC2E
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_FcDj8Af1kqFuhR45
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2831,19 +3438,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:58 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:42:06 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "757"
+      - "996"
       X-Request-Id:
-      - 6372075d-4ab2-476a-84da-0e3d5cff709c
+      - 7407aab1-826c-4e4c-864d-319f7201bd66
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2854,15 +3461,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_T9HFO8cKRx7BgJr1
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2872,19 +3481,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:58 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:42:06 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "756"
+      - "995"
       X-Request-Id:
-      - e45cc3f9-05c9-44c1-ae6b-99cb27d01b6e
+      - 062eaa64-ecd6-438b-bca4-e9ce52fb4d52
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_ips.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_ips.cassette.yaml
@@ -8,36 +8,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:09 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "973"
+      - "999"
       X-Request-Id:
-      - aa422897-e484-4b8d-be0c-01a927b384f2
+      - d6e4e0e6-6fe7-49a3-9d24-ec765cee8592
     status: 200 OK
     code: 200
     duration: ""
@@ -51,38 +53,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"185-44-255-199.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "552"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:15 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"786d5374035b29433c7d68f31c618264"
-      Server:
-      - Caddy
+      - W/"738d0fac5acf667df71916227635adcb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "972"
+      - "993"
       X-Request-Id:
-      - b284a1e8-b0f3-49d8-99be-e2e486c9d4cf
+      - 3c5d6543-29d6-45d8-8e33-d4e45692efae
     status: 200 OK
     code: 200
     duration: ""
@@ -93,38 +97,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"185-44-255-199.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:15 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"2f3ce063a8417469e1ef1750e98f47f2"
-      Server:
-      - Caddy
+      - W/"414171ee5fe1f0dccef809d2d8929926"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "920"
+      - "980"
       X-Request-Id:
-      - 5849dfa4-1ce4-4e29-a900-92c983673f27
+      - ffb74959-f8fb-402a-92d9-0f2042180f2c
     status: 200 OK
     code: 200
     duration: ""
@@ -135,44 +141,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"185-199-222-194.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"185-44-255-199.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "570"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:15 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"2f3ce063a8417469e1ef1750e98f47f2"
-      Server:
-      - Caddy
+      - W/"414171ee5fe1f0dccef809d2d8929926"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "919"
+      - "979"
       X-Request-Id:
-      - cf48e42c-e7fb-4d1c-ada0-61068d840467
+      - cdefc151-e04b-4c73-b4df-305d5f714042
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_bNVeyLPKVqujq5xL</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-tender-purring-leopard</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_tOxENxunxZKXcBKj</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-short-shrill-kumquat</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -180,36 +188,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_W8jPxXkjp2l44LZz","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_E4MSY4SUue7TMVwe","state":"pending"},"virtual_machine_build":{"id":"vmbuild_E4MSY4SUue7TMVwe","state":"pending"},"hostname":"tf-acc-test-tender-purring-leopard"}'
+    body: '{"task":{"id":"task_0HFP3TVVjw302W3g","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_btCphJCopWpNWwgW","state":"pending"},"virtual_machine_build":{"id":"vmbuild_btCphJCopWpNWwgW","state":"pending"},"hostname":"tf-acc-test-short-shrill-kumquat","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "273"
+      - "288"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:15 GMT
+      - Thu, 06 Feb 2025 16:40:20 GMT
       Etag:
-      - W/"1b21308693518138e13355e751096862"
-      Server:
-      - Caddy
+      - W/"21df126c2974eab7c49a7a4bc347b9c1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "918"
+      - "978"
       X-Request-Id:
-      - a734d8c2-7e4e-49c8-bf73-6a5e956a0af4
+      - ed5f6fd0-c6af-4902-9e57-9876fea782ee
     status: 201 Created
     code: 201
     duration: ""
@@ -220,43 +230,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_E4MSY4SUue7TMVwe
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_btCphJCopWpNWwgW
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_E4MSY4SUue7TMVwe","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_btCphJCopWpNWwgW","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-tender-purring-leopard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.199\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-short-shrill-kumquat\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595075}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1597"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:17 GMT
+      - Thu, 06 Feb 2025 16:40:22 GMT
       Etag:
-      - W/"b166221a4f10c107224c26a5b13c2d4f"
-      Server:
-      - Caddy
+      - W/"9d1689b059a2b4e5572c463667f4939d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "916"
+      - "974"
       X-Request-Id:
-      - 895a4c0d-1516-43f2-9604-fde847a5b0ae
+      - 2e63f512-4be9-44c3-acf7-2752bc60b2e5
     status: 200 OK
     code: 200
     duration: ""
@@ -267,43 +277,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_E4MSY4SUue7TMVwe
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_btCphJCopWpNWwgW
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_E4MSY4SUue7TMVwe","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_btCphJCopWpNWwgW","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-tender-purring-leopard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.199\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-short-shrill-kumquat\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595075}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1597"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:22 GMT
+      - Thu, 06 Feb 2025 16:40:27 GMT
       Etag:
-      - W/"b166221a4f10c107224c26a5b13c2d4f"
-      Server:
-      - Caddy
+      - W/"9d1689b059a2b4e5572c463667f4939d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "909"
+      - "970"
       X-Request-Id:
-      - 00ed65a1-bbaf-412a-b2b9-98add48485db
+      - 6a79eedc-e78d-488d-8664-db7feddff212
     status: 200 OK
     code: 200
     duration: ""
@@ -314,43 +324,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_E4MSY4SUue7TMVwe
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_btCphJCopWpNWwgW
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_E4MSY4SUue7TMVwe","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_btCphJCopWpNWwgW","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.222.194\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-tender-purring-leopard\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.199\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-short-shrill-kumquat\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595075}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1597"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:32 GMT
+      - Thu, 06 Feb 2025 16:40:37 GMT
       Etag:
-      - W/"f2a27ae2642999380041604209008f04"
-      Server:
-      - Caddy
+      - W/"de259c91666671b6c23d89a7125f0962"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "900"
+      - "966"
       X-Request-Id:
-      - 5a094821-472a-41f9-b912-4dfc83695bd4
+      - 04c7de8e-d94c-4599-aaa4-c74e943fb244
     status: 200 OK
     code: 200
     duration: ""
@@ -361,90 +371,138 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_btCphJCopWpNWwgW
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine_build":{"id":"vmbuild_btCphJCopWpNWwgW","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.199\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-short-shrill-kumquat\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860019},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:47 GMT
+      Etag:
+      - W/"de259c91666671b6c23d89a7125f0962"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - eecce04c-d5d9-482c-b55a-88259128ebaa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_btCphJCopWpNWwgW
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_btCphJCopWpNWwgW","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.199\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-short-shrill-kumquat\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","state":"allocating"},"created_at":1738860019},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:57 GMT
+      Etag:
+      - W/"15250364405d2340225f38c026b023eb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "910"
+      X-Request-Id:
+      - 2f1020cb-bdc4-4e4e-b132-8ea3ed5cd581
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
+      - Thu, 06 Feb 2025 16:40:59 GMT
       Etag:
-      - W/"8c53df8d8f98a448efe675d2efa6e853"
-      Server:
-      - Caddy
+      - W/"260a37917fbe7312389a65c22e07bb63"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "899"
-      X-Request-Id:
-      - 22977936-0666-4e36-ad62-90fe8519a043
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
-      Etag:
-      - W/"8c53df8d8f98a448efe675d2efa6e853"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "898"
       X-Request-Id:
-      - 6c07b4b3-b370-4537-9e62-e5f359bba548
+      - 0e4143aa-a07d-4980-994b-7fb155bfe2bf
     status: 200 OK
     code: 200
     duration: ""
@@ -455,127 +513,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "362"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
-      Etag:
-      - W/"b3d71288ba6f7895bef3e70fecd6b04f"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "897"
-      X-Request-Id:
-      - cd2892af-7c73-4168-a29e-b224284a9f68
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_f4FGlhuKmZRon9DU
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "497"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
-      Etag:
-      - W/"b9a97abb60a4aec1360f0d52e12ff857"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "896"
-      X-Request-Id:
-      - 0fc72233-c0da-472b-afd8-f9664bb7d0bc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"8c53df8d8f98a448efe675d2efa6e853"
-      Server:
-      - Caddy
+      - W/"db9d7b9097326dc7c53ef9372a264b94"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "895"
+      - "935"
       X-Request-Id:
-      - f65d72bf-d2b1-4662-9676-45ef39275b3f
+      - 74c8c49f-e98e-4f96-aa4a-5e3884762530
     status: 200 OK
     code: 200
     duration: ""
@@ -586,85 +561,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "734"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
-      Etag:
-      - W/"916171f1b98479c096a221ae79510a3c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "894"
-      X-Request-Id:
-      - 5913a432-34c4-4817-88c4-ae19bd270adc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:04 GMT
+      Etag:
+      - W/"db9d7b9097326dc7c53ef9372a264b94"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "934"
+      X-Request-Id:
+      - adbe0103-958d-4e6b-bf96-2de410fc0ae4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2212"
+      - "383"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"8c53df8d8f98a448efe675d2efa6e853"
-      Server:
-      - Caddy
+      - W/"be95ccdd3bdfbb84d0a835a8a4ad5ed0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "893"
+      - "933"
       X-Request-Id:
-      - 63d02244-255b-49ef-a64f-987283c3df36
+      - c9d787b1-e3cd-49fb-803e-85752a172d3b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:04 GMT
+      Etag:
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "932"
+      X-Request-Id:
+      - 27eefa89-97b1-4a24-a4c0-df8a925303e3
     status: 200 OK
     code: 200
     duration: ""
@@ -675,38 +693,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "362"
+      - "515"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"b3d71288ba6f7895bef3e70fecd6b04f"
-      Server:
-      - Caddy
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "892"
+      - "931"
       X-Request-Id:
-      - 96c0cf9e-5c43-4a9a-ab9f-032ec1d15cc0
+      - 067e6e49-af5b-4d64-b442-09e22d3e5d4b
     status: 200 OK
     code: 200
     duration: ""
@@ -717,127 +737,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_f4FGlhuKmZRon9DU
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "497"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
-      Etag:
-      - W/"b9a97abb60a4aec1360f0d52e12ff857"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "891"
-      X-Request-Id:
-      - 7840dc97-c8a3-464e-84cd-f1a3de12cb5a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "734"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
-      Etag:
-      - W/"916171f1b98479c096a221ae79510a3c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "890"
-      X-Request-Id:
-      - 22e64727-05cb-41ac-900c-cdcf2911c96d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"8c53df8d8f98a448efe675d2efa6e853"
-      Server:
-      - Caddy
+      - W/"db9d7b9097326dc7c53ef9372a264b94"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "889"
+      - "930"
       X-Request-Id:
-      - 2c5902c9-5bff-4335-89dd-72eda6522717
+      - 600ab020-791d-4a0c-9961-eee6654d38b8
     status: 200 OK
     code: 200
     duration: ""
@@ -848,38 +785,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"ip_address":{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "362"
+      - "743"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"b3d71288ba6f7895bef3e70fecd6b04f"
-      Server:
-      - Caddy
+      - W/"381bd3ddd3cb955a704f10837779cba3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "888"
+      - "929"
       X-Request-Id:
-      - b8c0ce4b-8260-4916-94ec-69f6a42158c9
+      - 2a4cd9c2-00c1-4ab4-a2c4-aae91af828ef
     status: 200 OK
     code: 200
     duration: ""
@@ -890,38 +829,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_f4FGlhuKmZRon9DU
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:04 GMT
+      Etag:
+      - W/"db9d7b9097326dc7c53ef9372a264b94"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "928"
+      X-Request-Id:
+      - e5251ce2-89ca-433c-a1e3-573da2e65d70
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "497"
+      - "383"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:35 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"b9a97abb60a4aec1360f0d52e12ff857"
-      Server:
-      - Caddy
+      - W/"be95ccdd3bdfbb84d0a835a8a4ad5ed0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "887"
+      - "927"
       X-Request-Id:
-      - 8921b7d9-74c6-47d3-96a9-25719051ff44
+      - c64a21da-5033-4160-a1aa-802acc6b0ffd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:04 GMT
+      Etag:
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "926"
+      X-Request-Id:
+      - fa7c66d2-561d-48d6-bf87-ee73597a5bdf
     status: 200 OK
     code: 200
     duration: ""
@@ -932,36 +961,302 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:04 GMT
+      Etag:
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "925"
+      X-Request-Id:
+      - da12260d-ce00-465e-82b5-0f2207c33b14
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "743"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:05 GMT
+      Etag:
+      - W/"381bd3ddd3cb955a704f10837779cba3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "924"
+      X-Request-Id:
+      - a5e636bd-fc02-46d0-b4e0-57994ec53150
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:05 GMT
+      Etag:
+      - W/"db9d7b9097326dc7c53ef9372a264b94"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "923"
+      X-Request-Id:
+      - d4bddf6d-7366-410b-a795-9f5832d6e195
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "383"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:05 GMT
+      Etag:
+      - W/"be95ccdd3bdfbb84d0a835a8a4ad5ed0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "921"
+      X-Request-Id:
+      - f3fb9547-d591-41d2-8620-6e8b8a65bef8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:05 GMT
+      Etag:
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "919"
+      X-Request-Id:
+      - 45b5b3de-d638-4375-87bc-3ffee7b26039
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:05 GMT
+      Etag:
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "918"
+      X-Request-Id:
+      - 9d8f7549-71dc-4708-b3e8-50bed68c17dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:36 GMT
+      - Thu, 06 Feb 2025 16:41:05 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "886"
+      - "917"
       X-Request-Id:
-      - fa65031a-c006-474d-9fec-8bf480ebcdc3
+      - 75f3d608-6f47-4bfa-8392-546d265b747a
     status: 200 OK
     code: 200
     duration: ""
@@ -975,38 +1270,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"185-199-222-82.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"185-44-255-49.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:41:05 GMT
       Etag:
-      - W/"621cf5e7e023db96570a2f8c12646d58"
-      Server:
-      - Caddy
+      - W/"1b5b0b25920ddf22e9c9bbd4f8fc320d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "885"
+      - "916"
       X-Request-Id:
-      - d81abe0d-4cf3-458f-99a2-ad593dd7b221
+      - d48c8b14-ada1-4d98-8aa4-536e7cd1ede6
     status: 200 OK
     code: 200
     duration: ""
@@ -1017,38 +1314,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"185-199-222-82.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"185-44-255-49.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:41:05 GMT
       Etag:
-      - W/"cda0687c826fe99974a1eaa7b8a9c2d8"
-      Server:
-      - Caddy
+      - W/"a062507a6b604deebe6684d01a381b4e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "870"
+      - "915"
       X-Request-Id:
-      - fa75bb98-568b-4668-a706-f4152454a309
+      - 79deb83b-87da-4640-ad7c-116df13cf757
     status: 200 OK
     code: 200
     duration: ""
@@ -1059,43 +1358,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2212"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:41:05 GMT
       Etag:
-      - W/"8c53df8d8f98a448efe675d2efa6e853"
-      Server:
-      - Caddy
+      - W/"db9d7b9097326dc7c53ef9372a264b94"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "867"
+      - "914"
       X-Request-Id:
-      - 2049a109-28fe-475a-9c80-fba27c9a31fc
+      - ea71c662-832b-4e2a-b175-fff7515f8b83
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,38 +1406,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "363"
+      - "383"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:41:05 GMT
       Etag:
-      - W/"9f3bc09db8b8178c9c710971f6799dbd"
-      Server:
-      - Caddy
+      - W/"be95ccdd3bdfbb84d0a835a8a4ad5ed0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "866"
+      - "913"
       X-Request-Id:
-      - f9e04007-502c-4b73-8434-aae698e9d213
+      - 30308d15-fc67-4c9e-8f02-b6610267a191
     status: 200 OK
     code: 200
     duration: ""
@@ -1148,44 +1450,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"185-199-222-82.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"185-44-255-49.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:39 GMT
+      - Thu, 06 Feb 2025 16:41:05 GMT
       Etag:
-      - W/"cda0687c826fe99974a1eaa7b8a9c2d8"
-      Server:
-      - Caddy
+      - W/"a062507a6b604deebe6684d01a381b4e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "865"
+      - "912"
       X-Request-Id:
-      - d4207108-7e34-4762-8737-58e7abe9881d
+      - 3a4953de-f8ac-4c83-9c17-e0b3b9a8fd44
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU"},"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH"}}
+      {"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2"},"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV"}}
     form: {}
     headers:
       Accept:
@@ -1193,44 +1497,46 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/allocate_ip
     method: POST
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "470"
+      - "487"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:06 GMT
       Etag:
-      - W/"2a44cd373ee8147d4ee4f4d6fca7f739"
-      Server:
-      - Caddy
+      - W/"820eacf3f536835e9017f5914f9e99cc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "864"
+      - "911"
       X-Request-Id:
-      - 719b795d-58a9-44ee-8322-1d14ddafc555
+      - b099814d-89a7-4dab-b3ba-e94dc7d5f45d
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm"},"properties":{}}
+      {"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS"},"properties":{}}
     form: {}
     headers:
       Accept:
@@ -1238,45 +1544,46 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2810"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:06 GMT
       Etag:
-      - W/"d140d6afd6decb2d1fe632f0d363c9fb"
-      Server:
-      - Caddy
+      - W/"faa6a8d82aa9524958c20fad34bd6795"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "861"
+      - "910"
       X-Request-Id:
-      - 71d616b0-6c9d-443d-9841-a3f347f27ad3
+      - b1e573c6-5c82-4f2c-b4ea-e631c587432f
     status: 200 OK
     code: 200
     duration: ""
@@ -1287,45 +1594,130 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:06 GMT
+      Etag:
+      - W/"faa6a8d82aa9524958c20fad34bd6795"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "909"
+      X-Request-Id:
+      - 0521c7e8-154b-4fc8-b827-2c691c565427
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2810"
+      - "438"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:06 GMT
       Etag:
-      - W/"d140d6afd6decb2d1fe632f0d363c9fb"
-      Server:
-      - Caddy
+      - W/"7a04c8a754322e4beeefbd97f105229e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "860"
+      - "908"
       X-Request-Id:
-      - f1bbaf73-8cd9-4c5f-bb19-275c560acfbf
+      - e611e2bd-692b-46a6-bc7b-94c607e6b21f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:06 GMT
+      Etag:
+      - W/"89cc174b28eb220ba433aedb1b160e37"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "907"
+      X-Request-Id:
+      - 82203909-09bb-498d-948e-18b9573878ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,38 +1728,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "418"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:06 GMT
       Etag:
-      - W/"74871bc2339da1dbb1d16c59d1d6a001"
-      Server:
-      - Caddy
+      - W/"89cc174b28eb220ba433aedb1b160e37"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "859"
+      - "906"
       X-Request-Id:
-      - 136b842b-2cb4-498a-9662-212e18fe6795
+      - 147a4718-daf1-43c9-a0d9-f75fd01ea3d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1378,87 +1772,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_f4FGlhuKmZRon9DU
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "553"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
-      Etag:
-      - W/"76008363f6c659a360a37806945db1a5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "858"
-      X-Request-Id:
-      - 5a476178-29b9-4486-b2fb-0e5ac6f34862
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2810"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:06 GMT
       Etag:
-      - W/"d140d6afd6decb2d1fe632f0d363c9fb"
-      Server:
-      - Caddy
+      - W/"faa6a8d82aa9524958c20fad34bd6795"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "857"
+      - "905"
       X-Request-Id:
-      - 8e6edaba-39c5-49a6-8682-fe24777e6537
+      - 66727f32-5c19-4eac-bc24-7bdf29b61fa4
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,38 +1822,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"}}}'
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "734"
+      - "741"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:06 GMT
       Etag:
-      - W/"916171f1b98479c096a221ae79510a3c"
-      Server:
-      - Caddy
+      - W/"c48abf31d7f3a07d13e03067824f0b4e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "856"
+      - "904"
       X-Request-Id:
-      - 08b4d59e-e305-4ee5-94b6-b4b34312841a
+      - d01eac39-43f0-45c1-9877-24d169f6e172
     status: 200 OK
     code: 200
     duration: ""
@@ -1511,38 +1866,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"}}}'
+    body: '{"ip_address":{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "743"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:06 GMT
       Etag:
-      - W/"bfa5c35c61d4f79ebb26f79aa01405ca"
-      Server:
-      - Caddy
+      - W/"381bd3ddd3cb955a704f10837779cba3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "855"
+      - "903"
       X-Request-Id:
-      - 7eccd249-13b9-46cb-9e25-591a8e361722
+      - 98251fe8-3218-405b-bb66-bd517fe2096d
     status: 200 OK
     code: 200
     duration: ""
@@ -1553,45 +1910,130 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:07 GMT
+      Etag:
+      - W/"faa6a8d82aa9524958c20fad34bd6795"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "902"
+      X-Request-Id:
+      - 24ed24a7-afd0-405b-81fe-b52b6758f02a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2810"
+      - "438"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:07 GMT
       Etag:
-      - W/"d140d6afd6decb2d1fe632f0d363c9fb"
-      Server:
-      - Caddy
+      - W/"7a04c8a754322e4beeefbd97f105229e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "854"
+      - "901"
       X-Request-Id:
-      - fdfaf4a8-b5a4-42fa-9f3e-b80b0720c5e6
+      - d4fb8552-3f23-434c-aea9-0222e56f4acc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:07 GMT
+      Etag:
+      - W/"89cc174b28eb220ba433aedb1b160e37"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "900"
+      X-Request-Id:
+      - 913a3d56-c3a4-4e39-acf9-987ddd5678fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1602,38 +2044,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "418"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:07 GMT
       Etag:
-      - W/"74871bc2339da1dbb1d16c59d1d6a001"
-      Server:
-      - Caddy
+      - W/"89cc174b28eb220ba433aedb1b160e37"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "853"
+      - "899"
       X-Request-Id:
-      - dc8db028-9bdc-41cc-8bf9-44b96e1ff94d
+      - e421e38c-4c69-4b79-bc20-c1a52c4ce720
     status: 200 OK
     code: 200
     duration: ""
@@ -1644,38 +2088,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_f4FGlhuKmZRon9DU
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "553"
+      - "743"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:07 GMT
       Etag:
-      - W/"76008363f6c659a360a37806945db1a5"
-      Server:
-      - Caddy
+      - W/"381bd3ddd3cb955a704f10837779cba3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "852"
+      - "898"
       X-Request-Id:
-      - a349e319-8d16-49ff-be93-39446f059f76
+      - a88d4432-3fb1-4329-8160-6ad2b666de59
     status: 200 OK
     code: 200
     duration: ""
@@ -1686,38 +2132,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"}}}'
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "732"
+      - "741"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:07 GMT
       Etag:
-      - W/"bfa5c35c61d4f79ebb26f79aa01405ca"
-      Server:
-      - Caddy
+      - W/"c48abf31d7f3a07d13e03067824f0b4e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "851"
+      - "898"
       X-Request-Id:
-      - c858b679-a10d-4647-8b96-1116b4c19665
+      - dc7b29bf-8c63-43b4-91f3-0b1a092ad405
     status: 200 OK
     code: 200
     duration: ""
@@ -1728,87 +2176,130 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "734"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
-      Etag:
-      - W/"916171f1b98479c096a221ae79510a3c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "851"
-      X-Request-Id:
-      - be1fc255-837a-47c3-9c42-93bfcfb8b897
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:07 GMT
+      Etag:
+      - W/"faa6a8d82aa9524958c20fad34bd6795"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "896"
+      X-Request-Id:
+      - 0c6aeedd-90c5-4fa2-bfb8-858ae455ce27
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2810"
+      - "438"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:07 GMT
       Etag:
-      - W/"d140d6afd6decb2d1fe632f0d363c9fb"
-      Server:
-      - Caddy
+      - W/"7a04c8a754322e4beeefbd97f105229e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "848"
+      - "895"
       X-Request-Id:
-      - a091a73a-0f5f-46b5-87c4-810bda6ecdc4
+      - a67bf68f-c1e5-4aec-96bf-d61dc64c4e8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "570"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:07 GMT
+      Etag:
+      - W/"89cc174b28eb220ba433aedb1b160e37"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "894"
+      X-Request-Id:
+      - 22320495-336a-4afc-9555-ccfe11be9e0f
     status: 200 OK
     code: 200
     duration: ""
@@ -1819,38 +2310,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "418"
+      - "570"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
+      - Thu, 06 Feb 2025 16:41:07 GMT
       Etag:
-      - W/"74871bc2339da1dbb1d16c59d1d6a001"
-      Server:
-      - Caddy
+      - W/"89cc174b28eb220ba433aedb1b160e37"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "847"
+      - "893"
       X-Request-Id:
-      - 1c92babc-8204-4538-9094-8d9b700bc2d6
+      - 539e8717-6a22-402b-80af-08aba24e1ec9
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,87 +2354,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_f4FGlhuKmZRon9DU
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "553"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:40 GMT
-      Etag:
-      - W/"76008363f6c659a360a37806945db1a5"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "845"
-      X-Request-Id:
-      - 45470328-45e0-4222-9451-f3778b030ec3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2810"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:41 GMT
+      - Thu, 06 Feb 2025 16:41:07 GMT
       Etag:
-      - W/"d140d6afd6decb2d1fe632f0d363c9fb"
-      Server:
-      - Caddy
+      - W/"faa6a8d82aa9524958c20fad34bd6795"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "844"
+      - "892"
       X-Request-Id:
-      - 111072f9-1701-4628-9e2a-c066a9bc5886
+      - 8c28cae7-6894-4632-afff-874e1d619593
     status: 200 OK
     code: 200
     duration: ""
@@ -1952,14 +2404,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1969,25 +2423,25 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:41 GMT
+      - Thu, 06 Feb 2025 16:41:08 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "843"
+      - "891"
       X-Request-Id:
-      - 75dce37b-34ed-438a-8a01-4dbb3526fa00
+      - 8360d61e-c858-4356-9888-c5722469309f
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm"},"properties":{"tag_names":["lb","app","web"]}}
+      {"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS"},"properties":{"tag_names":["lb","app","web"]}}
     form: {}
     headers:
       Accept:
@@ -1995,43 +2449,44 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2496"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:41 GMT
+      - Thu, 06 Feb 2025 16:41:08 GMT
       Etag:
-      - W/"079b1350209cbff836b8c7659fc26328"
-      Server:
-      - Caddy
+      - W/"6b9f5f65595680aaa04c3e9a9492d47b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "838"
+      - "889"
       X-Request-Id:
-      - aaf938a0-5725-4b61-8ae3-2a2a4ce2abe4
+      - ac8a9ca7-cda6-4020-88d9-fa8fc82658df
     status: 200 OK
     code: 200
     duration: ""
@@ -2042,43 +2497,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:08 GMT
+      Etag:
+      - W/"6b9f5f65595680aaa04c3e9a9492d47b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "888"
+      X-Request-Id:
+      - 25f8a3fc-6628-4268-bc93-fbacd9ea6f43
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2496"
+      - "383"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:08 GMT
       Etag:
-      - W/"079b1350209cbff836b8c7659fc26328"
-      Server:
-      - Caddy
+      - W/"be95ccdd3bdfbb84d0a835a8a4ad5ed0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "825"
+      - "887"
       X-Request-Id:
-      - ff7fcf1b-dbd9-4a5f-984c-cfc0c90de858
+      - b6bae858-aa15-422a-97c9-a59149416cf3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:08 GMT
+      Etag:
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "886"
+      X-Request-Id:
+      - 1b5ea573-334b-4f90-b19f-b04a7c4d3eb1
     status: 200 OK
     code: 200
     duration: ""
@@ -2089,38 +2629,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "362"
+      - "515"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:08 GMT
       Etag:
-      - W/"b3d71288ba6f7895bef3e70fecd6b04f"
-      Server:
-      - Caddy
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "824"
+      - "885"
       X-Request-Id:
-      - 1d91ccad-607c-4c6d-a9f2-1f7b2fb12cac
+      - de104402-6ab5-4968-acd0-6a459be4686b
     status: 200 OK
     code: 200
     duration: ""
@@ -2131,85 +2673,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_f4FGlhuKmZRon9DU
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "497"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
-      Etag:
-      - W/"b9a97abb60a4aec1360f0d52e12ff857"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "822"
-      X-Request-Id:
-      - ab4822b3-6681-4b81-a540-160036377d58
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2496"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:09 GMT
       Etag:
-      - W/"079b1350209cbff836b8c7659fc26328"
-      Server:
-      - Caddy
+      - W/"6b9f5f65595680aaa04c3e9a9492d47b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "821"
+      - "884"
       X-Request-Id:
-      - 98a1001f-07d2-4997-8db2-8feabd7a491e
+      - e9b94e8a-b4e8-4f7f-812d-5cf3afb2fc34
     status: 200 OK
     code: 200
     duration: ""
@@ -2220,80 +2721,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "734"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
-      Etag:
-      - W/"916171f1b98479c096a221ae79510a3c"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "809"
-      X-Request-Id:
-      - 61e1965e-9ab3-45bb-9852-b5843ec8b255
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_z6ShjS7x8jv8GyKH","address":"185.199.222.82","reverse_dns":"185-199-222-82.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.82/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_I5iBFR5yTEbZlqZV","address":"185.44.255.49","reverse_dns":"185-44-255-49.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.49/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:09 GMT
       Etag:
-      - W/"cda0687c826fe99974a1eaa7b8a9c2d8"
-      Server:
-      - Caddy
+      - W/"a062507a6b604deebe6684d01a381b4e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "809"
+      - "883"
       X-Request-Id:
-      - 9982eefe-681c-4dfb-bd93-8534e85d7f0c
+      - 9b0e12af-bd11-4d0e-afc1-a28da6e3d987
     status: 200 OK
     code: 200
     duration: ""
@@ -2304,43 +2765,172 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"ip_address":{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "743"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:09 GMT
+      Etag:
+      - W/"381bd3ddd3cb955a704f10837779cba3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "882"
+      X-Request-Id:
+      - 191ba7b6-f51a-42ff-8598-072df1424bdc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:09 GMT
+      Etag:
+      - W/"6b9f5f65595680aaa04c3e9a9492d47b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "881"
+      X-Request-Id:
+      - f5772857-6ae4-442a-ab38-d8413a304900
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_zphrNgjrDus4bTO2","name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2496"
+      - "383"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:09 GMT
       Etag:
-      - W/"079b1350209cbff836b8c7659fc26328"
-      Server:
-      - Caddy
+      - W/"be95ccdd3bdfbb84d0a835a8a4ad5ed0"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "807"
+      - "880"
       X-Request-Id:
-      - 5afae63b-0f1d-40fe-bc8b-06803f162c1f
+      - 17891d9c-0580-4120-9a26-5970097a6e5b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "515"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:09 GMT
+      Etag:
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "879"
+      X-Request-Id:
+      - 866da92a-0fa5-48a6-a013-07014ffa1e9c
     status: 200 OK
     code: 200
     duration: ""
@@ -2351,38 +2941,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_zphrNgjrDus4bTO2
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_f4FGlhuKmZRon9DU","name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_zphrNgjrDus4bTO2","virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat"},"name":"Public
+      Network on tf-acc-test-short-shrill-kumquat","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:27:de:03:ef:95","state":"attached","ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "362"
+      - "515"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:09 GMT
       Etag:
-      - W/"b3d71288ba6f7895bef3e70fecd6b04f"
-      Server:
-      - Caddy
+      - W/"5ce9f46df268c64b8cb78e999fcfed8e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "806"
+      - "878"
       X-Request-Id:
-      - fc036e3c-e48a-4eba-abcd-bbe2f216b093
+      - ecb5efd2-8ec7-446d-be14-f74fd58061fc
     status: 200 OK
     code: 200
     duration: ""
@@ -2393,85 +2985,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_f4FGlhuKmZRon9DU
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_f4FGlhuKmZRon9DU","virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard"},"name":"Public
-      Network on tf-acc-test-tender-purring-leopard","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:96:1d:0d:a1:ab","state":"attached","ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "497"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
-      Etag:
-      - W/"b9a97abb60a4aec1360f0d52e12ff857"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "805"
-      X-Request-Id:
-      - 19339a5b-dbc1-47ca-8db4-128327abf5b0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2496"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:09 GMT
       Etag:
-      - W/"079b1350209cbff836b8c7659fc26328"
-      Server:
-      - Caddy
+      - W/"6b9f5f65595680aaa04c3e9a9492d47b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "802"
+      - "877"
       X-Request-Id:
-      - 8eaa3497-98d0-4a99-bb2a-e048c380a2b5
+      - ae6c13d1-2ecb-49ec-9bef-791510d537b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2482,14 +3033,58 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:09 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "876"
+      X-Request-Id:
+      - a7bed2cb-c27b-4ea7-97cc-3a4a94399527
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: POST
   response:
-    body: '{"task":{"id":"task_PvWCUDQiTk8fO7wc","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_KWwFUnv8AgKz0Uq9","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2499,19 +3094,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
+      - Thu, 06 Feb 2025 16:41:09 GMT
       Etag:
-      - W/"94dea1183b4185f939de4243c95e26d6"
-      Server:
-      - Caddy
+      - W/"ce670f4b49b293ecce8e15115b479645"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "800"
+      - "875"
       X-Request-Id:
-      - dc8fd335-2e3e-4491-b966-d2d69e786a51
+      - 43dc3929-f14d-49fa-9b05-97248645b3d9
     status: 200 OK
     code: 200
     duration: ""
@@ -2522,54 +3117,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:11:42 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "801"
-      X-Request-Id:
-      - 434aa3f4-d276-4d54-a4ce-10efe6f2839d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_PvWCUDQiTk8fO7wc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_KWwFUnv8AgKz0Uq9
     method: GET
   response:
-    body: '{"task":{"id":"task_PvWCUDQiTk8fO7wc","name":"Stop virtual machine","status":"running","created_at":1679595102,"started_at":1679595103,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_KWwFUnv8AgKz0Uq9","name":"Stop virtual machine","status":"running","created_at":1738860069,"started_at":1738860070,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2579,19 +3136,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:43 GMT
+      - Thu, 06 Feb 2025 16:41:10 GMT
       Etag:
-      - W/"ebee70692024b1ce0dabfb4197bb7085"
-      Server:
-      - Caddy
+      - W/"a852004a640aeb9813cfee284d936fb9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "797"
+      - "872"
       X-Request-Id:
-      - 799a8199-8ec1-48c2-8a76-0f99d76fb63e
+      - 564302ae-a584-488d-9204-8ff38c0a9890
     status: 200 OK
     code: 200
     duration: ""
@@ -2602,14 +3159,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_PvWCUDQiTk8fO7wc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_KWwFUnv8AgKz0Uq9
     method: GET
   response:
-    body: '{"task":{"id":"task_PvWCUDQiTk8fO7wc","name":"Stop virtual machine","status":"completed","created_at":1679595102,"started_at":1679595103,"finished_at":1679595107,"progress":100}}'
+    body: '{"task":{"id":"task_KWwFUnv8AgKz0Uq9","name":"Stop virtual machine","status":"completed","created_at":1738860069,"started_at":1738860070,"finished_at":1738860073,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2619,19 +3178,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:48 GMT
+      - Thu, 06 Feb 2025 16:41:15 GMT
       Etag:
-      - W/"a156e21eb19a4417af7dea7b70b78fd5"
-      Server:
-      - Caddy
+      - W/"17ef5d18658df02523c912be2928f92b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "782"
+      - "861"
       X-Request-Id:
-      - 74c9f3b2-e053-4005-bcb7-21ccbaf210f4
+      - b0a55149-0431-4797-aa9f-8df0eb3b20ba
     status: 200 OK
     code: 200
     duration: ""
@@ -2642,43 +3201,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2496"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:50 GMT
+      - Thu, 06 Feb 2025 16:41:16 GMT
       Etag:
-      - W/"b53ebe1e34ec2f55b7f9c2a1d365990d"
-      Server:
-      - Caddy
+      - W/"ace51d525bdc4d0967e4e7dd36e35b75"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "778"
+      - "860"
       X-Request-Id:
-      - d3caea55-03b2-4954-9a09-54e30eeb3898
+      - d9637e42-0aa5-4e28-b16e-0358e5fe56e9
     status: 200 OK
     code: 200
     duration: ""
@@ -2689,43 +3249,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_pWR2GxPWWWxNBVPD","keep_until":1679767910,"object_id":"vm_1i31DTTOiHAmpfSm","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_1i31DTTOiHAmpfSm","name":"tf-acc-test-tender-purring-leopard","hostname":"tf-acc-test-tender-purring-leopard","fqdn":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595077,"initial_root_password":"uttzVGq7lnqwBzKk","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_HqXxC7ObTNkvLyNt","keep_until":1739032876,"object_id":"vm_1n1jYQzatKHjPKDS","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_1n1jYQzatKHjPKDS","name":"tf-acc-test-short-shrill-kumquat","hostname":"tf-acc-test-short-shrill-kumquat","fqdn":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860031,"initial_root_password":"lq8AbCrJYB77WQpG","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_bNVeyLPKVqujq5xL","address":"185.199.222.194","reverse_dns":"tf-acc-test-tender-purring-leopard.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.222.194/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1i31DTTOiHAmpfSm","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329},{"id":"tag_mlIpqWdqnStbSOtr","name":"app","color":"pastel_yellow","created_at":1610041086},{"id":"tag_9l9FNBjBpuBbCMFc","name":"lb","color":"light_gray","created_at":1610155842}],"tag_names":["web","app","lb"],"ip_addresses":[{"id":"ip_tOxENxunxZKXcBKj","address":"185.44.255.199","reverse_dns":"tf-acc-test-short-shrill-kumquat.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.199/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_1n1jYQzatKHjPKDS","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2631"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:50 GMT
+      - Thu, 06 Feb 2025 16:41:17 GMT
       Etag:
-      - W/"2d00361bbde7759ab08b0d86d3e8c71c"
-      Server:
-      - Caddy
+      - W/"535ac8730b36d5f3b3590a5c98de8a59"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "776"
+      - "859"
       X-Request-Id:
-      - 1b40c2dd-ae7a-4a6b-a807-eef1eef54de2
+      - dc8771e0-4748-4034-9eaa-70ccfc970e6a
     status: 200 OK
     code: 200
     duration: ""
@@ -2736,14 +3297,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2753,19 +3316,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:50 GMT
+      - Thu, 06 Feb 2025 16:41:17 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "775"
+      - "858"
       X-Request-Id:
-      - 777240c9-316e-4232-9129-3905a10e50a0
+      - 2eac4006-2c63-4875-99a1-6503dc50d438
     status: 200 OK
     code: 200
     duration: ""
@@ -2776,14 +3339,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1n1jYQzatKHjPKDS
     method: DELETE
   response:
-    body: '{"task":{"id":"task_dXDIOOlVxiHoBpji","name":"Purge items from trash","status":"pending","created_at":1679595110,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_QTzwP1AUUOiA4fsh","name":"Purge items from trash","status":"pending","created_at":1738860077,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2793,19 +3358,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:50 GMT
+      - Thu, 06 Feb 2025 16:41:17 GMT
       Etag:
-      - W/"321c53e74ca5010096b5f61863c3a701"
-      Server:
-      - Caddy
+      - W/"6c59ea1db6ca2746df27883ccb3308b8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "773"
+      - "857"
       X-Request-Id:
-      - 51b4ee6e-b05a-402a-9d66-f51f7506d666
+      - 3404d467-c710-4a62-90a6-a61a15165c8c
     status: 200 OK
     code: 200
     duration: ""
@@ -2816,14 +3381,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_pWR2GxPWWWxNBVPD","keep_until":1679767910,"object_id":"vm_1i31DTTOiHAmpfSm","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_HqXxC7ObTNkvLyNt","keep_until":1739032876,"object_id":"vm_1n1jYQzatKHjPKDS","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2833,19 +3400,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:51 GMT
+      - Thu, 06 Feb 2025 16:41:18 GMT
       Etag:
-      - W/"4765a0108bf1724155efaebe228255f9"
-      Server:
-      - Caddy
+      - W/"84a27a327212ca632ef3e61d337dad7a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "771"
+      - "854"
       X-Request-Id:
-      - 4d1bb75b-7907-4f0d-9a0a-61c220150295
+      - 978d2426-8291-40f9-bc93-6f25efa3eaba
     status: 200 OK
     code: 200
     duration: ""
@@ -2856,14 +3423,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_pWR2GxPWWWxNBVPD","keep_until":1679767910,"object_id":"vm_1i31DTTOiHAmpfSm","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_HqXxC7ObTNkvLyNt","keep_until":1739032876,"object_id":"vm_1n1jYQzatKHjPKDS","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2873,19 +3442,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:11:56 GMT
+      - Thu, 06 Feb 2025 16:41:23 GMT
       Etag:
-      - W/"4765a0108bf1724155efaebe228255f9"
-      Server:
-      - Caddy
+      - W/"84a27a327212ca632ef3e61d337dad7a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "761"
+      - "852"
       X-Request-Id:
-      - 43a2d117-e482-4d02-ba09-ba9e0a0ed0cd
+      - 695a77a5-14f7-4ff4-ba01-7c618c7bdc17
     status: 200 OK
     code: 200
     duration: ""
@@ -2896,14 +3465,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_pWR2GxPWWWxNBVPD","keep_until":1679767910,"object_id":"vm_1i31DTTOiHAmpfSm","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_HqXxC7ObTNkvLyNt","keep_until":1739032876,"object_id":"vm_1n1jYQzatKHjPKDS","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2913,19 +3484,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:06 GMT
+      - Thu, 06 Feb 2025 16:41:33 GMT
       Etag:
-      - W/"4765a0108bf1724155efaebe228255f9"
-      Server:
-      - Caddy
+      - W/"84a27a327212ca632ef3e61d337dad7a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "974"
+      - "844"
       X-Request-Id:
-      - b0087c81-e91c-4b96-ba4c-2e7bbcb866fd
+      - ab81f48b-44b7-4898-925f-d4f57f4be960
     status: 200 OK
     code: 200
     duration: ""
@@ -2936,15 +3507,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2954,19 +3527,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:16 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:43 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "832"
       X-Request-Id:
-      - f48aca47-7e27-4023-b77a-d47554dd4a6e
+      - e5611d59-14c5-482e-9215-8ad54706bdb4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2977,14 +3550,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2994,19 +3569,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
+      - Thu, 06 Feb 2025 16:41:44 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "831"
       X-Request-Id:
-      - ede8f69a-6895-4c4d-83ac-7b4a3176e94b
+      - e7926253-7526-4bac-9d55-05a3d7640656
     status: 200 OK
     code: 200
     duration: ""
@@ -3017,15 +3592,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3035,19 +3612,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:44 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "830"
       X-Request-Id:
-      - 1e248672-0a74-481a-acc5-ecae295f56f7
+      - bfa17a19-8592-4659-9e56-e26da66e3fa4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3058,15 +3635,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1i31DTTOiHAmpfSm
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_1n1jYQzatKHjPKDS
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3076,19 +3655,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:44 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "829"
       X-Request-Id:
-      - 842cf01b-51f9-484f-a4a7-fbf4fdeded2f
+      - 9d65e7d7-ce64-4c22-836a-70d8388d8f01
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3099,15 +3678,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_z6ShjS7x8jv8GyKH
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_I5iBFR5yTEbZlqZV
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3117,19 +3698,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:44 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "828"
       X-Request-Id:
-      - 16d720bc-9a8d-4e03-ae89-83cb4b2b1094
+      - 60c212ec-3176-42d1-82cb-19d736a55391
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3140,15 +3721,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_bNVeyLPKVqujq5xL
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_tOxENxunxZKXcBKj
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -3158,19 +3741,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:12:17 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:44 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "827"
       X-Request-Id:
-      - 4d06adc9-48ab-4258-a1d9-6e22754a9b1e
+      - 3ba6210e-fa3d-47b7-94ff-84197286d95f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.rand_id
+++ b/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.rand_id
@@ -1,1 +1,1 @@
-y3263shxf973
+tcebk7cewjce

--- a/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.yaml
+++ b/internal/provider/testdata/VirtualMachine_update_network_speed_profile.cassette.yaml
@@ -8,36 +8,38 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/data_centers/_/default_network?data_center%5Bpermalink%5D=uk-lon-01
     method: GET
   response:
-    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
+    body: '{"network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "181"
+      - "196"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:08 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"d60d47b2ba0b179327bb89a97b1c0e77"
-      Server:
-      - Caddy
+      - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "973"
+      - "999"
       X-Request-Id:
-      - 7c373728-c294-4258-9d93-451da2b0eee9
+      - 7e0c0337-d354-4e22-b374-ec3dc7805287
     status: 200 OK
     code: 200
     duration: ""
@@ -51,38 +53,40 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"185-44-253-113.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "549"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:08 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"137b10129b421fd5b21a6014fed1266d"
-      Server:
-      - Caddy
+      - W/"6f3c4094b2995f0dd60c41a83d564d21"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "971"
+      - "993"
       X-Request-Id:
-      - d1516525-1e85-4974-99d0-d5afe603a70e
+      - abe0faf5-0d46-4764-8fa1-206cb6e88d00
     status: 200 OK
     code: 200
     duration: ""
@@ -93,38 +97,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"185-44-253-113.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:08 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"ed756f7534ea083f21fb8c3b4dd7ba21"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "983"
       X-Request-Id:
-      - 28dc55e4-f937-4e12-81ad-59995cd406be
+      - 3e5b6d06-6e6c-4388-aa4b-72872731c1ed
     status: 200 OK
     code: 200
     duration: ""
@@ -135,44 +141,46 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"185-199-221-65.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"ip_address":{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"185-44-253-113.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:08 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"e2dd9834428ed6e25c43af1579322fc9"
-      Server:
-      - Caddy
+      - W/"ed756f7534ea083f21fb8c3b4dd7ba21"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "965"
+      - "982"
       X-Request-Id:
-      - 71625f1f-28ef-4eb4-9e46-f23c138457c7
+      - d153e305-5c2b-4400-975b-4cd23cc1c3bf
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_hc3GUyhBe6toov2e</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-fierce-young-owl</Hostname></Hostname><Name>tf-acc-test-update-network-speed-profile-y3263shxf973</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_g5lU7r1UXaw9kcF0</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-thundering-modern-zinc</Hostname></Hostname><Name>tf-acc-test-update-network-speed-profile-tcebk7cewjce</Name><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -180,36 +188,38 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Jy5hHqygBHEP2dPZ","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_WMEsOc6gBD3YPsZY","state":"pending"},"virtual_machine_build":{"id":"vmbuild_WMEsOc6gBD3YPsZY","state":"pending"},"hostname":"tf-acc-test-fierce-young-owl"}'
+    body: '{"task":{"id":"task_3JQFjH7RC1c5Qg9Y","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_nhrtVIs87oGOe0f6","state":"pending"},"virtual_machine_build":{"id":"vmbuild_nhrtVIs87oGOe0f6","state":"pending"},"hostname":"tf-acc-test-thundering-modern-zinc","annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "267"
+      - "290"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:09 GMT
+      - Thu, 06 Feb 2025 16:40:19 GMT
       Etag:
-      - W/"ea672c945bf0e70396844b1b99e2c970"
-      Server:
-      - Caddy
+      - W/"e7e8e9a5ff755d0c14938407e6c9f0b2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "981"
       X-Request-Id:
-      - 08f74cb9-768a-400a-9429-27ac5978191d
+      - 3b83d027-3357-444d-8ef9-6fd84df26b27
     status: 201 Created
     code: 201
     duration: ""
@@ -220,43 +230,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_WMEsOc6gBD3YPsZY
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_nhrtVIs87oGOe0f6
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_WMEsOc6gBD3YPsZY","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_nhrtVIs87oGOe0f6","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-fierce-young-owl\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-y3263shxf973\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.113\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-thundering-modern-zinc\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-tcebk7cewjce\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595009}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1687"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:11 GMT
+      - Thu, 06 Feb 2025 16:40:21 GMT
       Etag:
-      - W/"40213ca6bb86faaee23d991317a5331a"
-      Server:
-      - Caddy
+      - W/"1d0c12242747ba72ad3a028ca85fb01f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "930"
+      - "975"
       X-Request-Id:
-      - dc8ebf2b-3808-438d-8596-a6e09e46b00d
+      - f34a17b4-32d4-4418-b545-736b49ffa07a
     status: 200 OK
     code: 200
     duration: ""
@@ -267,43 +277,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_WMEsOc6gBD3YPsZY
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_nhrtVIs87oGOe0f6
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_WMEsOc6gBD3YPsZY","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_nhrtVIs87oGOe0f6","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-fierce-young-owl\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-y3263shxf973\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.113\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-thundering-modern-zinc\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-tcebk7cewjce\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1679595009}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1687"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:16 GMT
+      - Thu, 06 Feb 2025 16:40:26 GMT
       Etag:
-      - W/"40213ca6bb86faaee23d991317a5331a"
-      Server:
-      - Caddy
+      - W/"1d0c12242747ba72ad3a028ca85fb01f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "802"
+      - "971"
       X-Request-Id:
-      - 0b50dc4f-e7c4-4948-8f83-94acc141f53e
+      - 8b6ff965-7336-49d9-acec-ada5170feed1
     status: 200 OK
     code: 200
     duration: ""
@@ -314,43 +324,43 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_WMEsOc6gBD3YPsZY
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_nhrtVIs87oGOe0f6
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_WMEsOc6gBD3YPsZY","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_nhrtVIs87oGOe0f6","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.65\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-fierce-young-owl\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-y3263shxf973\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.113\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-thundering-modern-zinc\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-tcebk7cewjce\u003c/Name\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1679595009}}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738860019},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "1687"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:26 GMT
+      - Thu, 06 Feb 2025 16:40:36 GMT
       Etag:
-      - W/"ce699d389596a5b88b638e8b4c8bcc90"
-      Server:
-      - Caddy
+      - W/"8b1e5eb9e0efc43bf3b31ee437624edd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "763"
+      - "967"
       X-Request-Id:
-      - c2a9fe81-d79b-4c2f-908c-58282a6bd023
+      - d104d0a0-f7a6-47fc-bba1-b84c295be831
     status: 200 OK
     code: 200
     duration: ""
@@ -361,43 +371,91 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_nhrtVIs87oGOe0f6
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine_build":{"id":"vmbuild_nhrtVIs87oGOe0f6","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.113\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-thundering-modern-zinc\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cName\u003etf-acc-test-update-network-speed-profile-tcebk7cewjce\u003c/Name\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738860019},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:46 GMT
+      Etag:
+      - W/"14d8838cc1f519636cdc781260b253f2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - 9b6601e0-f7f8-459c-b143-134e650b6cbd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:48 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"f81547cd1ed48bc0dd2cbf20a6079e4c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "751"
+      - "959"
       X-Request-Id:
-      - 73c24814-7f81-4684-8137-2ee34793c1c5
+      - 3ddc8d05-0d1f-49dc-9403-2fa854ff4810
     status: 200 OK
     code: 200
     duration: ""
@@ -408,43 +466,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:53 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"7850d0976dff1111bb7d708905ea678a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "749"
+      - "957"
       X-Request-Id:
-      - f80a304c-1a83-4133-911b-e73b4a11a406
+      - f930bb5f-8675-4ce2-b4a4-c543d8ad3918
     status: 200 OK
     code: 200
     duration: ""
@@ -455,127 +514,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_20Qq0IPZSDUUrSMD","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "380"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
-      Etag:
-      - W/"c3a00daba70b038192d51cab7eaaffda"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "747"
-      X-Request-Id:
-      - 26f66ba3-51ab-4b3e-a1ec-5efce31ba100
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_20Qq0IPZSDUUrSMD
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_20Qq0IPZSDUUrSMD","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:54:28:ec:03:bc","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
-      Etag:
-      - W/"0404834bed94b5f859cb911e39ec4d38"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "746"
-      X-Request-Id:
-      - bfd0751d-0dc3-41aa-8b97-2b0166a748ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:54 GMT
+      Etag:
+      - W/"7850d0976dff1111bb7d708905ea678a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - ad498a65-41e3-444d-9a89-c7df4f9ff667
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VwwmmOoCPtpFUzLk","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2211"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:54 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"f03e1c63219e991366a93239bed85bcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "745"
+      - "954"
       X-Request-Id:
-      - d1ec884b-4681-4858-a691-1f1e03e8d448
+      - 2b3eb7d8-b6c7-42c0-ac4d-844c1ea45d3c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:54 GMT
+      Etag:
+      - W/"8224eff0148c6378c0283019ce185f31"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - 35841b2f-70f8-480f-a3ce-657c3dbaf5ca
     status: 200 OK
     code: 200
     duration: ""
@@ -586,38 +646,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "745"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:54 GMT
       Etag:
-      - W/"328e0b2e25c68dc419857f0afdb5c649"
-      Server:
-      - Caddy
+      - W/"8224eff0148c6378c0283019ce185f31"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "743"
+      - "950"
       X-Request-Id:
-      - e3d25e42-222c-4f2c-8813-aacd1545eed5
+      - c681cdd3-7212-40a0-84dd-18902cae150e
     status: 200 OK
     code: 200
     duration: ""
@@ -628,43 +690,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:54 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"7850d0976dff1111bb7d708905ea678a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "742"
+      - "948"
       X-Request-Id:
-      - 3f37e620-a9c2-4795-bdb7-c234fac5744b
+      - 70baf967-5856-4a02-8d9d-633b2c49ad19
     status: 200 OK
     code: 200
     duration: ""
@@ -675,38 +738,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_20Qq0IPZSDUUrSMD","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"ip_address":{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "766"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"c3a00daba70b038192d51cab7eaaffda"
-      Server:
-      - Caddy
+      - W/"420be6a6bf4b6f095af205db93ba5130"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "741"
+      - "946"
       X-Request-Id:
-      - 1864707d-af4c-4fd8-86b9-0f1859f561d2
+      - 90e6a814-897d-4a16-b58d-6a0ac084a55d
     status: 200 OK
     code: 200
     duration: ""
@@ -717,127 +782,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_20Qq0IPZSDUUrSMD
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_20Qq0IPZSDUUrSMD","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:54:28:ec:03:bc","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
-      Etag:
-      - W/"0404834bed94b5f859cb911e39ec4d38"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "740"
-      X-Request-Id:
-      - 021a68aa-5e42-4905-a1f1-946fa264ec71
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "745"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
-      Etag:
-      - W/"328e0b2e25c68dc419857f0afdb5c649"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "739"
-      X-Request-Id:
-      - 2c1efcc4-93ee-479b-aebc-af2e80aa9c4c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:55 GMT
+      Etag:
+      - W/"7850d0976dff1111bb7d708905ea678a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - b029d64a-cf4a-4f91-8e39-fd737b93ff32
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VwwmmOoCPtpFUzLk","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2211"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"f03e1c63219e991366a93239bed85bcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "738"
+      - "942"
       X-Request-Id:
-      - 54f040bf-a471-475a-aa13-19c26e804c21
+      - 9011826e-505e-4330-8df9-101f69c8d43d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:55 GMT
+      Etag:
+      - W/"8224eff0148c6378c0283019ce185f31"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "940"
+      X-Request-Id:
+      - be1c4a67-da1f-46d0-95a2-3c201b0fe6fd
     status: 200 OK
     code: 200
     duration: ""
@@ -848,38 +914,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_20Qq0IPZSDUUrSMD","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"c3a00daba70b038192d51cab7eaaffda"
-      Server:
-      - Caddy
+      - W/"8224eff0148c6378c0283019ce185f31"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "737"
+      - "939"
       X-Request-Id:
-      - f4db8a00-e245-4550-bbbd-117bf44e11e7
+      - a9568646-0818-4291-9807-4b31613205f6
     status: 200 OK
     code: 200
     duration: ""
@@ -890,38 +958,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_20Qq0IPZSDUUrSMD
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_20Qq0IPZSDUUrSMD","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:54:28:ec:03:bc","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "534"
+      - "766"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:28 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"0404834bed94b5f859cb911e39ec4d38"
-      Server:
-      - Caddy
+      - W/"420be6a6bf4b6f095af205db93ba5130"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "736"
+      - "938"
       X-Request-Id:
-      - 1577c17b-4ae8-41a3-9128-f5d8e8472ecd
+      - e96cda78-3497-4f65-8d4f-1fd880bb120f
     status: 200 OK
     code: 200
     duration: ""
@@ -932,43 +1002,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:55 GMT
+      Etag:
+      - W/"7850d0976dff1111bb7d708905ea678a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "937"
+      X-Request-Id:
+      - f5d7c54d-de59-4b91-99b0-46bb19eb3b51
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VwwmmOoCPtpFUzLk","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2211"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:29 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"f03e1c63219e991366a93239bed85bcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "732"
+      - "936"
       X-Request-Id:
-      - 4f5c578a-d2c9-49ee-9c80-b64ec99c0da2
+      - dd6cd8e5-6b44-4fa0-8f88-72fbb480db0e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:55 GMT
+      Etag:
+      - W/"8224eff0148c6378c0283019ce185f31"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "935"
+      X-Request-Id:
+      - 46974aeb-f2a5-4840-935a-cb91ea6b26f3
     status: 200 OK
     code: 200
     duration: ""
@@ -979,38 +1134,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "745"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:29 GMT
+      - Thu, 06 Feb 2025 16:40:55 GMT
       Etag:
-      - W/"328e0b2e25c68dc419857f0afdb5c649"
-      Server:
-      - Caddy
+      - W/"8224eff0148c6378c0283019ce185f31"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "729"
+      - "934"
       X-Request-Id:
-      - 036d1ffc-5f7a-4520-bdc0-3a60056fa63b
+      - ed264d11-5015-49b9-951c-b6936592f6c6
     status: 200 OK
     code: 200
     duration: ""
@@ -1021,43 +1178,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:29 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"7850d0976dff1111bb7d708905ea678a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "725"
+      - "931"
       X-Request-Id:
-      - 761f7a86-c425-47fa-b7c5-522729922632
+      - cdbe2020-b9b8-4e48-b800-a8c3c7d54ffd
     status: 200 OK
     code: 200
     duration: ""
@@ -1068,38 +1226,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_20Qq0IPZSDUUrSMD","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"ip_address":{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "766"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:29 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"c3a00daba70b038192d51cab7eaaffda"
-      Server:
-      - Caddy
+      - W/"420be6a6bf4b6f095af205db93ba5130"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "723"
+      - "927"
       X-Request-Id:
-      - 67fcb19d-7f11-4277-a2ee-ecec247759d6
+      - b0eda990-9580-4447-b846-46a2cca2c7c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1110,127 +1270,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_20Qq0IPZSDUUrSMD
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_20Qq0IPZSDUUrSMD","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:54:28:ec:03:bc","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:10:29 GMT
-      Etag:
-      - W/"0404834bed94b5f859cb911e39ec4d38"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "722"
-      X-Request-Id:
-      - 7ccc58db-dc6e-4fb6-bd05-0fff2e0534be
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "745"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:10:30 GMT
-      Etag:
-      - W/"328e0b2e25c68dc419857f0afdb5c649"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "720"
-      X-Request-Id:
-      - 383d3351-624b-4ccc-910f-38a30c3975e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"7850d0976dff1111bb7d708905ea678a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "925"
+      X-Request-Id:
+      - dd302f83-2d88-4468-a930-b7288f0a760c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VwwmmOoCPtpFUzLk","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2211"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:30 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"f03e1c63219e991366a93239bed85bcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "719"
+      - "923"
       X-Request-Id:
-      - fc60677b-1f00-4d10-b718-422b25a8a5e8
+      - 2b07d198-18e2-4fd9-a6fd-7a7fc2b006ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"8224eff0148c6378c0283019ce185f31"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "922"
+      X-Request-Id:
+      - 6009050c-8f21-4650-9ed7-56b4d7b3a0f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1241,38 +1402,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_20Qq0IPZSDUUrSMD","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:30 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"c3a00daba70b038192d51cab7eaaffda"
-      Server:
-      - Caddy
+      - W/"8224eff0148c6378c0283019ce185f31"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "717"
+      - "921"
       X-Request-Id:
-      - d87c74f2-908d-4782-99ef-9703955453a7
+      - a44c137d-95ab-4c66-8875-5b979ac98ad1
     status: 200 OK
     code: 200
     duration: ""
@@ -1283,38 +1446,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_20Qq0IPZSDUUrSMD
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_20Qq0IPZSDUUrSMD","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:54:28:ec:03:bc","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "534"
+      - "766"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:30 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"0404834bed94b5f859cb911e39ec4d38"
-      Server:
-      - Caddy
+      - W/"420be6a6bf4b6f095af205db93ba5130"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "716"
+      - "918"
       X-Request-Id:
-      - 8d06aa7a-8e0b-4bab-ba2d-0304be77f132
+      - 2b598707-0d1c-4204-aae3-d017f7ecb249
     status: 200 OK
     code: 200
     duration: ""
@@ -1325,44 +1490,222 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_20Qq0IPZSDUUrSMD","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"7850d0976dff1111bb7d708905ea678a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "917"
+      X-Request-Id:
+      - 21451608-5422-4cdd-83ee-db4cb4e60edd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VwwmmOoCPtpFUzLk","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "381"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:30 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"eec7b326db94ea6636895cf28cc6eb2c"
-      Server:
-      - Caddy
+      - W/"f03e1c63219e991366a93239bed85bcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "715"
+      - "916"
       X-Request-Id:
-      - a077dc1a-7d58-4e98-b135-0a684d14de2e
+      - fc8fc4d5-e0df-43ee-9edd-236caae542d9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"8224eff0148c6378c0283019ce185f31"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "915"
+      X-Request-Id:
+      - 6b3d2444-496d-4e7f-80aa-48813c8033f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"8224eff0148c6378c0283019ce185f31"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "914"
+      X-Request-Id:
+      - 75a08341-abed-4334-8502-dd291368a64a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VwwmmOoCPtpFUzLk","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "404"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:40:56 GMT
+      Etag:
+      - W/"f03e1c63219e991366a93239bed85bcc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "913"
+      X-Request-Id:
+      - 0e8c8041-0346-40af-a836-92ca03193437
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine_network_interface":{"id":"vmnet_20Qq0IPZSDUUrSMD"},"speed_profile":{"permalink":"1gbps"}}
+      {"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk"},"speed_profile":{"permalink":"1gbps"}}
     form: {}
     headers:
       Accept:
@@ -1370,15 +1713,17 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_/update_speed_profile
     method: PATCH
   response:
-    body: '{"task":{"id":"task_mCSdIQYhgpIVL3nR","name":"Change network interface
-      speed profile","status":"pending","created_at":1679595030,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_CAvu8Ak30cOeJQ4S","name":"Change network interface
+      speed profile","status":"pending","created_at":1738860056,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1388,19 +1733,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:30 GMT
+      - Thu, 06 Feb 2025 16:40:56 GMT
       Etag:
-      - W/"892d494b5cbae501e196cf0e96f92d2d"
-      Server:
-      - Caddy
+      - W/"24ae024fc39a7517e5dc7c884ff87d42"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "714"
+      - "912"
       X-Request-Id:
-      - 92433775-36a3-4c6a-82be-f5197914dfe2
+      - ea014d72-b762-441c-a2c9-b66a4410c132
     status: 200 OK
     code: 200
     duration: ""
@@ -1411,37 +1756,39 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_mCSdIQYhgpIVL3nR
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_CAvu8Ak30cOeJQ4S
     method: GET
   response:
-    body: '{"task":{"id":"task_mCSdIQYhgpIVL3nR","name":"Change network interface
-      speed profile","status":"running","created_at":1679595030,"started_at":1679595031,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_CAvu8Ak30cOeJQ4S","name":"Change network interface
+      speed profile","status":"pending","created_at":1738860056,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "186"
+      - "180"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:31 GMT
+      - Thu, 06 Feb 2025 16:40:57 GMT
       Etag:
-      - W/"1154904419486c14cc2065851b36e8d5"
-      Server:
-      - Caddy
+      - W/"24ae024fc39a7517e5dc7c884ff87d42"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "711"
+      - "908"
       X-Request-Id:
-      - 29aac255-bbc7-4807-81b1-bf2ae642db1a
+      - 4a83dd8c-463e-4fad-a502-69b20e55d3c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1452,15 +1799,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_mCSdIQYhgpIVL3nR
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_CAvu8Ak30cOeJQ4S
     method: GET
   response:
-    body: '{"task":{"id":"task_mCSdIQYhgpIVL3nR","name":"Change network interface
-      speed profile","status":"completed","created_at":1679595030,"started_at":1679595031,"finished_at":1679595032,"progress":100}}'
+    body: '{"task":{"id":"task_CAvu8Ak30cOeJQ4S","name":"Change network interface
+      speed profile","status":"completed","created_at":1738860056,"started_at":1738860058,"finished_at":1738860060,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1470,25 +1819,25 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:36 GMT
+      - Thu, 06 Feb 2025 16:41:02 GMT
       Etag:
-      - W/"330a2af843c254974c9937fa3d600a01"
-      Server:
-      - Caddy
+      - W/"753eeebad5dbda4eee57466742db90d1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "699"
+      - "962"
       X-Request-Id:
-      - df96a584-bfce-4b3c-b7ba-5e860bced4b3
+      - 993c0cd2-615d-46d4-bfaf-21b08bb353d3
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f"},"properties":{}}
+      {"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP"},"properties":{}}
     form: {}
     headers:
       Accept:
@@ -1496,43 +1845,44 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:36 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"7850d0976dff1111bb7d708905ea678a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "698"
+      - "961"
       X-Request-Id:
-      - 0c2d01a6-9de4-4891-b001-251a3597f2c3
+      - 744ccd77-70c3-4ce4-b681-9deaf22f90b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1543,43 +1893,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:03 GMT
+      Etag:
+      - W/"7850d0976dff1111bb7d708905ea678a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - 1d60ee56-a970-4091-834b-d6be7b5477d6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VwwmmOoCPtpFUzLk","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2211"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:36 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"f03e1c63219e991366a93239bed85bcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "697"
+      - "955"
       X-Request-Id:
-      - ad35a024-dbd7-4453-aadc-4cb7655f0f04
+      - 4708a4d7-6ddc-4b65-b314-020bd9392cc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "555"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:03 GMT
+      Etag:
+      - W/"99785c80209093c0f6e361d117c4f512"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - 7d58c0f2-1319-4445-9290-de7d7ab060e9
     status: 200 OK
     code: 200
     duration: ""
@@ -1590,38 +2025,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_20Qq0IPZSDUUrSMD","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "555"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:36 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"c3a00daba70b038192d51cab7eaaffda"
-      Server:
-      - Caddy
+      - W/"99785c80209093c0f6e361d117c4f512"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "695"
+      - "952"
       X-Request-Id:
-      - 67fbaee5-4aef-41ea-a0f9-954fbab7c7e4
+      - 48206433-42d8-4c08-9994-3be0f2455007
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,85 +2069,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_20Qq0IPZSDUUrSMD
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_20Qq0IPZSDUUrSMD","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:54:28:ec:03:bc","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "532"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:10:36 GMT
-      Etag:
-      - W/"91df73e6f2f27f786ab23544581b4492"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "694"
-      X-Request-Id:
-      - fdc71341-6dfe-451b-872c-a52a6940ce88
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:36 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"7850d0976dff1111bb7d708905ea678a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "693"
+      - "950"
       X-Request-Id:
-      - ee320284-7172-47df-9b37-e731d3b3ce9e
+      - d14af2da-afd0-4363-825f-f2238983a138
     status: 200 OK
     code: 200
     duration: ""
@@ -1721,38 +2117,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"}}}'
+    body: '{"ip_address":{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "745"
+      - "766"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:37 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"328e0b2e25c68dc419857f0afdb5c649"
-      Server:
-      - Caddy
+      - W/"420be6a6bf4b6f095af205db93ba5130"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "689"
+      - "947"
       X-Request-Id:
-      - c4832e09-d6cb-4412-9d9e-f3f143afc01b
+      - da900ae8-9db8-4bf9-9b92-ea2df043c0d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1763,43 +2161,128 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:03 GMT
+      Etag:
+      - W/"7850d0976dff1111bb7d708905ea678a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 13074e8f-aa6a-439f-bafd-e2c3fd8db6c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_VwwmmOoCPtpFUzLk","name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2211"
+      - "404"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:37 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"f03e1c63219e991366a93239bed85bcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "688"
+      - "944"
       X-Request-Id:
-      - e626e663-36ec-4099-bf67-4c4a9396b23f
+      - ba335454-325c-42dc-b175-60297bc47938
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "555"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:03 GMT
+      Etag:
+      - W/"99785c80209093c0f6e361d117c4f512"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - d0ee6f08-a27f-4f1b-a275-c14316e2d6f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1810,38 +2293,40 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_VwwmmOoCPtpFUzLk
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_20Qq0IPZSDUUrSMD","name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_VwwmmOoCPtpFUzLk","virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce"},"name":"Public
+      Network on tf-acc-test-update-network-speed-profile-tcebk7cewjce","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:20:36:5f:69:15","state":"attached","ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "380"
+      - "555"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:37 GMT
+      - Thu, 06 Feb 2025 16:41:03 GMT
       Etag:
-      - W/"c3a00daba70b038192d51cab7eaaffda"
-      Server:
-      - Caddy
+      - W/"99785c80209093c0f6e361d117c4f512"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "687"
+      - "940"
       X-Request-Id:
-      - 0d1ecf70-14cc-40e3-aac8-db2ad83f20a1
+      - 275cff47-9099-4f16-b4dc-7dff5cf3672a
     status: 200 OK
     code: 200
     duration: ""
@@ -1852,85 +2337,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_20Qq0IPZSDUUrSMD
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_20Qq0IPZSDUUrSMD","virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973"},"name":"Public
-      Network on tf-acc-test-update-network-speed-profile-y3263shxf973","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"mac_address":"3a:54:28:ec:03:bc","state":"attached","ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65"}],"speed_profile":{"id":"nsp_Y8YS65yTivlCAjIY","name":"1Gbps","permalink":"1gbps"}}}'
-    headers:
-      Access-Control-Allow-Methods:
-      - '*'
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "532"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 23 Mar 2023 18:10:37 GMT
-      Etag:
-      - W/"91df73e6f2f27f786ab23544581b4492"
-      Server:
-      - Caddy
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "686"
-      X-Request-Id:
-      - 1750348d-18e1-4fcd-af2c-1082a0c002fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:37 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"22c043dd0f348ee67049d1fffe06a922"
-      Server:
-      - Caddy
+      - W/"7850d0976dff1111bb7d708905ea678a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "683"
+      - "938"
       X-Request-Id:
-      - 36c8ff6e-097c-42ff-8889-7e00db9b905f
+      - bd53bf71-b09e-474c-8979-f943722db950
     status: 200 OK
     code: 200
     duration: ""
@@ -1941,14 +2385,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: POST
   response:
-    body: '{"task":{"id":"task_O38UL3bAyQEsxtlw","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_rsMbkpuONEQjqxtv","name":"Stop virtual machine","status":"pending"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1958,19 +2404,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:37 GMT
+      - Thu, 06 Feb 2025 16:41:04 GMT
       Etag:
-      - W/"50b2b6803f378b90ba71181ae9942cf3"
-      Server:
-      - Caddy
+      - W/"056f381c9eaaacd5025876d7bc465f94"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "682"
+      - "936"
       X-Request-Id:
-      - 2b03ae70-d022-484e-bbf4-534e0956a54f
+      - ccfefada-1a99-4823-a7ee-6fbd4a78cabe
     status: 200 OK
     code: 200
     duration: ""
@@ -1981,14 +2427,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_O38UL3bAyQEsxtlw
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_rsMbkpuONEQjqxtv
     method: GET
   response:
-    body: '{"task":{"id":"task_O38UL3bAyQEsxtlw","name":"Stop virtual machine","status":"running","created_at":1679595037,"started_at":1679595038,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_rsMbkpuONEQjqxtv","name":"Stop virtual machine","status":"running","created_at":1738860064,"started_at":1738860064,"finished_at":null,"progress":5}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -1998,19 +2446,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:38 GMT
+      - Thu, 06 Feb 2025 16:41:05 GMT
       Etag:
-      - W/"6e8665f691230e5a06d7151067fd6f49"
-      Server:
-      - Caddy
+      - W/"d728c586d5bb3150ebb66826cbfa486a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "676"
+      - "920"
       X-Request-Id:
-      - 1acffcb6-65a4-4306-821c-5a0bc9455750
+      - f10f338c-318c-4771-8a9b-9a3b3e58e96d
     status: 200 OK
     code: 200
     duration: ""
@@ -2021,14 +2469,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_O38UL3bAyQEsxtlw
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_rsMbkpuONEQjqxtv
     method: GET
   response:
-    body: '{"task":{"id":"task_O38UL3bAyQEsxtlw","name":"Stop virtual machine","status":"completed","created_at":1679595037,"started_at":1679595038,"finished_at":1679595041,"progress":100}}'
+    body: '{"task":{"id":"task_rsMbkpuONEQjqxtv","name":"Stop virtual machine","status":"completed","created_at":1738860064,"started_at":1738860064,"finished_at":1738860068,"progress":100}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2038,19 +2488,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:43 GMT
+      - Thu, 06 Feb 2025 16:41:10 GMT
       Etag:
-      - W/"427e197edfdcad56e54b3bda309f45c0"
-      Server:
-      - Caddy
+      - W/"efe4dad0f3019caba8237ce38ed36946"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "660"
+      - "873"
       X-Request-Id:
-      - 89afa7e5-304c-4844-8741-147ab7796af1
+      - 14605579-8182-4427-a5d9-f531ca48236b
     status: 200 OK
     code: 200
     duration: ""
@@ -2061,43 +2511,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2211"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:44 GMT
+      - Thu, 06 Feb 2025 16:41:11 GMT
       Etag:
-      - W/"4e367967754cabb29552839f4a996622"
-      Server:
-      - Caddy
+      - W/"9f22327ff9c40e298b4f55410e516566"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "658"
+      - "870"
       X-Request-Id:
-      - 82dd482e-50ef-4e32-a3c1-39862a4e4522
+      - 04b4e756-c7ff-42ff-a1b8-aa86c9de6a4f
     status: 200 OK
     code: 200
     duration: ""
@@ -2108,43 +2559,44 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_ZuCaqwtxSIfBdtVE","keep_until":1679767844,"object_id":"vm_xuSwwzpoGxwu4Y2f","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_xuSwwzpoGxwu4Y2f","name":"tf-acc-test-update-network-speed-profile-y3263shxf973","hostname":"tf-acc-test-fierce-young-owl","fqdn":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","description":null,"created_at":1679595010,"initial_root_password":"SimlTZ4Ry5W3RHNc","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+    body: '{"trash_object":{"id":"trsh_yssnu8nLWJUC2A05","keep_until":1739032871,"object_id":"vm_mrpZcFd2QQBGmjAP","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_mrpZcFd2QQBGmjAP","name":"tf-acc-test-update-network-speed-profile-tcebk7cewjce","hostname":"tf-acc-test-thundering-modern-zinc","fqdn":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738860028,"initial_root_password":"kCqVecHTUveJDcWj","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_hc3GUyhBe6toov2e","address":"185.199.221.65","reverse_dns":"tf-acc-test-fierce-young-owl.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.65/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_xuSwwzpoGxwu4Y2f","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_g5lU7r1UXaw9kcF0","address":"185.44.253.113","reverse_dns":"tf-acc-test-thundering-modern-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.113/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_mrpZcFd2QQBGmjAP","allocation_type":"VirtualMachine"}]}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2346"
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:44 GMT
+      - Thu, 06 Feb 2025 16:41:11 GMT
       Etag:
-      - W/"dd03f2328f358305461f37178632c6eb"
-      Server:
-      - Caddy
+      - W/"ba2cf83e161dee2cba2e22c86917d3b9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "657"
+      - "868"
       X-Request-Id:
-      - 16352b18-2550-47dc-b7a3-f1ea0b3cef43
+      - 9ecf1db6-3b54-46cd-8a73-256de8ba33f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2155,14 +2607,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: POST
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2172,19 +2626,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:45 GMT
+      - Thu, 06 Feb 2025 16:41:12 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "656"
+      - "866"
       X-Request-Id:
-      - 8d2121ae-2aa3-4c77-bf2e-9c599505da6b
+      - 2e705c6e-906e-4273-8e98-f55d3b2e1741
     status: 200 OK
     code: 200
     duration: ""
@@ -2195,14 +2649,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_mrpZcFd2QQBGmjAP
     method: DELETE
   response:
-    body: '{"task":{"id":"task_LeqKobdZmbCfxFYj","name":"Purge items from trash","status":"pending","created_at":1679595045,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_jzmtLtwaTedM4v58","name":"Purge items from trash","status":"pending","created_at":1738860072,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2212,19 +2668,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:45 GMT
+      - Thu, 06 Feb 2025 16:41:12 GMT
       Etag:
-      - W/"4b9707786c40ca7f7e2a8460fb6f184b"
-      Server:
-      - Caddy
+      - W/"3e53105469c3ab01bff826a8eb772ae8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "654"
+      - "864"
       X-Request-Id:
-      - f9902b95-c973-4217-a75a-dcf701c95f36
+      - 41428c6b-c7f5-4986-ac62-cdb53b019970
     status: 200 OK
     code: 200
     duration: ""
@@ -2235,14 +2691,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_ZuCaqwtxSIfBdtVE","keep_until":1679767844,"object_id":"vm_xuSwwzpoGxwu4Y2f","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_yssnu8nLWJUC2A05","keep_until":1739032871,"object_id":"vm_mrpZcFd2QQBGmjAP","object_type":"VirtualMachine"}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2252,19 +2710,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:46 GMT
+      - Thu, 06 Feb 2025 16:41:13 GMT
       Etag:
-      - W/"022021d208dd764bd6f36f3dd98268a7"
-      Server:
-      - Caddy
+      - W/"64a0162d888398e876c7b856603d812f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "653"
+      - "862"
       X-Request-Id:
-      - d826f03d-3388-482c-9724-82ab75dd1fd6
+      - e1d7d2b7-f88f-45fe-9e6b-b221da9e68ca
     status: 200 OK
     code: 200
     duration: ""
@@ -2275,15 +2733,101 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_yssnu8nLWJUC2A05","keep_until":1739032871,"object_id":"vm_mrpZcFd2QQBGmjAP","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:19 GMT
+      Etag:
+      - W/"64a0162d888398e876c7b856603d812f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "853"
+      X-Request-Id:
+      - a86ec4e6-f58b-4760-a969-f621cb2cf189
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_mrpZcFd2QQBGmjAP
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_yssnu8nLWJUC2A05","keep_until":1739032871,"object_id":"vm_mrpZcFd2QQBGmjAP","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 16:41:29 GMT
+      Etag:
+      - W/"64a0162d888398e876c7b856603d812f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "845"
+      X-Request-Id:
+      - 66ed0703-be38-4edd-ace4-a034a68fcfe8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2293,19 +2837,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "642"
+      - "842"
       X-Request-Id:
-      - bc677e19-9337-4410-97d4-1078148939fe
+      - 6ac33d63-d54c-432e-8f5f-bc8e879f284f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2316,14 +2860,16 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.3.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: DELETE
   response:
     body: '{}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2333,19 +2879,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
+      - Thu, 06 Feb 2025 16:41:39 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Server:
-      - Caddy
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "641"
+      - "841"
       X-Request-Id:
-      - 8025ab43-9a8b-48fb-883c-8ffab0429472
+      - e16ecb70-da94-47e9-bf0c-fdf44dcd68f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2356,15 +2902,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
     body: '{"error":{"code":"virtual_machine_not_found","description":"No virtual
       machine was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2374,19 +2922,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "640"
+      - "840"
       X-Request-Id:
-      - 999b9d23-521a-40e6-9c03-bed4e84fa8a4
+      - c1ada68b-f049-4e69-8c8e-3f7eaea677b3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2397,15 +2945,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_xuSwwzpoGxwu4Y2f
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_mrpZcFd2QQBGmjAP
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
       was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2415,19 +2965,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "639"
+      - "839"
       X-Request-Id:
-      - 5a51747c-3b6b-4e53-a63d-9c8f9a06a675
+      - c862a4b1-6449-43e2-8dc6-1594ea5b405d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2438,15 +2988,17 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.10.1 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_hc3GUyhBe6toov2e
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_g5lU7r1UXaw9kcF0
     method: GET
   response:
     body: '{"error":{"code":"ip_address_not_found","description":"No IP addresses
       were found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
       Access-Control-Allow-Methods:
-      - '*'
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
@@ -2456,19 +3008,19 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Mar 2023 18:10:51 GMT
-      Server:
-      - Caddy
+      - Thu, 06 Feb 2025 16:41:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Api-Schema:
       - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "638"
+      - "838"
       X-Request-Id:
-      - 76fffe51-3e03-417a-bb38-3c3d25e2c5a3
+      - 618db78b-38c0-47b2-9321-02321c77ed0b
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/v6provider/testdata/DataSourceFileStorageVolume_associations.cassette.rand_id
+++ b/internal/v6provider/testdata/DataSourceFileStorageVolume_associations.cassette.rand_id
@@ -1,1 +1,1 @@
-5w9Pa5UjMDS9
+PlrBPQ3GZVdk

--- a/internal/v6provider/testdata/DataSourceFileStorageVolume_associations.cassette.yaml
+++ b/internal/v6provider/testdata/DataSourceFileStorageVolume_associations.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:08:31 GMT
+      - Thu, 06 Feb 2025 17:40:20 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "999"
       X-Request-Id:
-      - 41648a48-fbc3-4b7e-a4b1-fb01ba92b093
+      - 80fc2c37-6a15-40b1-b10e-ed3c1ff5e878
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"185-53-57-139.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"185-44-252-231.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -69,9 +69,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:08:31 GMT
+      - Thu, 06 Feb 2025 17:40:20 GMT
       Etag:
-      - W/"b5afbe826e52657a3a307c161adbcea3"
+      - W/"be95a97f968359ea6edd68f030e35e04"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -79,9 +79,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "998"
       X-Request-Id:
-      - 2261db19-c539-4571-ba0a-2effe1cad7e7
+      - 6d80fc27-058f-4e59-acf2-ee450d12d2bf
     status: 200 OK
     code: 200
     duration: ""
@@ -91,10 +91,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_dunFi1ND20lnuHy2
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"185-53-57-139.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"185-44-252-231.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -111,9 +111,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:08:31 GMT
+      - Thu, 06 Feb 2025 17:40:20 GMT
       Etag:
-      - W/"d67cfe199bfb3175816bd98697701fa7"
+      - W/"e7bb9a8eee5f97e1526185c41fc94db1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -121,9 +121,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "997"
       X-Request-Id:
-      - a0d69aef-fe98-45e9-bfd9-4e267602a69c
+      - 2afd067d-62c5-4113-9bba-7df407d67007
     status: 200 OK
     code: 200
     duration: ""
@@ -134,11 +134,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_dunFi1ND20lnuHy2
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"185-53-57-139.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"185-44-252-231.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -155,9 +155,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:08:31 GMT
+      - Thu, 06 Feb 2025 17:40:20 GMT
       Etag:
-      - W/"d67cfe199bfb3175816bd98697701fa7"
+      - W/"e7bb9a8eee5f97e1526185c41fc94db1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -165,15 +165,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "996"
       X-Request-Id:
-      - 77947176-1a26-44f8-9a40-ca56105f18e9
+      - f53f8d6d-607e-40a1-ba57-c72fd8206d01
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_dunFi1ND20lnuHy2</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-associations-5w9pa5ujmds9-web</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_VY1yFEi3yDSPQG6i</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-associations-plrbpq3gzvdk-web</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -181,11 +181,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_aSEtWYfzPLzccPPz","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_DhpAdKzUpuRBtoOn","state":"pending"},"virtual_machine_build":{"id":"vmbuild_DhpAdKzUpuRBtoOn","state":"pending"},"hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","annotations":[]}'
+    body: '{"task":{"id":"task_IjBYDFonreDWBm5F","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_KWeRzaglw1mWkyra","state":"pending"},"virtual_machine_build":{"id":"vmbuild_KWeRzaglw1mWkyra","state":"pending"},"hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -200,9 +200,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:08:32 GMT
+      - Thu, 06 Feb 2025 17:40:20 GMT
       Etag:
-      - W/"cf6b56e4fcb1be71c7b9f65fb8eefd42"
+      - W/"3f0093ab157063a11cac9b645200b7e2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -210,9 +210,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "995"
       X-Request-Id:
-      - c71391bb-0c69-4d6e-88ca-832f797714f0
+      - f5014a62-d1f7-4ae8-bc9b-6b25c5ca5729
     status: 201 Created
     code: 201
     duration: ""
@@ -223,18 +223,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_DhpAdKzUpuRBtoOn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_KWeRzaglw1mWkyra
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DhpAdKzUpuRBtoOn","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_KWeRzaglw1mWkyra","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.139\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-5w9pa5ujmds9-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.231\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734710912},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863620},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -247,9 +247,150 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:08:34 GMT
+      - Thu, 06 Feb 2025 17:40:22 GMT
       Etag:
-      - W/"9b3e18e18ac8b09168bc86e5c4e7a16e"
+      - W/"093b315bcac2019156521712b9a5f13b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 5a3d63d8-928b-48f2-8cb6-f78f12291136
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_KWeRzaglw1mWkyra
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_KWeRzaglw1mWkyra","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.231\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863620},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:40:27 GMT
+      Etag:
+      - W/"093b315bcac2019156521712b9a5f13b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 40aa1a07-3b20-457e-ad79-2073a789193c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_KWeRzaglw1mWkyra
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_KWeRzaglw1mWkyra","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.231\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863620},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:40:37 GMT
+      Etag:
+      - W/"7440fa0787f4ee67727a6a1c54fd0c78"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 43845d19-1d6d-4d9f-8ca6-dbf8df6e87ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_KWeRzaglw1mWkyra
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_KWeRzaglw1mWkyra","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.231\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738863620},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:40:47 GMT
+      Etag:
+      - W/"49603d817748b5e587234c94eec7f818"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -259,7 +400,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "991"
       X-Request-Id:
-      - 78404943-8057-4fd9-8575-d5d25f16c973
+      - 774138fe-d983-4cf8-b020-55303115c0ff
     status: 200 OK
     code: 200
     duration: ""
@@ -270,18 +411,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_DhpAdKzUpuRBtoOn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DhpAdKzUpuRBtoOn","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.139\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-5w9pa5ujmds9-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734710912},"annotations":[]}'
+    body: '{"virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863628,"initial_root_password":"Ha7JooBGjwW0zHQF","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -294,9 +436,57 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:08:39 GMT
+      - Thu, 06 Feb 2025 17:40:49 GMT
       Etag:
-      - W/"588e5cc0774d0c295ea1151b7ed1fd16"
+      - W/"5c6286c3a13bf7597cf2a7abcfe4f50d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - d6d307fc-7bbf-48d1-936e-6fa1188d7a48
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863628,"initial_root_password":"Ha7JooBGjwW0zHQF","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:40:49 GMT
+      Etag:
+      - W/"5c6286c3a13bf7597cf2a7abcfe4f50d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -306,7 +496,91 @@ interactions:
       X-Ratelimit-Remaining:
       - "989"
       X-Request-Id:
-      - 81b86573-2e89-4425-b8e5-b2ca81677199
+      - 2926b249-9350-4229-9796-5d85b0e2673e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5KdjMHTdv3aO9Um","name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "404"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:40:49 GMT
+      Etag:
+      - W/"5e6da4f588f07c6d79ee7ac19188c2a2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 8e06abb6-824d-45be-a4f9-16456cc87b9d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_o5KdjMHTdv3aO9Um
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5KdjMHTdv3aO9Um","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:a7:00:b1:35:7e","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:40:49 GMT
+      Etag:
+      - W/"74d2a7eb4896e83cde22b8337545ef14"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - ca48c9b9-81f0-4d8a-8b0d-fec996f19783
     status: 200 OK
     code: 200
     duration: ""
@@ -317,18 +591,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_DhpAdKzUpuRBtoOn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5KdjMHTdv3aO9Um
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DhpAdKzUpuRBtoOn","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.139\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-5w9pa5ujmds9-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734710912},"annotations":[]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5KdjMHTdv3aO9Um","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:a7:00:b1:35:7e","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -338,12 +607,14 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:08:49 GMT
+      - Thu, 06 Feb 2025 17:40:49 GMT
       Etag:
-      - W/"588e5cc0774d0c295ea1151b7ed1fd16"
+      - W/"74d2a7eb4896e83cde22b8337545ef14"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -353,243 +624,12 @@ interactions:
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - 12761c5d-292a-4c76-9f90-f821300d10a1
+      - 0b68799c-fa84-45a4-a6c3-2a42ceee64a7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_DhpAdKzUpuRBtoOn
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_DhpAdKzUpuRBtoOn","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.53.57.139\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-5w9pa5ujmds9-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1734710912},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:08:59 GMT
-      Etag:
-      - W/"8b046e73060ee96b95fb0888f4298a79"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - 1d8145bd-5da9-4509-86c4-bafec13bbf59
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710915,"initial_root_password":"4GPENIiRmzjKtnEb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:01 GMT
-      Etag:
-      - W/"de13857259b09cff92ba4455c5f094f9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - e6221abd-a8e5-41ee-95b5-95f2ee1da817
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710915,"initial_root_password":"4GPENIiRmzjKtnEb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:01 GMT
-      Etag:
-      - W/"de13857259b09cff92ba4455c5f094f9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - bce8369d-0faa-4a63-a848-f3800edd27d8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_dbWR9KepGZsMZ4lV","name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "402"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:01 GMT
-      Etag:
-      - W/"54cf904a1a2fff8abfe0c97996427690"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - cfa9dfe6-c632-4145-8954-1ed234805474
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_dbWR9KepGZsMZ4lV
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_dbWR9KepGZsMZ4lV","virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web"},"name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:40:e3:87:0f:06","state":"attached","ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "556"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:01 GMT
-      Etag:
-      - W/"a7d509838bd845de32617a6d00a7fcb2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - df01ba7f-5223-4bc4-8c1d-8967bed135e5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"associations":["vm_5WOKgBEx3m2nrO5x"],"data_center":{"permalink":"uk-lon-01"},"name":"tf-acc-test-data-source-associations-5w9pa5ujmds9"}}'
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"associations":["vm_bOPHwyaA5dGKhMp9"],"data_center":{"permalink":"uk-lon-01"},"name":"tf-acc-test-data-source-associations-plrbpq3gzvdk"}}'
     form: {}
     headers:
       Content-Type:
@@ -599,7 +639,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/file_storage_volumes
     method: POST
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -614,331 +654,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:01 GMT
+      - Thu, 06 Feb 2025 17:40:50 GMT
       Etag:
-      - W/"d3582150808f7d3c2ab89f231eba0e35"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - 41f6dc56-3eb9-4ef6-ba9b-699581289273
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "303"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:03 GMT
-      Etag:
-      - W/"cfec53e3a1b9bd59a51a347cd49b0b41"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - 9ca5e3bb-ff7d-429d-b88f-304f2a405440
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "303"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:08 GMT
-      Etag:
-      - W/"cfec53e3a1b9bd59a51a347cd49b0b41"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - 2a6d0e01-6e69-4b71-a806-e82cc3b9d0c5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:18 GMT
-      Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - a807524b-9ab2-4a75-8f7d-868352303bcf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:18 GMT
-      Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - 152cd872-7312-4a26-9b1a-9b999923a9f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:18 GMT
-      Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - 29a84ff0-e167-43ae-aa4e-87875d271f5d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - 660ae77e-f13e-4e2d-b57a-91f18f49784d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - 57eb3b8e-1a6f-4630-a99d-86eca2026b21
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_dunFi1ND20lnuHy2
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "783"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"951f8a02ce721a2a1854139b38c1df55"
+      - W/"4b1807f92337ac0144331ab2735f3d2c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -948,30 +666,20 @@ interactions:
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - bb1eac83-9072-4122-bc66-243ee42db2bc
-    status: 200 OK
-    code: 200
+      - 6dd1ab80-50af-4379-8a11-b51bbbd84521
+    status: 201 Created
+    code: 201
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710915,"initial_root_password":"4GPENIiRmzjKtnEb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -981,12 +689,14 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Content-Length:
+      - "303"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
+      - Thu, 06 Feb 2025 17:40:52 GMT
       Etag:
-      - W/"de13857259b09cff92ba4455c5f094f9"
+      - W/"a0e5316f378cb75af84d782029e65590"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -996,7 +706,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "984"
       X-Request-Id:
-      - 824c3c69-f1d3-4e7a-a751-7da6bb877cb5
+      - ee9b3c93-da8a-4420-a32a-753d4b2eaa8a
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,16 +714,12 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_dbWR9KepGZsMZ4lV","name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139"}]}]}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1024,13 +730,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "402"
+      - "303"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
+      - Thu, 06 Feb 2025 17:40:57 GMT
       Etag:
-      - W/"54cf904a1a2fff8abfe0c97996427690"
+      - W/"a0e5316f378cb75af84d782029e65590"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1040,7 +746,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "983"
       X-Request-Id:
-      - a8f23a8d-64aa-4f50-83f5-3104a297e399
+      - cccaf36d-548f-459a-a6cf-daef32261a48
     status: 200 OK
     code: 200
     duration: ""
@@ -1048,16 +754,12 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_dbWR9KepGZsMZ4lV
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_dbWR9KepGZsMZ4lV","virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web"},"name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:40:e3:87:0f:06","state":"attached","ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1068,13 +770,729 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "556"
+      - "354"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
+      - Thu, 06 Feb 2025 17:41:07 GMT
       Etag:
-      - W/"a7d509838bd845de32617a6d00a7fcb2"
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - d4cb224c-add6-4c38-82bf-f3d4a93652c2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - c6f3f0e1-32c6-4ca4-95d8-2666c64920d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 44b38732-fabc-4544-bc57-9ceaf5222bd0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 2ff32e52-400c-4d63-a955-6b8685e76ebd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 7a46a110-b780-4aee-ae9c-91306ee0af77
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "785"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"55591b4f4e516fad7b43f26c87849ad3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 0acde809-292a-4298-95ea-5dbe98e17530
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863628,"initial_root_password":"Ha7JooBGjwW0zHQF","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"5c6286c3a13bf7597cf2a7abcfe4f50d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 60a55109-6f42-4611-8f78-9702bc953896
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5KdjMHTdv3aO9Um","name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "404"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"5e6da4f588f07c6d79ee7ac19188c2a2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 67d34a1c-8ae9-49c9-8842-f0cf6d0812aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_o5KdjMHTdv3aO9Um
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5KdjMHTdv3aO9Um","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:a7:00:b1:35:7e","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"74d2a7eb4896e83cde22b8337545ef14"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 6ec53dfe-783c-4553-b583-b59aa9cf09ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5KdjMHTdv3aO9Um
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5KdjMHTdv3aO9Um","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:a7:00:b1:35:7e","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"74d2a7eb4896e83cde22b8337545ef14"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - a71130ab-c582-4267-a738-c7f1a2cad9a6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:07 GMT
+      Etag:
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 9ce7178c-6d4e-40d5-af1b-b7ee137f104f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:08 GMT
+      Etag:
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 454dd926-76cf-410b-ba9d-61084b52fbe4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:08 GMT
+      Etag:
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 7ed14275-8d82-4590-a82d-020d1783e8a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "785"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:08 GMT
+      Etag:
+      - W/"55591b4f4e516fad7b43f26c87849ad3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 7d21d959-b5a4-4e30-b41f-362fdf74ff21
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863628,"initial_root_password":"Ha7JooBGjwW0zHQF","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:08 GMT
+      Etag:
+      - W/"5c6286c3a13bf7597cf2a7abcfe4f50d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 7df3de76-d041-44d6-b9e5-3a58b68c95d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5KdjMHTdv3aO9Um","name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "404"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:08 GMT
+      Etag:
+      - W/"5e6da4f588f07c6d79ee7ac19188c2a2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 9a7cc939-9811-4641-97f9-959803f96995
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_o5KdjMHTdv3aO9Um
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5KdjMHTdv3aO9Um","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:a7:00:b1:35:7e","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:08 GMT
+      Etag:
+      - W/"74d2a7eb4896e83cde22b8337545ef14"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - e0a4e163-37b0-4435-9da3-eb3c6dcbbe96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5KdjMHTdv3aO9Um
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5KdjMHTdv3aO9Um","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:a7:00:b1:35:7e","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:08 GMT
+      Etag:
+      - W/"74d2a7eb4896e83cde22b8337545ef14"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1084,7 +1502,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "982"
       X-Request-Id:
-      - 46dc2c70-ceb4-4791-886c-371f5b296fbd
+      - ba24dac6-ad50-431d-af8a-13d706e22ac4
     status: 200 OK
     code: 200
     duration: ""
@@ -1094,10 +1512,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1112,9 +1530,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
+      - Thu, 06 Feb 2025 17:41:08 GMT
       Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
+      - W/"179a3cb2aafc813bebc79f0fbbc77263"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1124,305 +1542,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "981"
       X-Request-Id:
-      - 4304fec1-b079-4d7c-8211-48a1017677f1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - 51143989-3c22-4c51-b76d-cf317ad46c29
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - 41d203d3-4189-4b1e-9672-8f6d344878d0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_dunFi1ND20lnuHy2
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "783"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"951f8a02ce721a2a1854139b38c1df55"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "978"
-      X-Request-Id:
-      - bf95928c-5ffd-4c84-8169-c3999dcaf3ad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710915,"initial_root_password":"4GPENIiRmzjKtnEb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"de13857259b09cff92ba4455c5f094f9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - 5e6cdb39-a044-4e50-b05e-483b6d178c49
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_dbWR9KepGZsMZ4lV","name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "402"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"54cf904a1a2fff8abfe0c97996427690"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "976"
-      X-Request-Id:
-      - 37b7ac03-5680-4cb9-8301-c6fbbb701175
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_dbWR9KepGZsMZ4lV
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_dbWR9KepGZsMZ4lV","virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web"},"name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:40:e3:87:0f:06","state":"attached","ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "556"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"a7d509838bd845de32617a6d00a7fcb2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "975"
-      X-Request-Id:
-      - 8f85dfbb-06b6-4747-9175-580fd16cb5c2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:19 GMT
-      Etag:
-      - W/"68012a6a04d6a399f6e03a162295f4c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - f7c3b274-97da-44a1-a095-7fb00e2233c0
+      - 1b07d822-a808-4157-ad3e-cc1677e5db0b
     status: 200 OK
     code: 200
     duration: ""
@@ -1450,7 +1570,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:20 GMT
+      - Thu, 06 Feb 2025 17:41:08 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -1460,9 +1580,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "973"
+      - "980"
       X-Request-Id:
-      - 1b753a0b-6764-4a2e-89c9-e6cfbf63b65a
+      - 4432603b-03a1-45c9-b49d-e0a245daa9d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1477,7 +1597,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"185-199-221-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"185-44-255-71.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -1490,13 +1610,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:20 GMT
+      - Thu, 06 Feb 2025 17:41:08 GMT
       Etag:
-      - W/"66b7bfb48beb09ad79d9b839a0013275"
+      - W/"e8324408291d1231ff760989728d3e1b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1504,9 +1624,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "972"
+      - "979"
       X-Request-Id:
-      - 707938b7-683e-43e4-9713-215de3d8bc15
+      - 70b982df-94a2-4423-afaa-bf8b1fabbef3
     status: 200 OK
     code: 200
     duration: ""
@@ -1516,10 +1636,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kI5YFBN4RnPoCm57
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"185-199-221-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"185-44-255-71.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -1532,13 +1652,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "585"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:20 GMT
+      - Thu, 06 Feb 2025 17:41:08 GMT
       Etag:
-      - W/"c1743df52b6ceb11f77087d26139894f"
+      - W/"9ea9d16c4a58037a42cd9ef97cd93b0c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1546,9 +1666,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "971"
+      - "978"
       X-Request-Id:
-      - 527c88a8-acfb-4964-8ada-bd5fb7003480
+      - 1f6d3553-bebf-4f1a-ae40-564596060bb4
     status: 200 OK
     code: 200
     duration: ""
@@ -1559,11 +1679,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_kI5YFBN4RnPoCm57
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"185-199-221-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"185-44-255-71.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -1576,13 +1696,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "585"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:20 GMT
+      - Thu, 06 Feb 2025 17:41:08 GMT
       Etag:
-      - W/"c1743df52b6ceb11f77087d26139894f"
+      - W/"9ea9d16c4a58037a42cd9ef97cd93b0c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1590,15 +1710,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "970"
+      - "977"
       X-Request-Id:
-      - a146484f-8820-4840-8dc3-adb1fc449f0f
+      - ac43f3e6-3b5a-41cd-b209-570de3023fbf
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_TYUsRxZHSTCBKzbA</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-associations-5w9pa5ujmds9-db</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_kI5YFBN4RnPoCm57</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-data-source-associations-plrbpq3gzvdk-db</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -1606,11 +1726,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_tWgNZLPhHdTgdhUv","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_W7nUpLVwlElpaHPn","state":"pending"},"virtual_machine_build":{"id":"vmbuild_W7nUpLVwlElpaHPn","state":"pending"},"hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","annotations":[]}'
+    body: '{"task":{"id":"task_aOajAbtZNRu3ts9h","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_VhVaZnlni6Tykhcf","state":"pending"},"virtual_machine_build":{"id":"vmbuild_VhVaZnlni6Tykhcf","state":"pending"},"hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1625,9 +1745,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:20 GMT
+      - Thu, 06 Feb 2025 17:41:09 GMT
       Etag:
-      - W/"c8f0e5c7d7fbcc0c27dc878b861305f7"
+      - W/"c39c8f2f8276c9e42b52d81cb36d785f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1635,9 +1755,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "969"
+      - "976"
       X-Request-Id:
-      - 64ca1c9d-0d22-4a49-8934-ff7571b9c328
+      - f79b47e8-2c27-4ecf-8f89-ef1312eba264
     status: 201 Created
     code: 201
     duration: ""
@@ -1648,18 +1768,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_W7nUpLVwlElpaHPn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VhVaZnlni6Tykhcf
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_W7nUpLVwlElpaHPn","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_VhVaZnlni6Tykhcf","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-5w9pa5ujmds9-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734710960},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863668},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1672,9 +1792,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:22 GMT
+      - Thu, 06 Feb 2025 17:41:11 GMT
       Etag:
-      - W/"4b21ae22a88317ecda864711f8dac30b"
+      - W/"004745c447b90472d0fec3f3aea168a2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1682,9 +1802,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "968"
+      - "975"
       X-Request-Id:
-      - c0267fa5-fbf3-40eb-856d-b6c92c624405
+      - e3e256f8-0d7e-4d95-bd40-1016f1d038ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1695,18 +1815,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_W7nUpLVwlElpaHPn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VhVaZnlni6Tykhcf
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_W7nUpLVwlElpaHPn","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_VhVaZnlni6Tykhcf","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-5w9pa5ujmds9-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734710960},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863668},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1719,9 +1839,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:27 GMT
+      - Thu, 06 Feb 2025 17:41:16 GMT
       Etag:
-      - W/"79077fa32aa36082fe9461351a2a06da"
+      - W/"5e3fbf20e47eaa3b942882a74e31ed15"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1729,9 +1849,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "974"
       X-Request-Id:
-      - 357a40e1-418a-4666-8216-0b828a4aa844
+      - 518b8c02-8195-4a87-9d71-a239ca2659d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1742,18 +1862,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_W7nUpLVwlElpaHPn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VhVaZnlni6Tykhcf
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_W7nUpLVwlElpaHPn","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_VhVaZnlni6Tykhcf","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-5w9pa5ujmds9-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734710960},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863668},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1766,9 +1886,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:37 GMT
+      - Thu, 06 Feb 2025 17:41:26 GMT
       Etag:
-      - W/"79077fa32aa36082fe9461351a2a06da"
+      - W/"5e3fbf20e47eaa3b942882a74e31ed15"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1776,9 +1896,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "973"
       X-Request-Id:
-      - e17ff47c-4eb0-4a11-8d66-825787f141a3
+      - c563cfb7-000a-4b19-99a1-d9abab6b7323
     status: 200 OK
     code: 200
     duration: ""
@@ -1789,18 +1909,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_W7nUpLVwlElpaHPn
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VhVaZnlni6Tykhcf
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_W7nUpLVwlElpaHPn","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_VhVaZnlni6Tykhcf","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-5w9pa5ujmds9-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","state":"allocating"},"created_at":1734710960},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863668},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1813,9 +1933,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:47 GMT
+      - Thu, 06 Feb 2025 17:41:36 GMT
       Etag:
-      - W/"7c3b1eb700e6c5b6e0ecf3be47e01202"
+      - W/"5e3fbf20e47eaa3b942882a74e31ed15"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1823,9 +1943,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "972"
       X-Request-Id:
-      - a8e21449-2de9-44ca-91f8-da3ca6243651
+      - 631b8bad-da72-4b8d-9f76-8b98190a832a
     status: 200 OK
     code: 200
     duration: ""
@@ -1836,19 +1956,66 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_VhVaZnlni6Tykhcf
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710963,"initial_root_password":"Fwxch4kWqDVYFwA1","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine_build":{"id":"vmbuild_VhVaZnlni6Tykhcf","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.71\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-data-source-associations-plrbpq3gzvdk-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1738863668},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:46 GMT
+      Etag:
+      - W/"3c27444056c2c8847e92ad062f5a7c22"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - aa783e89-e027-4ee9-b6fd-d433a525eada
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863674,"initial_root_password":"ZAR4ANksK746ort6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_KzkECl3nG42b3qCM","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_40qRE38nJBIWBJKs","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1861,9 +2028,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:49 GMT
+      - Thu, 06 Feb 2025 17:41:48 GMT
       Etag:
-      - W/"625c8e7c8d48ec0192d3f8979130ee58"
+      - W/"80bf1aaecd56b13bcb98ffaa01094efc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1871,9 +2038,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "970"
       X-Request-Id:
-      - 52eb46e7-2924-44fa-ac47-2d8ebeaa216d
+      - 03dcaeca-7560-4eed-8127-3e0f70a73982
     status: 200 OK
     code: 200
     duration: ""
@@ -1884,19 +2051,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710963,"initial_root_password":"Fwxch4kWqDVYFwA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863674,"initial_root_password":"ZAR4ANksK746ort6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_KzkECl3nG42b3qCM","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_40qRE38nJBIWBJKs","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1909,9 +2076,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:09:54 GMT
+      - Thu, 06 Feb 2025 17:41:48 GMT
       Etag:
-      - W/"a203cb40ca62767a266faa6a9822db90"
+      - W/"80bf1aaecd56b13bcb98ffaa01094efc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1919,187 +2086,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "969"
       X-Request-Id:
-      - 5c7e0bb7-58c2-4f8f-8c83-d4cf1c02e4b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710963,"initial_root_password":"Fwxch4kWqDVYFwA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_KzkECl3nG42b3qCM","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:54 GMT
-      Etag:
-      - W/"a203cb40ca62767a266faa6a9822db90"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "957"
-      X-Request-Id:
-      - 59e48c8f-6993-417d-a9f3-a9aa9086611c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_JzlIygiWB3OyU26t","name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "403"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:54 GMT
-      Etag:
-      - W/"283c10fa04e2c032a9702e6733510cf2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "956"
-      X-Request-Id:
-      - 095c04dd-f2b8-41eb-b1b9-4ecac2fbcc0c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_JzlIygiWB3OyU26t
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_JzlIygiWB3OyU26t","virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db"},"name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:86:40:72:12:ba","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "556"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:54 GMT
-      Etag:
-      - W/"a1d8606e0f39dc2d8f468c2ad06fa53f"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "955"
-      X-Request-Id:
-      - bdef1ae5-3b7d-493e-9c28-364fa99a06c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV"},"properties":{"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"]}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
-    method: PATCH
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:09:54 GMT
-      Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "954"
-      X-Request-Id:
-      - 9cdd23bb-95e9-47fb-a1ff-556a6c67a39d
+      - a0a49885-039f-4e69-b209-6e1fc46a0017
     status: 200 OK
     code: 200
     duration: ""
@@ -2108,519 +2097,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "382"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:00 GMT
-      Etag:
-      - W/"0645b82d2cc491e50dafaab66f912d54"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - 21c3e7a5-7b9c-49b2-9973-1d4ba5ff74a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "382"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:05 GMT
-      Etag:
-      - W/"0645b82d2cc491e50dafaab66f912d54"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - d1915855-00ee-434b-9124-1b8e543b1ff8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - 7fd918e1-0d02-44cd-af68-5c8f3603937c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 0a483f74-8e6e-487e-8b4d-e517df58b47f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - fe83fb46-eef1-4460-8e26-786862493490
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - cc5ff07c-f417-4280-a465-c1100cded034
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - 42a78426-4b48-4a36-bda2-84a9d8660b35
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_dunFi1ND20lnuHy2
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "783"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"951f8a02ce721a2a1854139b38c1df55"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - c8b982f8-df13-45ea-b10e-6c2913d3bc21
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_KzkECl3nG42b3qCM","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "785"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"3be335a426b56d3902f6673d245e71d6"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "991"
-      X-Request-Id:
-      - 6323c4f7-6143-4ad3-952e-c8b92433ce55
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710915,"initial_root_password":"4GPENIiRmzjKtnEb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"de13857259b09cff92ba4455c5f094f9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - b34e34af-abda-4d81-a2f8-9575fbcc1191
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710963,"initial_root_password":"Fwxch4kWqDVYFwA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_KzkECl3nG42b3qCM","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"a203cb40ca62767a266faa6a9822db90"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - 429a8c14-ce38-4a9e-ad09-ae167c5699b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_JzlIygiWB3OyU26t","name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "403"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
-      Etag:
-      - W/"283c10fa04e2c032a9702e6733510cf2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - 1b6b1f22-d103-46f9-8dbe-32a2a170147a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_dbWR9KepGZsMZ4lV","name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_GOkSXjJbTuMdnrwP","name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2635,9 +2118,723 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
+      - Thu, 06 Feb 2025 17:41:48 GMT
       Etag:
-      - W/"54cf904a1a2fff8abfe0c97996427690"
+      - W/"bf1847d4c09991ca06eb187ab3a517e7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - 657bc576-6d83-44b4-8de2-04bb44ddcdfe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_GOkSXjJbTuMdnrwP
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_GOkSXjJbTuMdnrwP","virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4f:c3:58:26:10","state":"attached","ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "554"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:48 GMT
+      Etag:
+      - W/"49b6b5895a332cf32e3971de4f44522c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 32bc10e5-c667-43c6-a266-85f172d14087
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_GOkSXjJbTuMdnrwP
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_GOkSXjJbTuMdnrwP","virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4f:c3:58:26:10","state":"attached","ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "554"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:48 GMT
+      Etag:
+      - W/"49b6b5895a332cf32e3971de4f44522c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 0ae82bb2-15eb-4768-9d89-fc8c0bb941a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn"},"properties":{"associations":["vm_40qRE38nJBIWBJKs","vm_bOPHwyaA5dGKhMp9"]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
+    method: PATCH
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:48 GMT
+      Etag:
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - 71c8b4b8-b3a2-43ff-88f2-ca374ac4ecc7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "382"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:53 GMT
+      Etag:
+      - W/"a85d4629e6c1844daa4f7ccd33eab468"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 5135ae39-e3a6-4ee4-b8c5-413a7ad01e1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "382"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:41:59 GMT
+      Etag:
+      - W/"a85d4629e6c1844daa4f7ccd33eab468"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - 202e85c1-9591-4be7-88a4-6049d6923b8f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 2ba3949a-2195-4526-ac98-997debeccbba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 482f4341-8046-4808-811f-ab0d94cc4102
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 9ce74a0e-f15d-4393-a1d7-ea48521bf188
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 07a67b06-d6be-45d3-90ee-04632d88b352
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 0a59a1dd-c7ba-40f4-8a4c-d4c699e60015
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "785"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"55591b4f4e516fad7b43f26c87849ad3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 3b1a9cd5-eddc-45bf-8a97-e64fe01e0031
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kI5YFBN4RnPoCm57
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_40qRE38nJBIWBJKs","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "781"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"5509a694c3529294fa75cac1a788fa57"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - d6fbc2fe-a533-4ce2-b4bc-47a805d3dddc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863674,"initial_root_password":"ZAR4ANksK746ort6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_40qRE38nJBIWBJKs","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"80bf1aaecd56b13bcb98ffaa01094efc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 02805fa6-9e85-4d96-b931-f4f04bfee70b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863628,"initial_root_password":"Ha7JooBGjwW0zHQF","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"5c6286c3a13bf7597cf2a7abcfe4f50d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - ee1e8a64-a35b-4131-913a-9ebecf671fd2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_o5KdjMHTdv3aO9Um","name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "404"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"5e6da4f588f07c6d79ee7ac19188c2a2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - ecbda647-18ff-4285-9682-ca2cd4fdf5a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_GOkSXjJbTuMdnrwP","name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "402"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"bf1847d4c09991ca06eb187ab3a517e7"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 77256236-6c43-47cc-b985-d8df7feb7a99
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_o5KdjMHTdv3aO9Um
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5KdjMHTdv3aO9Um","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:a7:00:b1:35:7e","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"74d2a7eb4896e83cde22b8337545ef14"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2647,7 +2844,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "988"
       X-Request-Id:
-      - 939d5b8e-64af-42e5-81b7-f1199416f691
+      - 2bb7a359-c954-4899-b99f-589e5301429d
     status: 200 OK
     code: 200
     duration: ""
@@ -2655,16 +2852,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_dbWR9KepGZsMZ4lV
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_GOkSXjJbTuMdnrwP
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_dbWR9KepGZsMZ4lV","virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web"},"name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:40:e3:87:0f:06","state":"attached","ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_GOkSXjJbTuMdnrwP","virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4f:c3:58:26:10","state":"attached","ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2675,13 +2870,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "556"
+      - "554"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
+      - Thu, 06 Feb 2025 17:42:09 GMT
       Etag:
-      - W/"a7d509838bd845de32617a6d00a7fcb2"
+      - W/"49b6b5895a332cf32e3971de4f44522c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2689,9 +2884,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "987"
       X-Request-Id:
-      - 9622b21a-047d-4ff7-9106-c7805f775c69
+      - 3b78f6f3-ef7e-4875-b47a-78a1a0ddd658
     status: 200 OK
     code: 200
     duration: ""
@@ -2702,13 +2897,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_JzlIygiWB3OyU26t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_GOkSXjJbTuMdnrwP
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_JzlIygiWB3OyU26t","virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db"},"name":"Public
-      Network on tf-acc-test-data-source-associations-5w9pa5ujmds9-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:86:40:72:12:ba","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_GOkSXjJbTuMdnrwP","virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:4f:c3:58:26:10","state":"attached","ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2719,13 +2914,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "556"
+      - "554"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
+      - Thu, 06 Feb 2025 17:42:09 GMT
       Etag:
-      - W/"a1d8606e0f39dc2d8f468c2ad06fa53f"
+      - W/"49b6b5895a332cf32e3971de4f44522c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2735,7 +2930,51 @@ interactions:
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - 9f8d291b-43dd-406a-a770-c1150883b65d
+      - 49c88629-be2e-450e-a511-865d858f9a18
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_o5KdjMHTdv3aO9Um
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_o5KdjMHTdv3aO9Um","virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web"},"name":"Public
+      Network on tf-acc-test-data-source-associations-plrbpq3gzvdk-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:a7:00:b1:35:7e","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "557"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:09 GMT
+      Etag:
+      - W/"74d2a7eb4896e83cde22b8337545ef14"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 1ee3abf2-6470-46c8-b9a6-a7eb3ced8580
     status: 200 OK
     code: 200
     duration: ""
@@ -2745,10 +2984,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2763,9 +3002,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:15 GMT
+      - Thu, 06 Feb 2025 17:42:09 GMT
       Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2775,7 +3014,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "984"
       X-Request-Id:
-      - c97979bc-4bf0-46c3-9fbf-174723dc98e0
+      - 00e605cc-e94d-43d0-ad3b-b44767d64eae
     status: 200 OK
     code: 200
     duration: ""
@@ -2785,10 +3024,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2803,9 +3042,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:16 GMT
+      - Thu, 06 Feb 2025 17:42:09 GMT
       Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2815,7 +3054,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "983"
       X-Request-Id:
-      - fc7a21e4-f952-4a56-b0e9-79b9a9f1ce3d
+      - 66cde84a-ba30-449a-9670-dfa6dd72795e
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,10 +3064,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2843,9 +3082,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:16 GMT
+      - Thu, 06 Feb 2025 17:42:09 GMT
       Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2855,7 +3094,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "982"
       X-Request-Id:
-      - caf2480d-1e47-4285-90ec-c613ce72a76f
+      - 96904309-0b6c-4373-9de4-39b620cbf09e
     status: 200 OK
     code: 200
     duration: ""
@@ -2865,10 +3104,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2883,9 +3122,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:16 GMT
+      - Thu, 06 Feb 2025 17:42:09 GMT
       Etag:
-      - W/"153d60d1edb8dc3cf9ad783d8cdfa567"
+      - W/"aaf34a45bb04a612d045c7b572a41e3e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2895,12 +3134,12 @@ interactions:
       X-Ratelimit-Remaining:
       - "981"
       X-Request-Id:
-      - 7b6b2671-5860-4a47-918a-038b4f6899e4
+      - d0519eb9-1e86-461c-a228-ef387cf440bd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV"}}'
+    body: '{"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn"}}'
     form: {}
     headers:
       Content-Type:
@@ -2910,7 +3149,7 @@ interactions:
     url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_ID93afyfYfrrpZGg","keep_until":1734883816,"object_id":"fsv_Le17AydbyuWPvtmV","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_Le17AydbyuWPvtmV","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_5WOKgBEx3m2nrO5x","vm_KzkECl3nG42b3qCM"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Le17AydbyuWPvtmV","size":0}}'
+    body: '{"trash_object":{"id":"trsh_o5RmK3r8rS1v7vKl","keep_until":1739036529,"object_id":"fsv_CEsxz9k1LKCtL3Hn","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_CEsxz9k1LKCtL3Hn","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_bOPHwyaA5dGKhMp9","vm_40qRE38nJBIWBJKs"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_CEsxz9k1LKCtL3Hn","size":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2925,9 +3164,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:16 GMT
+      - Thu, 06 Feb 2025 17:42:10 GMT
       Etag:
-      - W/"f851954520a7e8b407fa43d0a28f25b4"
+      - W/"271f3bb2b97ee4b5dd0860b71f58d8f2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2937,12 +3176,12 @@ interactions:
       X-Ratelimit-Remaining:
       - "980"
       X-Request-Id:
-      - d4e13047-233e-4c51-9dc7-b01ebdb6e54e
+      - 1ee53381-8c12-4e91-b5fd-56d59ab59d47
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"trash_object":{"object_id":"fsv_Le17AydbyuWPvtmV"}}'
+    body: '{"trash_object":{"object_id":"fsv_CEsxz9k1LKCtL3Hn"}}'
     form: {}
     headers:
       Content-Type:
@@ -2952,7 +3191,7 @@ interactions:
     url: https://api.katapult.io/core/v1/trash_objects/trash_object
     method: DELETE
   response:
-    body: '{"task":{"id":"task_CEE3RwyLIGOFqUSu","name":"Purge items from trash","status":"pending","created_at":1734711016,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_BK9hg5vxXLWH3lPa","name":"Purge items from trash","status":"pending","created_at":1738863730,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2967,9 +3206,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:16 GMT
+      - Thu, 06 Feb 2025 17:42:10 GMT
       Etag:
-      - W/"0586df7623078b65df8eef69e754ff30"
+      - W/"1d98f1dbb734614b3e149394da6a6112"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2979,7 +3218,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - 891655f4-da74-4927-b348-20b042ec3a7a
+      - d69ffaa0-bf7c-423b-b695-6573b2b67857
     status: 200 OK
     code: 200
     duration: ""
@@ -2989,10 +3228,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_ID93afyfYfrrpZGg","keep_until":1734883816,"object_id":"fsv_Le17AydbyuWPvtmV","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_o5RmK3r8rS1v7vKl","keep_until":1739036529,"object_id":"fsv_CEsxz9k1LKCtL3Hn","object_type":"FileStorageVolume"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3007,9 +3246,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:17 GMT
+      - Thu, 06 Feb 2025 17:42:11 GMT
       Etag:
-      - W/"525265e80a66acd0cd74a493abcc1dea"
+      - W/"5c89507a8d7744491d36de216e3018bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3019,7 +3258,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "978"
       X-Request-Id:
-      - 737e30fd-38bf-4628-bcc4-24255022eae2
+      - df51500d-4115-43c0-8763-bae00b6fb67f
     status: 200 OK
     code: 200
     duration: ""
@@ -3029,10 +3268,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_ID93afyfYfrrpZGg","keep_until":1734883816,"object_id":"fsv_Le17AydbyuWPvtmV","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_o5RmK3r8rS1v7vKl","keep_until":1739036529,"object_id":"fsv_CEsxz9k1LKCtL3Hn","object_type":"FileStorageVolume"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3047,9 +3286,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:22 GMT
+      - Thu, 06 Feb 2025 17:42:16 GMT
       Etag:
-      - W/"525265e80a66acd0cd74a493abcc1dea"
+      - W/"5c89507a8d7744491d36de216e3018bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3059,7 +3298,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "977"
       X-Request-Id:
-      - 9245bb24-9f18-4b92-9999-77dd28c3b5e6
+      - cccbb483-c9a9-4417-be41-7fa1006dc3e4
     status: 200 OK
     code: 200
     duration: ""
@@ -3069,10 +3308,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_ID93afyfYfrrpZGg","keep_until":1734883816,"object_id":"fsv_Le17AydbyuWPvtmV","object_type":"FileStorageVolume"}}'
+    body: '{"trash_object":{"id":"trsh_o5RmK3r8rS1v7vKl","keep_until":1739036529,"object_id":"fsv_CEsxz9k1LKCtL3Hn","object_type":"FileStorageVolume"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3087,9 +3326,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:32 GMT
+      - Thu, 06 Feb 2025 17:42:26 GMT
       Etag:
-      - W/"525265e80a66acd0cd74a493abcc1dea"
+      - W/"5c89507a8d7744491d36de216e3018bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3099,7 +3338,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - 0ef8671f-fbe0-4f7b-8ec4-8d4bc5c02595
+      - ce89407e-f81e-449e-995f-0dc8cddbdf04
     status: 200 OK
     code: 200
     duration: ""
@@ -3109,7 +3348,47 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_CEsxz9k1LKCtL3Hn
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_o5RmK3r8rS1v7vKl","keep_until":1739036529,"object_id":"fsv_CEsxz9k1LKCtL3Hn","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:36 GMT
+      Etag:
+      - W/"5c89507a8d7744491d36de216e3018bd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - f402b133-47f3-418c-a21c-072e37118679
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -3128,7 +3407,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:42 GMT
+      - Thu, 06 Feb 2025 17:42:46 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3138,9 +3417,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "974"
       X-Request-Id:
-      - ee97a1cc-543c-4c4c-a170-2569b9b650dd
+      - 38c0128c-80c4-4228-ab51-ae33eb3f6f0a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3151,19 +3430,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710963,"initial_root_password":"Fwxch4kWqDVYFwA1","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863628,"initial_root_password":"Ha7JooBGjwW0zHQF","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_KzkECl3nG42b3qCM","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3176,57 +3455,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:43 GMT
+      - Thu, 06 Feb 2025 17:42:46 GMT
       Etag:
-      - W/"a203cb40ca62767a266faa6a9822db90"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - f5fc2aef-609c-4e82-af9a-6aad5e2e411e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710915,"initial_root_password":"4GPENIiRmzjKtnEb","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:43 GMT
-      Etag:
-      - W/"de13857259b09cff92ba4455c5f094f9"
+      - W/"5c6286c3a13bf7597cf2a7abcfe4f50d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3236,7 +3467,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "973"
       X-Request-Id:
-      - d10d5997-d616-4d1e-87b8-d1913319cebc
+      - 17796b5c-0765-45bb-bb76-4a89663d68cf
     status: 200 OK
     code: 200
     duration: ""
@@ -3247,11 +3478,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
-    method: POST
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
+    method: GET
   response:
-    body: '{"task":{"id":"task_FE9CO97sEHPDLRdx","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863674,"initial_root_password":"ZAR4ANksK746ort6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_40qRE38nJBIWBJKs","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3261,14 +3500,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "88"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:43 GMT
+      - Thu, 06 Feb 2025 17:42:46 GMT
       Etag:
-      - W/"05cc42607c2ae214819613ceeceb5937"
+      - W/"80bf1aaecd56b13bcb98ffaa01094efc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3278,7 +3515,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "972"
       X-Request-Id:
-      - 8ff3b0eb-9190-41f5-b4e7-99e14286d58f
+      - 3126d10a-2c69-4567-96e8-f48c64d84031
     status: 200 OK
     code: 200
     duration: ""
@@ -3289,11 +3526,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
     method: POST
   response:
-    body: '{"task":{"id":"task_YLw9V9goRbrHOF71","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_VKmqCj0AenaPhpLu","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3308,9 +3545,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:43 GMT
+      - Thu, 06 Feb 2025 17:42:46 GMT
       Etag:
-      - W/"1cfada71400fb77e8c2e00c98e32ec6b"
+      - W/"1ebf0132893af3a2916106c3c22b409c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3320,7 +3557,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "971"
       X-Request-Id:
-      - 8c40f771-3c7d-4c93-a8e9-71fc85fbc218
+      - 937b08fc-6c2c-44c7-b57a-aa39d8284f0a
     status: 200 OK
     code: 200
     duration: ""
@@ -3331,11 +3568,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FE9CO97sEHPDLRdx
-    method: GET
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
+    method: POST
   response:
-    body: '{"task":{"id":"task_FE9CO97sEHPDLRdx","name":"Stop virtual machine","status":"running","created_at":1734711043,"started_at":1734711043,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_NauyhFfPHP6gg2Ev","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3346,13 +3583,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "88"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:44 GMT
+      - Thu, 06 Feb 2025 17:42:46 GMT
       Etag:
-      - W/"563657e8e4788b1ecb11ee3af6476d94"
+      - W/"436f41120acb898c91a2a7825dfc9bea"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3362,7 +3599,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "970"
       X-Request-Id:
-      - 30c24ef1-6f0b-4dd5-846a-6e1806bcfd2d
+      - c63b94d5-0400-489c-9ecb-43f11e77449e
     status: 200 OK
     code: 200
     duration: ""
@@ -3373,11 +3610,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_YLw9V9goRbrHOF71
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_VKmqCj0AenaPhpLu
     method: GET
   response:
-    body: '{"task":{"id":"task_YLw9V9goRbrHOF71","name":"Stop virtual machine","status":"running","created_at":1734711043,"started_at":1734711043,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_VKmqCj0AenaPhpLu","name":"Stop virtual machine","status":"running","created_at":1738863766,"started_at":1738863767,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3392,9 +3629,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:44 GMT
+      - Thu, 06 Feb 2025 17:42:47 GMT
       Etag:
-      - W/"3b9d22dd37a90fc474d1281193dd5486"
+      - W/"ebb574719fabe415ebe407cd3bfeb9f4"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3404,7 +3641,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "969"
       X-Request-Id:
-      - 1e1ebd01-597c-420b-94e5-12e199abec29
+      - 87bd4170-c9bb-44ad-9acb-cf561b53a1fe
     status: 200 OK
     code: 200
     duration: ""
@@ -3415,11 +3652,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_FE9CO97sEHPDLRdx
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_NauyhFfPHP6gg2Ev
     method: GET
   response:
-    body: '{"task":{"id":"task_FE9CO97sEHPDLRdx","name":"Stop virtual machine","status":"completed","created_at":1734711043,"started_at":1734711043,"finished_at":1734711046,"progress":100}}'
+    body: '{"task":{"id":"task_NauyhFfPHP6gg2Ev","name":"Stop virtual machine","status":"running","created_at":1738863766,"started_at":1738863767,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3430,13 +3667,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "178"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:49 GMT
+      - Thu, 06 Feb 2025 17:42:47 GMT
       Etag:
-      - W/"bbc879aec633c7f6db250d88997ed2a7"
+      - W/"95911265fcc668a434ec763399f7a194"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3446,7 +3683,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "968"
       X-Request-Id:
-      - 4cedb6a1-6841-4dd4-9f26-518292326a75
+      - 764e358c-876a-4b4c-9a00-fec020badd04
     status: 200 OK
     code: 200
     duration: ""
@@ -3457,11 +3694,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_YLw9V9goRbrHOF71
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_VKmqCj0AenaPhpLu
     method: GET
   response:
-    body: '{"task":{"id":"task_YLw9V9goRbrHOF71","name":"Stop virtual machine","status":"completed","created_at":1734711043,"started_at":1734711043,"finished_at":1734711045,"progress":100}}'
+    body: '{"task":{"id":"task_VKmqCj0AenaPhpLu","name":"Stop virtual machine","status":"completed","created_at":1738863766,"started_at":1738863767,"finished_at":1738863772,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3476,9 +3713,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:49 GMT
+      - Thu, 06 Feb 2025 17:42:52 GMT
       Etag:
-      - W/"1a7c5956c8a636631e0de99d2f180138"
+      - W/"a18835306411b8784a2a0e9c3696b6eb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3488,7 +3725,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "967"
       X-Request-Id:
-      - 6fb7a334-7a88-4547-a86d-cdb28f90918f
+      - 672a89e4-c23d-4891-a35d-05a9504da352
     status: 200 OK
     code: 200
     duration: ""
@@ -3499,19 +3736,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_NauyhFfPHP6gg2Ev
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710915,"initial_root_password":"4GPENIiRmzjKtnEb","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    body: '{"task":{"id":"task_NauyhFfPHP6gg2Ev","name":"Stop virtual machine","status":"running","created_at":1738863766,"started_at":1738863767,"finished_at":null,"progress":53}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3521,60 +3750,14 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Content-Length:
+      - "169"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:50 GMT
+      - Thu, 06 Feb 2025 17:42:52 GMT
       Etag:
-      - W/"83efabf1df23364a0581e89842771d94"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "965"
-      X-Request-Id:
-      - 31634c88-fb76-4117-89ea-d9b0d577742f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710963,"initial_root_password":"Fwxch4kWqDVYFwA1","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_KzkECl3nG42b3qCM","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:50 GMT
-      Etag:
-      - W/"c4732b14e89f63b424ec9a4cf0d7fd44"
+      - W/"edf7aa66d7745092cc67787743f82c4e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3584,7 +3767,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "966"
       X-Request-Id:
-      - 37659049-1f2d-4d0e-92be-5f2c01eea330
+      - 8cf1bbb1-135b-4b2a-9908-2b786b027166
     status: 200 OK
     code: 200
     duration: ""
@@ -3595,19 +3778,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_KzkECl3nG42b3qCM
-    method: DELETE
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_hVKUUuV53iilRpno","keep_until":1734883850,"object_id":"vm_KzkECl3nG42b3qCM","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_KzkECl3nG42b3qCM","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710963,"initial_root_password":"Fwxch4kWqDVYFwA1","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863628,"initial_root_password":"Ha7JooBGjwW0zHQF","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_KzkECl3nG42b3qCM","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3620,9 +3803,57 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:50 GMT
+      - Thu, 06 Feb 2025 17:42:53 GMT
       Etag:
-      - W/"6691df2443a7036382e752fbef5d2174"
+      - W/"069740ce97d0f3f9b235dd747ea9008d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - a6b04cba-8428-4d0a-a79f-1f66a3cb85ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_bOPHwyaA5dGKhMp9
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_N08spk4O2JUTo6j5","keep_until":1739036573,"object_id":"vm_bOPHwyaA5dGKhMp9","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_bOPHwyaA5dGKhMp9","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863628,"initial_root_password":"Ha7JooBGjwW0zHQF","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_bOPHwyaA5dGKhMp9","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:42:53 GMT
+      Etag:
+      - W/"bb758b86439114417c191b132928f31f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3632,7 +3863,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "964"
       X-Request-Id:
-      - e41aaffd-c2c9-40ca-9c69-493f2cbb66ac
+      - b2bff81a-3272-471a-8c6f-ba957713bd62
     status: 200 OK
     code: 200
     duration: ""
@@ -3643,19 +3874,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_5WOKgBEx3m2nrO5x
-    method: DELETE
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
+    method: POST
   response:
-    body: '{"trash_object":{"id":"trsh_mgcLyYdlCbcttIMR","keep_until":1734883850,"object_id":"vm_5WOKgBEx3m2nrO5x","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_5WOKgBEx3m2nrO5x","name":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","hostname":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web","fqdn":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734710915,"initial_root_password":"4GPENIiRmzjKtnEb","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_dunFi1ND20lnuHy2","address":"185.53.57.139","reverse_dns":"tf-acc-test-data-source-associations-5w9pa5ujmds9-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.53.57.139/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_5WOKgBEx3m2nrO5x","allocation_type":"VirtualMachine"}]}}'
+    body: '{}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3665,12 +3888,14 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:50 GMT
+      - Thu, 06 Feb 2025 17:42:54 GMT
       Etag:
-      - W/"812d2673790088b82f97d73838ee9921"
+      - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3680,7 +3905,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "963"
       X-Request-Id:
-      - d9521789-4903-47f7-b8f3-ef4ec2273c88
+      - be7f6d10-030d-4677-86be-0fca5e3b1da3
     status: 200 OK
     code: 200
     duration: ""
@@ -3691,11 +3916,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_dunFi1ND20lnuHy2
-    method: POST
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_bOPHwyaA5dGKhMp9
+    method: DELETE
   response:
-    body: '{}'
+    body: '{"task":{"id":"task_4qNR9MXZEu4TDuM4","name":"Purge items from trash","status":"pending","created_at":1738863774,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3706,55 +3931,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "2"
+      - "164"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:51 GMT
+      - Thu, 06 Feb 2025 17:42:54 GMT
       Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "961"
-      X-Request-Id:
-      - fbd8e7ac-160e-4b58-853d-f5d2a21a5ed5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: POST
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:51 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
+      - W/"f97004bef425540fb48b7d620b8b3e57"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3764,7 +3947,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "962"
       X-Request-Id:
-      - 28cbdbab-5186-4b1f-8886-6e59d86dd731
+      - 641c1d68-302d-4a47-a80c-569b1f0c9d8e
     status: 200 OK
     code: 200
     duration: ""
@@ -3775,95 +3958,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_5WOKgBEx3m2nrO5x
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_CA0kXtlJkOxL5nJe","name":"Purge items from trash","status":"pending","created_at":1734711051,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:51 GMT
-      Etag:
-      - W/"455e7e75f0c3f7b6a12391335ba4db77"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "960"
-      X-Request-Id:
-      - d0365244-9cbe-48b9-9ab0-7e851b45234a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_KzkECl3nG42b3qCM
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_9mi3FqbgWILkv4oV","name":"Purge items from trash","status":"pending","created_at":1734711051,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:51 GMT
-      Etag:
-      - W/"4e867215fe5fb12fce5d9cbcdb41d81b"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "959"
-      X-Request-Id:
-      - 7095bf3b-fd50-4124-b8e5-ac55e68315bc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_5WOKgBEx3m2nrO5x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_bOPHwyaA5dGKhMp9
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_mgcLyYdlCbcttIMR","keep_until":1734883850,"object_id":"vm_5WOKgBEx3m2nrO5x","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_N08spk4O2JUTo6j5","keep_until":1739036573,"object_id":"vm_bOPHwyaA5dGKhMp9","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3878,9 +3977,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:52 GMT
+      - Thu, 06 Feb 2025 17:42:55 GMT
       Etag:
-      - W/"c4c63598e1b13124550fb4813c95bace"
+      - W/"46c36b1b510e80f6fb3b00e372fda566"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3888,9 +3987,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "961"
       X-Request-Id:
-      - cb1cb683-cacb-4635-b4b5-e784fc6ef4c8
+      - 26aa2d45-9232-45d6-ac9d-064751afeb2e
     status: 200 OK
     code: 200
     duration: ""
@@ -3901,11 +4000,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_KzkECl3nG42b3qCM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_bOPHwyaA5dGKhMp9
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_hVKUUuV53iilRpno","keep_until":1734883850,"object_id":"vm_KzkECl3nG42b3qCM","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_N08spk4O2JUTo6j5","keep_until":1739036573,"object_id":"vm_bOPHwyaA5dGKhMp9","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3920,178 +4019,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:10:52 GMT
+      - Thu, 06 Feb 2025 17:43:00 GMT
       Etag:
-      - W/"91b80c963dfbd96323e27a71ae80d70f"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "957"
-      X-Request-Id:
-      - 7d7d8d49-c00b-42b9-bb81-0d7483ce9168
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_5WOKgBEx3m2nrO5x
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:57 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "956"
-      X-Request-Id:
-      - 4381c934-5739-4617-b579-015dee65a624
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_KzkECl3nG42b3qCM
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_hVKUUuV53iilRpno","keep_until":1734883850,"object_id":"vm_KzkECl3nG42b3qCM","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:57 GMT
-      Etag:
-      - W/"91b80c963dfbd96323e27a71ae80d70f"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "955"
-      X-Request-Id:
-      - cc20311f-2983-4265-8783-170cb32e5fb6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"ip_address":{"id":"ip_dunFi1ND20lnuHy2"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:10:58 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "954"
-      X-Request-Id:
-      - ec9f23d7-3d46-438d-8595-f26b1b03c9e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_KzkECl3nG42b3qCM
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_hVKUUuV53iilRpno","keep_until":1734883850,"object_id":"vm_KzkECl3nG42b3qCM","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 16:11:07 GMT
-      Etag:
-      - W/"91b80c963dfbd96323e27a71ae80d70f"
+      - W/"46c36b1b510e80f6fb3b00e372fda566"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -4101,7 +4031,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "999"
       X-Request-Id:
-      - a00be818-8a62-441b-9987-f4dfaefa499f
+      - 26125607-5beb-40b2-be8d-bcb7936fa198
     status: 200 OK
     code: 200
     duration: ""
@@ -4112,8 +4042,272 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_KzkECl3nG42b3qCM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_NauyhFfPHP6gg2Ev
+    method: GET
+  response:
+    body: '{"task":{"id":"task_NauyhFfPHP6gg2Ev","name":"Stop virtual machine","status":"completed","created_at":1738863766,"started_at":1738863767,"finished_at":1738863772,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:02 GMT
+      Etag:
+      - W/"e005bd82f1a51b568c62135071e53e55"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - b22a3704-b4a6-4a39-8736-59326ffb3264
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863674,"initial_root_password":"ZAR4ANksK746ort6","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_40qRE38nJBIWBJKs","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:03 GMT
+      Etag:
+      - W/"c04ad3441ddf9ac8ada4c777e6945457"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 9a7fe518-9196-47e2-aa07-596025cf325d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_40qRE38nJBIWBJKs
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_ZYC1TgmweKLtIXlf","keep_until":1739036583,"object_id":"vm_40qRE38nJBIWBJKs","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_40qRE38nJBIWBJKs","name":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","hostname":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db","fqdn":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863674,"initial_root_password":"ZAR4ANksK746ort6","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kI5YFBN4RnPoCm57","address":"185.44.255.71","reverse_dns":"tf-acc-test-data-source-associations-plrbpq3gzvdk-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.71/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_40qRE38nJBIWBJKs","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:03 GMT
+      Etag:
+      - W/"3cd756b8b99a9536a4756486575ba7f3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - e3420867-9834-402e-8857-81615f699f7f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_kI5YFBN4RnPoCm57
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:04 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 555c0999-72f7-4274-b0d6-31d400d37f59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_40qRE38nJBIWBJKs
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_ddEIoUe8sizri8dh","name":"Purge items from trash","status":"pending","created_at":1738863784,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:04 GMT
+      Etag:
+      - W/"0c07fe23d8b7c3b64ed41ca0c741d1a9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - aced035b-1fea-4d60-b7bb-c4d6dd088007
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_40qRE38nJBIWBJKs
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_ZYC1TgmweKLtIXlf","keep_until":1739036583,"object_id":"vm_40qRE38nJBIWBJKs","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:05 GMT
+      Etag:
+      - W/"1151915bc5b215bbf1becb97e00c26f3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - a3bc37f4-5e8f-48f3-a63c-8a9a653c4280
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_bOPHwyaA5dGKhMp9
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -4132,7 +4326,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:11:17 GMT
+      - Thu, 06 Feb 2025 17:43:10 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -4142,14 +4336,56 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "992"
       X-Request-Id:
-      - 48026cbf-7955-47f0-a630-01e6c615da43
+      - a052c300-9ea8-43b9-9d0d-b682be20728f
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA"}}'
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_40qRE38nJBIWBJKs
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_ZYC1TgmweKLtIXlf","keep_until":1739036583,"object_id":"vm_40qRE38nJBIWBJKs","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:10 GMT
+      Etag:
+      - W/"1151915bc5b215bbf1becb97e00c26f3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - ba3f1e1d-e35b-41e2-82ac-fd18ec8ea567
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i"}}'
     form: {}
     headers:
       Content-Type:
@@ -4174,7 +4410,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:11:17 GMT
+      - Thu, 06 Feb 2025 17:43:10 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -4184,9 +4420,94 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "990"
       X-Request-Id:
-      - 2468f040-f951-4b6e-980d-eea3275759c5
+      - a7313791-92a4-4daa-9347-bea1c226f46a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_40qRE38nJBIWBJKs
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:20 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - e5f6513e-de8a-4c4c-a45e-3fdc95ddf657
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_kI5YFBN4RnPoCm57"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:43:20 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - cdb56888-ea16-40ea-ad79-03a64ba3d5c1
     status: 200 OK
     code: 200
     duration: ""
@@ -4196,7 +4517,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
     body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
@@ -4215,7 +4536,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:11:17 GMT
+      - Thu, 06 Feb 2025 17:43:20 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -4225,9 +4546,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "987"
       X-Request-Id:
-      - d8ada8fd-600f-4071-86a9-6009791efbce
+      - c704a5bb-222b-40b1-a44f-979d7b6847c4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4237,7 +4558,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -4256,7 +4577,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:11:17 GMT
+      - Thu, 06 Feb 2025 17:43:20 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -4266,9 +4587,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "986"
       X-Request-Id:
-      - 256a076f-51db-4fcf-bb06-551f3336d11e
+      - 544bb6c8-5630-41b5-a2df-3d44e6631b5d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4278,7 +4599,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
     body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
@@ -4297,7 +4618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:11:17 GMT
+      - Thu, 06 Feb 2025 17:43:20 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -4307,9 +4628,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "985"
       X-Request-Id:
-      - a7a999b1-13ea-42b3-a68e-2a051118e399
+      - ed8aa3ea-58b7-44ee-a597-eca1c9f513da
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4319,7 +4640,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Le17AydbyuWPvtmV
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_CEsxz9k1LKCtL3Hn
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -4338,7 +4659,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 16:11:17 GMT
+      - Thu, 06 Feb 2025 17:43:20 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -4348,9 +4669,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "984"
       X-Request-Id:
-      - fe48a6e0-f5c0-42cf-b647-9425f65629d9
+      - a604610c-abdf-429a-a6d0-18b5cb0828ac
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/v6provider/testdata/FileStorageVolume_associations.cassette.rand_id
+++ b/internal/v6provider/testdata/FileStorageVolume_associations.cassette.rand_id
@@ -1,1 +1,1 @@
-VSjXzuOtI1wu
+jNucksep5xJZ

--- a/internal/v6provider/testdata/FileStorageVolume_associations.cassette.yaml
+++ b/internal/v6provider/testdata/FileStorageVolume_associations.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:09 GMT
+      - Thu, 06 Feb 2025 17:43:29 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "983"
       X-Request-Id:
-      - 13def9a8-4211-439e-a997-8618813c9fcb
+      - f988c621-6308-4222-9484-2bab47395501
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"185-199-221-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"185-44-252-55.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -65,13 +65,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "567"
+      - "558"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:10 GMT
+      - Thu, 06 Feb 2025 17:43:29 GMT
       Etag:
-      - W/"66b7bfb48beb09ad79d9b839a0013275"
+      - W/"5ecf5061aaa0374d3f8175eeefccdf5f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -79,9 +79,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "982"
       X-Request-Id:
-      - e1e56e7c-bce2-4505-b26b-d1437ea4f117
+      - f6668032-69fe-454c-b610-0b3a2e7e2171
     status: 200 OK
     code: 200
     duration: ""
@@ -91,10 +91,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"185-199-221-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"185-44-252-55.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -107,13 +107,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "585"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:10 GMT
+      - Thu, 06 Feb 2025 17:43:29 GMT
       Etag:
-      - W/"c1743df52b6ceb11f77087d26139894f"
+      - W/"986310eb78eeb757b1abd0ff47473cfe"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -121,9 +121,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "981"
       X-Request-Id:
-      - cad72917-2517-4112-85e8-83c3329d0754
+      - c715af8c-0f54-4bbf-b109-bafc666f1afe
     status: 200 OK
     code: 200
     duration: ""
@@ -134,11 +134,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"185-199-221-172.rdns.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"185-44-252-55.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -151,13 +151,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "585"
+      - "576"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:10 GMT
+      - Thu, 06 Feb 2025 17:43:29 GMT
       Etag:
-      - W/"c1743df52b6ceb11f77087d26139894f"
+      - W/"986310eb78eeb757b1abd0ff47473cfe"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -165,15 +165,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "980"
       X-Request-Id:
-      - b0931fb8-74b3-4fe2-a951-8e79299ce74b
+      - 4f12e0b4-d98c-4ff5-8155-0ad7dfc50714
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_TYUsRxZHSTCBKzbA</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-associations-vsjxzuoti1wu-web</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_t1CqlATVR28s9DHn</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-associations-jnucksep5xjz-web</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -181,11 +181,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_kxqQWdTmnpzMBCbw","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_m8s3xAUu4kJuXAdb","state":"pending"},"virtual_machine_build":{"id":"vmbuild_m8s3xAUu4kJuXAdb","state":"pending"},"hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","annotations":[]}'
+    body: '{"task":{"id":"task_ffnQP2qS0ezVW70p","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_tX41AyicqV4Se0eK","state":"pending"},"virtual_machine_build":{"id":"vmbuild_tX41AyicqV4Se0eK","state":"pending"},"hostname":"tf-acc-test-associations-jnucksep5xjz-web","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -200,9 +200,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:10 GMT
+      - Thu, 06 Feb 2025 17:43:30 GMT
       Etag:
-      - W/"0b104277769c394f7fcb5717ce26a95b"
+      - W/"2b185420231ac66868af795252599941"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -210,9 +210,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "979"
       X-Request-Id:
-      - 4fef0b7c-a6e7-4318-96ca-07e805788a1a
+      - 55ffc8f1-25b5-4e4e-833f-3e3644e824ba
     status: 201 Created
     code: 201
     duration: ""
@@ -223,18 +223,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_m8s3xAUu4kJuXAdb
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_tX41AyicqV4Se0eK
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_m8s3xAUu4kJuXAdb","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_tX41AyicqV4Se0eK","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-vsjxzuoti1wu-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734706510},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863809},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -247,9 +247,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:12 GMT
+      - Thu, 06 Feb 2025 17:43:32 GMT
       Etag:
-      - W/"3e8f007dca6f9e98c9d0a83ee719ef83"
+      - W/"65544a38541dc924d59aa3ab4ef63b13"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -257,9 +257,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "994"
+      - "978"
       X-Request-Id:
-      - 027428cf-8f58-48c5-b76b-ddf5a1b047d0
+      - 13ffbe81-153e-48a6-8c0d-eb2860a74413
     status: 200 OK
     code: 200
     duration: ""
@@ -270,18 +270,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_m8s3xAUu4kJuXAdb
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_tX41AyicqV4Se0eK
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_m8s3xAUu4kJuXAdb","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_tX41AyicqV4Se0eK","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-vsjxzuoti1wu-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734706510},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863809},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -294,9 +294,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:17 GMT
+      - Thu, 06 Feb 2025 17:43:37 GMT
       Etag:
-      - W/"ae5f3ac794c94b49df37da7164255685"
+      - W/"e6e9f388224c2c4617eeb2aff810ea8b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -304,9 +304,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "993"
+      - "977"
       X-Request-Id:
-      - ea221f34-7e17-40d6-bd51-5247b885d753
+      - 51ab103a-b3bc-43f6-9168-c087b0dbcd1f
     status: 200 OK
     code: 200
     duration: ""
@@ -317,18 +317,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_m8s3xAUu4kJuXAdb
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_tX41AyicqV4Se0eK
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_m8s3xAUu4kJuXAdb","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_tX41AyicqV4Se0eK","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-vsjxzuoti1wu-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734706510},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863809},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -341,9 +341,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:27 GMT
+      - Thu, 06 Feb 2025 17:43:47 GMT
       Etag:
-      - W/"ae5f3ac794c94b49df37da7164255685"
+      - W/"e6e9f388224c2c4617eeb2aff810ea8b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -351,9 +351,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "992"
+      - "976"
       X-Request-Id:
-      - f0443ca4-1584-419c-bd91-c06b44ddfde1
+      - 3151e4d6-8570-4da8-b055-83e8cfdc67a0
     status: 200 OK
     code: 200
     duration: ""
@@ -364,18 +364,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_m8s3xAUu4kJuXAdb
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_tX41AyicqV4Se0eK
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_m8s3xAUu4kJuXAdb","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_tX41AyicqV4Se0eK","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.199.221.172\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-vsjxzuoti1wu-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.55\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-web\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","state":"allocating"},"created_at":1734706510},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738863809},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -388,9 +388,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:37 GMT
+      - Thu, 06 Feb 2025 17:43:57 GMT
       Etag:
-      - W/"d70286441285c0c4d272fcdf57d42102"
+      - W/"bc3d614094f19a8518a8d5823d7b9e97"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -398,9 +398,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "975"
       X-Request-Id:
-      - d84c7a0c-aa07-4eb3-ba4a-83adfbf5e780
+      - 3d7a1026-4f32-4106-a19e-4d57b6d522d9
     status: 200 OK
     code: 200
     duration: ""
@@ -411,19 +411,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -436,9 +436,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:39 GMT
+      - Thu, 06 Feb 2025 17:43:59 GMT
       Etag:
-      - W/"f7f73f35e31c901cd628fd08852e401c"
+      - W/"8d324408d136ca4ad97a12b5797a0660"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -446,9 +446,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "974"
       X-Request-Id:
-      - f209ac8e-1670-46af-823c-9b5907f6683b
+      - 22a725ed-4580-4cfc-ad7c-c445fb51b816
     status: 200 OK
     code: 200
     duration: ""
@@ -459,19 +459,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -484,9 +484,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:44 GMT
+      - Thu, 06 Feb 2025 17:44:04 GMT
       Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -494,9 +494,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "989"
+      - "999"
       X-Request-Id:
-      - 37520f0c-ec15-4c97-a9a0-ca0fe85197d9
+      - d290f893-83d4-445a-8dab-be499d8fd673
     status: 200 OK
     code: 200
     duration: ""
@@ -507,19 +507,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -532,9 +532,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:44 GMT
+      - Thu, 06 Feb 2025 17:44:04 GMT
       Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -542,9 +542,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "998"
       X-Request-Id:
-      - 4f52a790-9363-4b0f-8452-a48881d6d227
+      - c986f2d0-82ab-43b4-b90a-83b59306f561
     status: 200 OK
     code: 200
     duration: ""
@@ -552,16 +552,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -572,13 +570,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "392"
+      - "391"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:44 GMT
+      - Thu, 06 Feb 2025 17:44:04 GMT
       Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -586,9 +584,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "987"
+      - "997"
       X-Request-Id:
-      - 6298b3b6-c703-4864-8f71-9f4367fad60c
+      - 20fa79f5-fb67-4f6b-af6f-d9a61b125b29
     status: 200 OK
     code: 200
     duration: ""
@@ -596,16 +594,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -616,13 +612,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "534"
+      - "532"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:44 GMT
+      - Thu, 06 Feb 2025 17:44:04 GMT
       Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -630,14 +626,58 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "996"
       X-Request-Id:
-      - bb793b6c-d996-4d11-9097-0f31d446bfb4
+      - 48425569-0f19-4127-a41e-d6fa7acc99bb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"associations":["vm_heORtn6n0n7gtd6u"],"data_center":{"permalink":"uk-lon-01"},"name":"tf-acc-test-associations-vsjxzuoti1wu"}}'
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:04 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 049454ac-1abd-4125-84c1-82eabd523fc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"associations":["vm_7tOuR5eK7zhFKEO2"],"data_center":{"permalink":"uk-lon-01"},"name":"tf-acc-test-associations-jnucksep5xjz"}}'
     form: {}
     headers:
       Content-Type:
@@ -647,7 +687,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/file_storage_volumes
     method: POST
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -662,9 +702,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:44 GMT
+      - Thu, 06 Feb 2025 17:44:04 GMT
       Etag:
-      - W/"4944c4240869143486c8defb23283052"
+      - W/"6235e0830e363f7a5236ec3bed08c66d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -672,9 +712,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "985"
+      - "994"
       X-Request-Id:
-      - 32529929-d69b-4f93-88a0-b0de2d577df4
+      - 2f270d54-3a4f-4fda-8e1a-f987f0828957
     status: 201 Created
     code: 201
     duration: ""
@@ -684,10 +724,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -702,9 +742,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:46 GMT
+      - Thu, 06 Feb 2025 17:44:06 GMT
       Etag:
-      - W/"e0f8f32fbed4223ae78386821b319ad4"
+      - W/"b03138922f877da0b54b6e0437878483"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -712,9 +752,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "993"
       X-Request-Id:
-      - b0630174-6d0f-41ce-a1cf-b81c13fd0448
+      - f36880b6-244b-468e-ba35-a52233325504
     status: 200 OK
     code: 200
     duration: ""
@@ -724,10 +764,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -742,9 +782,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:55:51 GMT
+      - Thu, 06 Feb 2025 17:44:11 GMT
       Etag:
-      - W/"e0f8f32fbed4223ae78386821b319ad4"
+      - W/"b03138922f877da0b54b6e0437878483"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -752,9 +792,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "992"
       X-Request-Id:
-      - cf76f99e-00ef-4a63-924a-c7b6c291f43a
+      - 2ac8180e-5d0a-418b-8f95-70cd73288bee
     status: 200 OK
     code: 200
     duration: ""
@@ -764,10 +804,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -782,9 +822,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:01 GMT
+      - Thu, 06 Feb 2025 17:44:21 GMT
       Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -792,9 +832,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "991"
       X-Request-Id:
-      - 2d54cad0-b0f4-4e0e-ad2e-8b1747ca68f5
+      - 636519be-a653-4e18-bbe4-b070bbaaeee2
     status: 200 OK
     code: 200
     duration: ""
@@ -804,10 +844,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -822,9 +862,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:01 GMT
+      - Thu, 06 Feb 2025 17:44:22 GMT
       Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -832,14 +872,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "990"
       X-Request-Id:
-      - 6a71bacb-6abc-4e63-b4ea-fe4d2b1895a9
+      - 471b65f7-e15f-4513-90ec-96dd06fd12ff
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"associations":null,"data_center":{"permalink":"uk-lon-01"},"name":"tf-acc-test-associations-vsjxzuoti1wu-cache"}}'
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"associations":null,"data_center":{"permalink":"uk-lon-01"},"name":"tf-acc-test-associations-jnucksep5xjz-cache"}}'
     form: {}
     headers:
       Content-Type:
@@ -849,7 +889,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/file_storage_volumes
     method: POST
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"pending","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -864,343 +904,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:02 GMT
+      - Thu, 06 Feb 2025 17:44:22 GMT
       Etag:
-      - W/"e555660ac435435d7a9380e3873a9d79"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - 168e9f39-4173-4cff-904f-ba5607c3c221
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "276"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:04 GMT
-      Etag:
-      - W/"9befa2f0b1a21798d8e9d9af7f470332"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 86e6b67b-0bed-4d93-a79e-75d6885819cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "276"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:09 GMT
-      Etag:
-      - W/"9befa2f0b1a21798d8e9d9af7f470332"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - 044cca64-abee-4c7e-a721-1923c1285bcb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - edddd57a-47ad-41a5-bfec-74bc595fa8fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - bd8d293d-8410-49e0-8689-6ddac99ffc13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - 93304c1b-be04-4228-b35a-8cf62a58eaef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "991"
-      X-Request-Id:
-      - 016bcaad-2e5e-450c-be9c-d8649506282f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - 73e2c61f-eb9d-499b-b1b2-b377389d9874
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
+      - W/"431cf51ce1560d467e9a25cf3f39760b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1210,24 +916,20 @@ interactions:
       X-Ratelimit-Remaining:
       - "989"
       X-Request-Id:
-      - bd846390-29e7-4496-b7ee-6cf4f03c5084
-    status: 200 OK
-    code: 200
+      - 68b4d334-905b-48ee-adbd-71edc2cd6485
+    status: 201 Created
+    code: 201
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1238,13 +940,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "534"
+      - "276"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
+      - Thu, 06 Feb 2025 17:44:24 GMT
       Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
+      - W/"615a333acb04885d22c73b288eb50be2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1254,7 +956,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "988"
       X-Request-Id:
-      - 6fb83bbb-6098-4e9a-97cd-99ab00c9a787
+      - 061b30be-aeb8-4ef0-91cc-8624b8f676c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1264,10 +966,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":null,"size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1278,13 +980,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "342"
+      - "276"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
+      - Thu, 06 Feb 2025 17:44:29 GMT
       Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
+      - W/"615a333acb04885d22c73b288eb50be2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1294,7 +996,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - b8b45766-a041-41f4-af00-b66c219c30cb
+      - 3e4b583f-77a0-4ab4-b2c0-3327334e7de1
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,10 +1006,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1322,9 +1024,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
+      - Thu, 06 Feb 2025 17:44:39 GMT
       Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1334,7 +1036,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - f8db8aa6-5e8c-4ef3-bfcd-ddc2f2276eec
+      - 58fbb6dc-8d84-4c83-bbb2-8043bab93fb9
     status: 200 OK
     code: 200
     duration: ""
@@ -1344,228 +1046,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "985"
-      X-Request-Id:
-      - 341b765e-8777-430e-8219-987ae15aae6d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 959f6b48-97ac-435e-baad-1d03190ea1e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - 11b963e7-a845-4aa9-a7ea-4a56c8b56fe9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "982"
-      X-Request-Id:
-      - dce5af57-4326-4d5b-9105-462351645fba
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "981"
-      X-Request-Id:
-      - 32d95e58-bcf6-43fa-b022-6ec89f10b548
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1580,9 +1064,223 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:19 GMT
+      - Thu, 06 Feb 2025 17:44:39 GMT
       Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 09a13d7d-fd66-4f13-ae7b-f39b29cae838
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:39 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 61ce540f-8e7e-46e9-943e-a6f327c59698
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 2f4c44cf-76b8-4ab5-9f43-8b426b66391a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 6c2858bb-e164-4546-a108-cad790e0b397
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - a9327d20-3516-4b5a-82f9-78a4e42e718d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1592,22 +1290,24 @@ interactions:
       X-Ratelimit-Remaining:
       - "980"
       X-Request-Id:
-      - 028ad774-fa5b-43d0-9cca-b7a670ea6484
+      - 6ddf8a73-6d38-42e8-9fc5-d11cb9294a1a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R"},"properties":{"associations":["vm_heORtn6n0n7gtd6u"]}}'
+    body: ""
     form: {}
     headers:
-      Content-Type:
+      Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
-    method: PATCH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1618,13 +1318,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "348"
+      - "532"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:20 GMT
+      - Thu, 06 Feb 2025 17:44:40 GMT
       Etag:
-      - W/"f34a8962c7a1c85fcfe737dae764ca71"
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1634,7 +1334,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - 04dcb256-ffe5-4e2a-8415-acfc8826be7f
+      - afebbde9-c4c4-4918-884b-e6c2d09509a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1644,10 +1344,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1658,13 +1358,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "354"
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:25 GMT
+      - Thu, 06 Feb 2025 17:44:40 GMT
       Etag:
-      - W/"a9f1d3661778e29482eebd646d47142c"
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1674,7 +1374,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "978"
       X-Request-Id:
-      - 3eabce9f-176e-4e18-b497-4c4b8c2fd16f
+      - 804c7114-3b15-4846-8221-b42be6546a9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1684,10 +1384,390 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - b6b50976-21ed-4384-b51b-05137390a734
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 8c90e215-c83b-464b-837e-ce33d0206a53
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - b4bc7752-881b-49b7-8e87-ebffb0c26987
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 57d7f30f-88ae-46f9-ad9e-cd0168ccf1ec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - edd5762c-e293-4fb7-b82a-5fd42bdd7648
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 2197c39a-3f8f-49ab-b018-826967e19b26
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - f176b230-e374-4fa7-bee1-a5d74f9474d6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 80a3b54f-2dc8-43fb-93b4-5033ec00f5a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t"},"properties":{"associations":["vm_7tOuR5eK7zhFKEO2"]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
+    method: PATCH
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:40 GMT
+      Etag:
+      - W/"1d940ab9d34543f358c6435e7d7b5d2c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - cc1a7dad-eb50-42ab-82cd-2a28324dad4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1702,387 +1782,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:30 GMT
+      - Thu, 06 Feb 2025 17:44:45 GMT
       Etag:
-      - W/"a9f1d3661778e29482eebd646d47142c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - b582c808-3c56-420f-9e36-063ac8d0efc7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:40 GMT
-      Etag:
-      - W/"f34a8962c7a1c85fcfe737dae764ca71"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "976"
-      X-Request-Id:
-      - 64078455-9691-47a3-8964-43df273aee1b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:40 GMT
-      Etag:
-      - W/"f34a8962c7a1c85fcfe737dae764ca71"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "975"
-      X-Request-Id:
-      - 163f52a4-518e-4880-8fd9-615a7f8ef0d8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - 0e4ad265-a7f3-48a3-88fd-8afdf9f817a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"f34a8962c7a1c85fcfe737dae764ca71"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "973"
-      X-Request-Id:
-      - 9a5a8833-4fa3-40eb-94c7-142a1c5ced36
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "972"
-      X-Request-Id:
-      - 8f515eef-2165-4458-904e-6fefdbf5d86b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - 78cf651b-f420-4947-ab2e-9ca6eb38a496
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "970"
-      X-Request-Id:
-      - 540d743d-2c81-4610-a26c-5ea0f7c26750
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - 00cd5e56-fca9-4ca9-92b4-c55bade8e2da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
+      - W/"e1c700383a4af8a107a7a185789580be"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2092,7 +1794,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "968"
       X-Request-Id:
-      - d9fe785e-eb79-40ae-bb3c-3601d6fea80f
+      - d41280ac-27ed-4170-8b72-cdd8d8fe64d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,10 +1804,50 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:44:50 GMT
+      Etag:
+      - W/"e1c700383a4af8a107a7a185789580be"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 19276dfe-6a45-4d50-b9cd-df9bd94f0932
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2120,9 +1862,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
+      - Thu, 06 Feb 2025 17:45:00 GMT
       Etag:
-      - W/"f34a8962c7a1c85fcfe737dae764ca71"
+      - W/"1d940ab9d34543f358c6435e7d7b5d2c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2130,9 +1872,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "968"
+      - "999"
       X-Request-Id:
-      - e2588386-2133-498f-b609-bf18e7340965
+      - 68aa27f8-0707-4ea4-9abb-4eb21160a27e
     status: 200 OK
     code: 200
     duration: ""
@@ -2142,12 +1884,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2158,13 +1898,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "763"
+      - "348"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
+      - Thu, 06 Feb 2025 17:45:01 GMT
       Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
+      - W/"1d940ab9d34543f358c6435e7d7b5d2c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2172,145 +1912,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "966"
+      - "998"
       X-Request-Id:
-      - a6ad945a-3e9b-4866-9d6d-3cd0e02cdb03
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "965"
-      X-Request-Id:
-      - fffb471b-d5fe-47f2-b9ef-49d23931474d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "964"
-      X-Request-Id:
-      - a351c3f2-78a3-40db-91af-9958eb6fbf47
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "963"
-      X-Request-Id:
-      - 5d1a9c12-0a0b-4445-94e6-ed8f770cb49a
+      - 6cb71a9a-a6ee-4941-9a8c-488ecf1d52d1
     status: 200 OK
     code: 200
     duration: ""
@@ -2320,10 +1924,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2338,9 +1942,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
+      - Thu, 06 Feb 2025 17:45:01 GMT
       Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2348,9 +1952,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "997"
       X-Request-Id:
-      - 9c67edeb-cd06-4491-a3c2-da053dc17a50
+      - 3dfd78e6-6655-426e-8e35-25b2f6b1fc9d
     status: 200 OK
     code: 200
     duration: ""
@@ -2360,10 +1964,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2378,9 +1982,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
+      - Thu, 06 Feb 2025 17:45:01 GMT
       Etag:
-      - W/"f34a8962c7a1c85fcfe737dae764ca71"
+      - W/"1d940ab9d34543f358c6435e7d7b5d2c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2388,9 +1992,605 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "996"
       X-Request-Id:
-      - f829e09d-ead8-4f51-9144-3f7233c01979
+      - 934d5ef4-48a8-4499-a356-bd4281dc5def
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 23600f85-cf09-45f5-a26a-c4acae070456
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 85a0abc7-0ee7-4a15-a683-27133b166b19
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - c557d9e2-f08c-4296-8289-18a966a0980a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - 167154b9-7cf5-4f18-95a2-3722d1f2c83d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 2df155c6-3ae8-4937-b5aa-4708ca80b229
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 0302c54d-dcea-4f2e-a722-255d4e3dd498
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"1d940ab9d34543f358c6435e7d7b5d2c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 1d22ce5a-6ad0-48fc-8dfe-31631e90a81d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - c9566fac-cf52-47bc-8c5b-43c3488298f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - e80fbead-3ce2-4e34-bbb4-11fdbf3897f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 3b8fe945-7d72-4843-989b-a08dc5a37070
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - fd1f3fe4-bd69-4fc6-92dd-d6edf8971cb1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 4b6d0988-5788-4e7a-ac51-d17d836b68cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - bc284666-0159-4fc4-838e-5f2308bd97f6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:02 GMT
+      Etag:
+      - W/"1d940ab9d34543f358c6435e7d7b5d2c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 1f80f10e-fa16-4dbf-9020-8d1eb7d4a19a
     status: 200 OK
     code: 200
     duration: ""
@@ -2418,7 +2618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:41 GMT
+      - Thu, 06 Feb 2025 17:45:03 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -2428,9 +2628,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "981"
       X-Request-Id:
-      - f06eb767-8fae-4578-973a-f3a743fa32fb
+      - c64cd23d-47ee-46c7-b743-544d19419edf
     status: 200 OK
     code: 200
     duration: ""
@@ -2445,7 +2645,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"185-44-253-66.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"185-44-253-157.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -2458,13 +2658,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "558"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:42 GMT
+      - Thu, 06 Feb 2025 17:45:03 GMT
       Etag:
-      - W/"06823c2b5c0ccef27908090ee27684ba"
+      - W/"9fbc50d16f5e92547db1c3d6841a8022"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2472,9 +2672,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "980"
       X-Request-Id:
-      - 525bdbab-d266-42c5-ae1d-47943a87dafb
+      - 8241b634-65d0-42dc-bd6b-91b135e62c88
     status: 200 OK
     code: 200
     duration: ""
@@ -2484,10 +2684,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"185-44-253-66.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"185-44-253-157.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -2500,13 +2700,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "576"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:42 GMT
+      - Thu, 06 Feb 2025 17:45:03 GMT
       Etag:
-      - W/"f0d74acf39e613304f0368980ec1ec95"
+      - W/"09801b24f90a1af197cd59dce0ad2de9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2514,9 +2714,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "979"
       X-Request-Id:
-      - 9cc5d83e-77e2-40b5-a44c-a32004410ee4
+      - d1032c2d-3446-4bd5-925b-9a9f71105ea0
     status: 200 OK
     code: 200
     duration: ""
@@ -2527,11 +2727,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"185-44-253-66.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"185-44-253-157.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -2544,13 +2744,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "576"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:42 GMT
+      - Thu, 06 Feb 2025 17:45:03 GMT
       Etag:
-      - W/"f0d74acf39e613304f0368980ec1ec95"
+      - W/"09801b24f90a1af197cd59dce0ad2de9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2558,15 +2758,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "978"
       X-Request-Id:
-      - c4e27607-f70c-43c4-99a6-196b745e7439
+      - 29300157-d514-4b74-95fa-9aac185bab3a
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_kT0YlUGdJt20NROI</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-associations-vsjxzuoti1wu-db</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-18-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_uvIewAo5cCiax5V9</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-acc-test-associations-jnucksep5xjz-db</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -2574,11 +2774,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_PSlgm0jCI1JhamHN","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_wAu3NBVp3ErrIiDd","state":"pending"},"virtual_machine_build":{"id":"vmbuild_wAu3NBVp3ErrIiDd","state":"pending"},"hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","annotations":[]}'
+    body: '{"task":{"id":"task_p7r9bAxVUhUM41ZQ","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_w10qmbNrBvqJ1GPu","state":"pending"},"virtual_machine_build":{"id":"vmbuild_w10qmbNrBvqJ1GPu","state":"pending"},"hostname":"tf-acc-test-associations-jnucksep5xjz-db","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2593,9 +2793,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:42 GMT
+      - Thu, 06 Feb 2025 17:45:03 GMT
       Etag:
-      - W/"1455a7eb370ffbde8dbd520c0469f286"
+      - W/"5f69809157947d682fa5d0bf4139cfe6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2603,9 +2803,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "977"
       X-Request-Id:
-      - 58fa70bd-e3cb-4f6b-b228-c9338883dc27
+      - 68d3dea0-16cd-40d7-8537-b9a93953c858
     status: 201 Created
     code: 201
     duration: ""
@@ -2616,18 +2816,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_wAu3NBVp3ErrIiDd
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_w10qmbNrBvqJ1GPu
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_wAu3NBVp3ErrIiDd","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_w10qmbNrBvqJ1GPu","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.66\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-vsjxzuoti1wu-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.157\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734706602},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863903},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2640,3752 +2840,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:56:44 GMT
+      - Thu, 06 Feb 2025 17:45:05 GMT
       Etag:
-      - W/"fca0d0210e43adae7df5ca7424eb9e4e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "955"
-      X-Request-Id:
-      - d95a7e0f-3719-4f01-ba27-8b70a5b1cd31
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_wAu3NBVp3ErrIiDd
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_wAu3NBVp3ErrIiDd","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.66\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-vsjxzuoti1wu-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734706602},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:49 GMT
-      Etag:
-      - W/"6f035d10cfb6faba8a56e9a30f3c3ce6"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "954"
-      X-Request-Id:
-      - e6806d93-d8fc-4752-8634-cd442bd1f9c7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_wAu3NBVp3ErrIiDd
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_wAu3NBVp3ErrIiDd","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.66\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-vsjxzuoti1wu-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734706602},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:56:59 GMT
-      Etag:
-      - W/"6f035d10cfb6faba8a56e9a30f3c3ce6"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "953"
-      X-Request-Id:
-      - 9e5ddc39-5937-417f-993b-7c7a0315fb2b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_wAu3NBVp3ErrIiDd
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_wAu3NBVp3ErrIiDd","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.66\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-vsjxzuoti1wu-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1734706602},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:09 GMT
-      Etag:
-      - W/"98a27aa9e491ea11c053e5273c95f98a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - da287737-578d-40f5-84d9-fcc802c5ca13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:11 GMT
-      Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - 5a6ff2c1-5780-434d-9206-e5505bc422d8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:11 GMT
-      Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - 4ab86259-9735-40a6-97eb-671d77bc7393
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_AZhAgNnlm1UvNnzW","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "389"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:11 GMT
-      Etag:
-      - W/"711753f066ba0c192bee67d906b28bde"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 450b3b41-2a09-43b3-852a-654f74669afb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_AZhAgNnlm1UvNnzW
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_AZhAgNnlm1UvNnzW","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:82:e4:cb:0e:80","state":"attached","ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "530"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:11 GMT
-      Etag:
-      - W/"33cf921ecd900936b2a0c3ed122cd8a4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - 8fa70caf-3d2a-445f-ac32-ac91746f81cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R"},"properties":{"associations":["vm_CVYIEGWjGgTxO0oo","vm_heORtn6n0n7gtd6u"]}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
-    method: PATCH
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u","vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "370"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:11 GMT
-      Etag:
-      - W/"59c3bba67611a3c8ef441be5aa8321e2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - 5a6cc2c2-2bdc-4fd1-842b-4831f2f54b8c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u","vm_CVYIEGWjGgTxO0oo"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:16 GMT
-      Etag:
-      - W/"26ca8d83afad161882b6cc3388b5f829"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - 3e97ea0d-da13-43c9-8718-0f4168263139
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u","vm_CVYIEGWjGgTxO0oo"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "376"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:22 GMT
-      Etag:
-      - W/"26ca8d83afad161882b6cc3388b5f829"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - c94f18d9-0376-4b72-a3a7-49f70bbd80b3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u","vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "370"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"59c3bba67611a3c8ef441be5aa8321e2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "991"
-      X-Request-Id:
-      - 09295450-11d6-4b8b-ab8b-5bb5c66f49ad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u","vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "370"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"59c3bba67611a3c8ef441be5aa8321e2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - fb22efe5-3ba2-40f5-8aa5-442b419e6f0e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - 677e23f0-e74d-4c11-9a68-afa6fdd0bbbb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u","vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "370"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"59c3bba67611a3c8ef441be5aa8321e2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - 5e253573-9662-4604-9c3f-c76024d126bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "757"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"21ddc6080539ed967821e083a6dd26c7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - 70654b47-f027-419d-b0c6-68de0d3cf0fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - 20c47640-16c4-42ee-899a-3e33bb215158
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "985"
-      X-Request-Id:
-      - 268f897c-90a9-414d-b6b3-07c5835009e0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - b17beca7-518c-4186-af17-b8ad52a531ae
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_AZhAgNnlm1UvNnzW","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "389"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"711753f066ba0c192bee67d906b28bde"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - 8b6ad7b2-3fb4-4669-bfd9-7d9509eb7d48
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "982"
-      X-Request-Id:
-      - b043693a-a9c3-47bd-8367-3d7be32978fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_AZhAgNnlm1UvNnzW
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_AZhAgNnlm1UvNnzW","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:82:e4:cb:0e:80","state":"attached","ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "530"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"33cf921ecd900936b2a0c3ed122cd8a4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "981"
-      X-Request-Id:
-      - 832fd0cb-cc2b-4f3e-9674-56800da019ce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - a5d9cd6d-e715-4cbb-8436-bb89be2d6e60
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - efdd8f75-3aa9-4a4f-a3bc-5f6ae394bbf7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u","vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "370"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"59c3bba67611a3c8ef441be5aa8321e2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - 7cc678dd-139d-4311-91cd-4503db963333
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - b4733c51-10d1-4649-ab91-cb7a7b41f8c8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "757"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"21ddc6080539ed967821e083a6dd26c7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - 4ac7e3c9-8dd3-4b22-b5db-26a95ea492d0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "975"
-      X-Request-Id:
-      - 46d5b27b-f409-4f13-959e-9fbfaeb5e4ea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - 0ec3547c-b9cc-46a8-950f-f89308763fd2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "972"
-      X-Request-Id:
-      - e3b34663-4be0-43e2-afa3-d2f123875dd6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_AZhAgNnlm1UvNnzW","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "389"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:32 GMT
-      Etag:
-      - W/"711753f066ba0c192bee67d906b28bde"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "973"
-      X-Request-Id:
-      - 6b6e632b-a8c7-42a7-b235-9c716171efe4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_AZhAgNnlm1UvNnzW
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_AZhAgNnlm1UvNnzW","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:82:e4:cb:0e:80","state":"attached","ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "530"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:33 GMT
-      Etag:
-      - W/"33cf921ecd900936b2a0c3ed122cd8a4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - 499a6dae-fd5a-49e8-b700-23dd25d2f59e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:33 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - 801a3fe2-70d2-4893-9eed-5a151ffba38a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u","vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "370"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:33 GMT
-      Etag:
-      - W/"59c3bba67611a3c8ef441be5aa8321e2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - 74ef4c03-b7d3-4085-b3d0-cc13f7f06725
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:33 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - 5a944dca-859b-47b0-b1f7-35fedc7f8806
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R"},"properties":{"associations":["vm_CVYIEGWjGgTxO0oo"]}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
-    method: PATCH
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:33 GMT
-      Etag:
-      - W/"cf1c0d3b87369e9f372a7729e5a332b5"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "967"
-      X-Request-Id:
-      - d7c55560-81cb-40e4-8419-a4b4d30dcb03
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CVYIEGWjGgTxO0oo"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:38 GMT
-      Etag:
-      - W/"1ca75457545d837936b090d5d519c2a1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "966"
-      X-Request-Id:
-      - ecf2b66c-1dbf-4f3f-aa79-15a463088796
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CVYIEGWjGgTxO0oo"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "354"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:43 GMT
-      Etag:
-      - W/"1ca75457545d837936b090d5d519c2a1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "965"
-      X-Request-Id:
-      - fd6246c5-8f79-4046-9a77-f2c62ed78645
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"cf1c0d3b87369e9f372a7729e5a332b5"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "964"
-      X-Request-Id:
-      - 0149a512-003b-4db2-ab5b-78062efc3338
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"cf1c0d3b87369e9f372a7729e5a332b5"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "963"
-      X-Request-Id:
-      - 4565e1b9-f021-4271-85ee-32f993c3aa65
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "962"
-      X-Request-Id:
-      - 07e18cd9-5c07-43fc-b04a-49585e54eb8a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"cf1c0d3b87369e9f372a7729e5a332b5"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "961"
-      X-Request-Id:
-      - e23f5c0b-57b3-4a54-bc48-8982a65c122e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "757"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"21ddc6080539ed967821e083a6dd26c7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "960"
-      X-Request-Id:
-      - 36e1332f-eb5b-4be2-8029-ac16ba2c7901
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "959"
-      X-Request-Id:
-      - b9d11d19-63ce-4a6b-a909-3154092fcb13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "958"
-      X-Request-Id:
-      - 02e0234d-8ad2-42ee-9654-7cd11229db62
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "957"
-      X-Request-Id:
-      - e05e6b3c-8b44-4bd4-8ba5-0ca212caaa5d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_AZhAgNnlm1UvNnzW","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "389"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"711753f066ba0c192bee67d906b28bde"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "956"
-      X-Request-Id:
-      - 35dbd912-89db-4877-b9e1-41e4cb251e60
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "955"
-      X-Request-Id:
-      - 8115c03f-55cb-47e5-ae91-784a00f21ab7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_AZhAgNnlm1UvNnzW
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_AZhAgNnlm1UvNnzW","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:82:e4:cb:0e:80","state":"attached","ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "530"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"33cf921ecd900936b2a0c3ed122cd8a4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "954"
-      X-Request-Id:
-      - 4d26afdb-ddb6-4d3f-b20a-03153dd54dbc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "953"
-      X-Request-Id:
-      - f91009ac-ea19-4d97-b0ec-532a93328bbe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"cf1c0d3b87369e9f372a7729e5a332b5"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - be284d44-16e5-4028-8083-c6ed319e4b4a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:53 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "951"
-      X-Request-Id:
-      - 659059f4-fc54-4242-9b9c-5d0c064d62f9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - 046b37f2-df91-40ec-83ad-312c042b232c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "757"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"21ddc6080539ed967821e083a6dd26c7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "950"
-      X-Request-Id:
-      - 7bdbeb20-1930-40ec-80a3-48bd19cd0aa1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_CVYIEGWjGgTxO0oo"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "348"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"cf1c0d3b87369e9f372a7729e5a332b5"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "948"
-      X-Request-Id:
-      - 9e19e8a6-1129-4830-a9b2-97ebb2ab188f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "947"
-      X-Request-Id:
-      - 15eb4da7-6be5-4771-bffe-0da71a410df6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "946"
-      X-Request-Id:
-      - c57edfc0-ff0a-48a7-884b-f7be8114fd82
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "945"
-      X-Request-Id:
-      - 7248172c-1996-4028-a25a-6002c2d54601
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_AZhAgNnlm1UvNnzW","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "389"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"711753f066ba0c192bee67d906b28bde"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "944"
-      X-Request-Id:
-      - 44058087-aab6-4594-8fcd-7092da3e2549
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "943"
-      X-Request-Id:
-      - b45e8676-d1df-4791-95ef-bd57e22b40f2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_AZhAgNnlm1UvNnzW
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_AZhAgNnlm1UvNnzW","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:82:e4:cb:0e:80","state":"attached","ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "530"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"33cf921ecd900936b2a0c3ed122cd8a4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "942"
-      X-Request-Id:
-      - 5889ae34-b2aa-4a3b-9535-6b14408e73a1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "941"
-      X-Request-Id:
-      - d5565281-b7f3-4c25-b444-b5b4d8484d47
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R"},"properties":{"associations":[]}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
-    method: PATCH
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:54 GMT
-      Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "940"
-      X-Request-Id:
-      - 1148b89b-9c1a-4bc1-bab4-804d47c76645
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "333"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:57:59 GMT
-      Etag:
-      - W/"7bc62a96d1cf30118fb0ff15d321bc5e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "939"
-      X-Request-Id:
-      - 5f94055c-b812-4ec9-9251-5459c1dc5858
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "333"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:04 GMT
-      Etag:
-      - W/"7bc62a96d1cf30118fb0ff15d321bc5e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - 210f1b0e-61e7-4e83-a937-d13b9216d1ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - 34419dc2-04b7-4225-9712-c4af624db1ce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - 64e30198-d5e3-40d6-a6e0-4c377c7c36bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - bef6e192-b780-4aa3-89d6-744e6c720be9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "995"
-      X-Request-Id:
-      - 1193c948-416f-42fc-aff3-4b486044f714
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - 290d3bcd-189d-4a67-800b-b0499f8a5e77
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "757"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"21ddc6080539ed967821e083a6dd26c7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - 543bf26b-0cd8-4627-bd2f-2349068a3c4a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - b7e6e62c-05f9-446e-86e4-a6d021b445f5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "991"
-      X-Request-Id:
-      - a71a665b-e77f-4cc6-8a71-e73dd9e7415b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:14 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - 59f7e153-1842-48a7-9869-3d28fd3e8b1c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_AZhAgNnlm1UvNnzW","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "389"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"711753f066ba0c192bee67d906b28bde"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - b3a2e3cb-92d1-4be2-90d1-38f4cdf04c11
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - a203a1f1-db5d-4d9e-8742-54357532adad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - b2ee4dc9-b918-4db1-830a-8bd287d83839
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_AZhAgNnlm1UvNnzW
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_AZhAgNnlm1UvNnzW","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:82:e4:cb:0e:80","state":"attached","ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "530"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"33cf921ecd900936b2a0c3ed122cd8a4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - 3a3ef080-1094-4fc8-ae20-be17dcb11873
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "985"
-      X-Request-Id:
-      - 9d7ffbec-72b2-473c-9841-d0c6ec0a1998
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "763"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 504fac0a-29dc-4db1-ba50-39002c871fde
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "757"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"21ddc6080539ed967821e083a6dd26c7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 1ac1a5c7-b342-452f-86e1-8889def7e331
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - 511a1718-90ee-4f79-a302-af196777c980
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_heORtn6n0n7gtd6u"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "342"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"f9750511b7864d37a84b392078435c9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "981"
-      X-Request-Id:
-      - 73091128-0b85-40f3-9adf-7cb01dfbf093
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - e3d5a4c6-4471-41ac-a599-c8d1ad383e4c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - 53766a5a-e157-4473-94e5-ff331c357f02
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "978"
-      X-Request-Id:
-      - 441e56bc-5530-4134-aa70-47cec4ca9041
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_AZhAgNnlm1UvNnzW","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "389"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"711753f066ba0c192bee67d906b28bde"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - b366c04e-f6a1-4c16-ac0a-2cf8788752d6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "534"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
-      Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
+      - W/"32926815267342ce19c05c8d88e00fbe"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6395,7 +2852,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - 84cc3fa4-5e6a-4f6f-b560-0542a477e8ab
+      - f995c5fd-1987-437e-9c23-9b9e11b6bace
     status: 200 OK
     code: 200
     duration: ""
@@ -6406,13 +2863,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_AZhAgNnlm1UvNnzW
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_w10qmbNrBvqJ1GPu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_AZhAgNnlm1UvNnzW","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:82:e4:cb:0e:80","state":"attached","ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_w10qmbNrBvqJ1GPu","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.157\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863903},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6422,14 +2884,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "530"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
+      - Thu, 06 Feb 2025 17:45:10 GMT
       Etag:
-      - W/"33cf921ecd900936b2a0c3ed122cd8a4"
+      - W/"32926815267342ce19c05c8d88e00fbe"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6439,22 +2899,29 @@ interactions:
       X-Ratelimit-Remaining:
       - "975"
       X-Request-Id:
-      - e6e25bdb-f272-4dd9-b924-b113bc8f6ce4
+      - 87862f15-fe75-487e-a409-0ac7135d23b0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0"},"properties":{"associations":[]}}'
+    body: ""
     form: {}
     headers:
-      Content-Type:
+      Accept:
       - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
-    method: PATCH
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_w10qmbNrBvqJ1GPu
+    method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_w10qmbNrBvqJ1GPu","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.157\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863903},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6464,14 +2931,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "321"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:15 GMT
+      - Thu, 06 Feb 2025 17:45:20 GMT
       Etag:
-      - W/"89fdacdee7589a1027bffe10d8f28296"
+      - W/"6381b96671828d406f05237e61ce599e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6481,7 +2946,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "974"
       X-Request-Id:
-      - 95cbf4df-568b-480a-8560-62a89e535b29
+      - e0c2da8e-70f7-4c1d-bb31-3a01823eae6a
     status: 200 OK
     code: 200
     duration: ""
@@ -6489,12 +2954,21 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_w10qmbNrBvqJ1GPu
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_w10qmbNrBvqJ1GPu","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.157\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863903},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6504,14 +2978,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:20 GMT
+      - Thu, 06 Feb 2025 17:45:30 GMT
       Etag:
-      - W/"8d6ece16bbd560e9aa7dd5307853b31e"
+      - W/"6381b96671828d406f05237e61ce599e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6521,7 +2993,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "973"
       X-Request-Id:
-      - c6ae268a-5201-445f-b073-2ede9e72cbe4
+      - ac5922fb-5eac-4458-8e8c-5869de99a7ad
     status: 200 OK
     code: 200
     duration: ""
@@ -6529,12 +3001,21 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_w10qmbNrBvqJ1GPu
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"virtual_machine_build":{"id":"vmbuild_w10qmbNrBvqJ1GPu","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-18-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.157\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-acc-test-associations-jnucksep5xjz-db\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738863903},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6544,14 +3025,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "327"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:25 GMT
+      - Thu, 06 Feb 2025 17:45:40 GMT
       Etag:
-      - W/"8d6ece16bbd560e9aa7dd5307853b31e"
+      - W/"75874f626c41388be54f6b8ef1d19187"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6561,7 +3040,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "972"
       X-Request-Id:
-      - c670344e-9a01-4553-9225-38c0a0e98c92
+      - 68182a6b-a13f-4df3-a76b-6ce26d6edb17
     status: 200 OK
     code: 200
     duration: ""
@@ -6569,12 +3048,22 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6584,14 +3073,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "321"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:35 GMT
+      - Thu, 06 Feb 2025 17:45:42 GMT
       Etag:
-      - W/"89fdacdee7589a1027bffe10d8f28296"
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6601,7 +3088,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "971"
       X-Request-Id:
-      - ee1127aa-782f-471a-93f7-d69913c51578
+      - c85d211b-3440-4d27-9c13-673ef90540b5
     status: 200 OK
     code: 200
     duration: ""
@@ -6609,12 +3096,22 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6624,14 +3121,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "321"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:35 GMT
+      - Thu, 06 Feb 2025 17:45:43 GMT
       Etag:
-      - W/"89fdacdee7589a1027bffe10d8f28296"
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6641,7 +3136,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "970"
       X-Request-Id:
-      - 8d5847e3-c24e-4339-b9f1-94af8229ee00
+      - 72f3522d-af91-4a8e-8e05-fc1d11852211
     status: 200 OK
     code: 200
     duration: ""
@@ -6650,11 +3145,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3PSsUvmKzyrUWwPs","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6665,13 +3162,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "321"
+      - "391"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:35 GMT
+      - Thu, 06 Feb 2025 17:45:43 GMT
       Etag:
-      - W/"89fdacdee7589a1027bffe10d8f28296"
+      - W/"2caeb44a45bdd3e1b9ca725597e11d89"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6681,7 +3178,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "969"
       X-Request-Id:
-      - 993305ff-f9c8-427d-bc48-0fd94f88f3d9
+      - e57d01cc-83aa-4043-90ac-de7958797b00
     status: 200 OK
     code: 200
     duration: ""
@@ -6690,11 +3187,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6705,13 +3204,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "327"
+      - "531"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:35 GMT
+      - Thu, 06 Feb 2025 17:45:43 GMT
       Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6721,7 +3220,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "968"
       X-Request-Id:
-      - b3bf5d3f-4bfd-43a2-8a21-473abf245554
+      - b902ab20-50de-4ccf-b60a-cbfc8001f189
     status: 200 OK
     code: 200
     duration: ""
@@ -6729,14 +3228,16 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6747,13 +3248,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "757"
+      - "531"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:45:43 GMT
       Etag:
-      - W/"21ddc6080539ed967821e083a6dd26c7"
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6763,22 +3264,22 @@ interactions:
       X-Ratelimit-Remaining:
       - "967"
       X-Request-Id:
-      - 8ff8e185-e48c-4050-ac35-88ac4466af5e
+      - d21b7b49-9769-4105-9a99-9fdf0f9e6f4e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t"},"properties":{"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"]}}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: GET
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
+    method: PATCH
   response:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"}}}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6789,13 +3290,53 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "763"
+      - "370"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:45:43 GMT
       Etag:
-      - W/"200aa5948f01c7670a247011111bd211"
+      - W/"97fa9efb7d2b1b760b25c8ee9d3fcb71"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 0477f92f-cd91-403f-85f2-67f741fabff1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "376"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:45:48 GMT
+      Etag:
+      - W/"f0fa33ac805aea0d44aa580cb879b1c5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6805,7 +3346,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "965"
       X-Request-Id:
-      - 2f2ebd30-8d8b-454c-9c99-9ae78eb33516
+      - 4ba89b38-6df5-45ae-b914-2e557cddde85
     status: 200 OK
     code: 200
     duration: ""
@@ -6815,10 +3356,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6829,13 +3370,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "321"
+      - "376"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:45:53 GMT
       Etag:
-      - W/"89fdacdee7589a1027bffe10d8f28296"
+      - W/"f0fa33ac805aea0d44aa580cb879b1c5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6843,9 +3384,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "967"
+      - "964"
       X-Request-Id:
-      - 6f9021ca-3c38-4c8a-b198-22fd23333712
+      - 1e38e4db-cd1d-4acf-9801-371b6d414a1b
     status: 200 OK
     code: 200
     duration: ""
@@ -6855,10 +3396,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6869,13 +3410,1367 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "327"
+      - "370"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:03 GMT
       Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
+      - W/"97fa9efb7d2b1b760b25c8ee9d3fcb71"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 2642a313-4414-43c9-a64b-31f95488b1a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"97fa9efb7d2b1b760b25c8ee9d3fcb71"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - ec9d70d5-6779-4ee7-a4b2-71d58a5828a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 82cd565e-8c82-4c26-ac92-9e53308de483
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"97fa9efb7d2b1b760b25c8ee9d3fcb71"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 153e53c1-0001-4607-8c27-5efa5fb544d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"ee72cbe3c5db00c9370224d5329a3c26"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 8311634a-615e-464b-aae6-0e6266e74a7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - f0a3a376-d87e-4fef-8bd9-a71c2a235aa7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 885e6773-f99c-4e05-a6c8-5339bcab366c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - fa94d7cc-116f-495b-801b-b8751e4a56f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3PSsUvmKzyrUWwPs","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"2caeb44a45bdd3e1b9ca725597e11d89"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 07d1761a-f51a-475c-be27-65de4640f00c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 3174fac0-13aa-47ad-90f4-f0703c98498b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 60f83266-bd05-4a07-8a31-58b0d078b5d1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - c98579da-eada-4a33-9a03-f6d3d5bf10a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 6a5c6641-55fc-4a9d-b64b-eaf3b9c8fbae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 98410be8-8b7c-4fe1-a473-479babe2f042
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 723f022e-ec8a-405f-bcdf-5728bedc40ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:03 GMT
+      Etag:
+      - W/"97fa9efb7d2b1b760b25c8ee9d3fcb71"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 2990357b-66ff-48f1-a40d-deca18fcdc96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"ee72cbe3c5db00c9370224d5329a3c26"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 54cc819e-c8b8-4fec-a722-3c8703af7893
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 399dca6f-0939-405f-8c15-3f6d46814096
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 798a5f4b-4d02-47d8-aefe-432644165e9f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - 0312c288-bb64-49fb-b352-7b695e0a0af2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3PSsUvmKzyrUWwPs","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"2caeb44a45bdd3e1b9ca725597e11d89"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 92592a9a-b725-4146-bbcd-df14e5d7bc5d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - b16ba7a1-2396-49d8-8e1d-14e36694ab0d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - 3dacbc10-7e40-40d8-8437-58f65226c7f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 3f574a1e-5bd5-4442-aebc-62588c651069
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 78e012ba-a8af-4eb3-bf64-73b2f6a4f664
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - b42af5a7-be4c-4b5f-8da7-705da46c1cf3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2","vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"97fa9efb7d2b1b760b25c8ee9d3fcb71"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 28e21674-a223-4cf9-883e-38fd7a9d1726
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - ca48cabd-b7e3-4cab-8857-614810df2593
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t"},"properties":{"associations":["vm_Cl2BRgFD3HyC4QzB"]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
+    method: PATCH
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:04 GMT
+      Etag:
+      - W/"42d99e9412c0a650b6892c563dbdc014"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - bc011f19-62ba-4ffe-a13f-c87cec115745
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Cl2BRgFD3HyC4QzB"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:09 GMT
+      Etag:
+      - W/"47116558cffe0167e042c5ad1dc9908b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - 9353b160-8b43-4de6-bcf4-26df2375d7a2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Cl2BRgFD3HyC4QzB"],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "354"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:14 GMT
+      Etag:
+      - W/"47116558cffe0167e042c5ad1dc9908b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - b71b3b45-000c-44c9-bb3f-cac94f29720c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:24 GMT
+      Etag:
+      - W/"42d99e9412c0a650b6892c563dbdc014"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - f73bb837-82a5-472e-b9ea-98a6a5217161
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:24 GMT
+      Etag:
+      - W/"42d99e9412c0a650b6892c563dbdc014"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6885,7 +4780,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "967"
       X-Request-Id:
-      - 225ae871-db39-4d12-816e-49b7eebd5f56
+      - 676b1684-2afc-49d2-a3dd-10d80db57d14
     status: 200 OK
     code: 200
     duration: ""
@@ -6893,22 +4788,12 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6918,12 +4803,138 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:24 GMT
       Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 40ea40ea-8db0-4443-b6f0-32696274d9bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:24 GMT
+      Etag:
+      - W/"42d99e9412c0a650b6892c563dbdc014"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - de1e7644-14f1-45d1-a78b-6b64b6739c4b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"ee72cbe3c5db00c9370224d5329a3c26"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - ab2c7b22-ec57-4f73-88a8-4df642d802ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6933,7 +4944,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "963"
       X-Request-Id:
-      - 0b3ac7b6-18ff-4633-adc6-b46c770206f9
+      - 519796cd-c527-4b3c-90a6-551d451caf1b
     status: 200 OK
     code: 200
     duration: ""
@@ -6944,19 +4955,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -6969,9 +4980,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:25 GMT
       Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -6979,9 +4990,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "962"
       X-Request-Id:
-      - 81732ec4-73c7-441c-8524-737523d95e55
+      - b45b11f0-9bf2-435e-b10b-0f8f1c5bc02b
     status: 200 OK
     code: 200
     duration: ""
@@ -6992,13 +5003,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_MYc0GEdDK6Nu897J","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}]}]}'
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7008,58 +5025,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "392"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:25 GMT
       Etag:
-      - W/"2977399efe625bc045bca3385c0e2c99"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "961"
-      X-Request-Id:
-      - c5a47381-671f-4c0f-a4d4-1f736557560a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_AZhAgNnlm1UvNnzW","name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "389"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
-      Etag:
-      - W/"711753f066ba0c192bee67d906b28bde"
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7069,7 +5040,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "961"
       X-Request-Id:
-      - d893a487-d477-4ee3-b21d-6c6cd8de40be
+      - 780c04ca-f853-43af-97fa-cd163ee73997
     status: 200 OK
     code: 200
     duration: ""
@@ -7077,16 +5048,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_MYc0GEdDK6Nu897J
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_MYc0GEdDK6Nu897J","virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:55:f0:2f:76:99","state":"attached","ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7097,13 +5066,55 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "534"
+      - "391"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:25 GMT
       Etag:
-      - W/"54eb36ff2ab8899e13112f3d93a7fd05"
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - a5e19f71-b632-4a05-b3dc-324148b06a6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3PSsUvmKzyrUWwPs","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"2caeb44a45bdd3e1b9ca725597e11d89"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7113,7 +5124,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "959"
       X-Request-Id:
-      - 49a4fdfc-2127-4187-9e81-e6d07bf232aa
+      - 25cf258d-fbbf-42f5-bf5e-23162f3fa1cc
     status: 200 OK
     code: 200
     duration: ""
@@ -7121,16 +5132,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_AZhAgNnlm1UvNnzW
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_AZhAgNnlm1UvNnzW","virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db"},"name":"Public
-      Network on tf-acc-test-associations-vsjxzuoti1wu-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:82:e4:cb:0e:80","state":"attached","ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7141,13 +5150,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "530"
+      - "531"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:25 GMT
       Etag:
-      - W/"33cf921ecd900936b2a0c3ed122cd8a4"
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7157,7 +5166,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "958"
       X-Request-Id:
-      - 4f5d460b-3d09-42cd-bff0-ad71ae717f2a
+      - 5fbabd1f-6923-44be-a7a5-2beadce44167
     status: 200 OK
     code: 200
     duration: ""
@@ -7165,12 +5174,16 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7181,13 +5194,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "321"
+      - "531"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:25 GMT
       Etag:
-      - W/"89fdacdee7589a1027bffe10d8f28296"
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7197,7 +5210,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "957"
       X-Request-Id:
-      - 1da2a4e2-3344-4e0c-ae16-e24a43ad1dc0
+      - f9008a46-57e7-425b-ac6d-c40a9884717c
     status: 200 OK
     code: 200
     duration: ""
@@ -7207,10 +5220,694 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"42d99e9412c0a650b6892c563dbdc014"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 747e9101-d3ab-4eb4-80a4-157b647dee3e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - 53331df8-eed9-4994-94b4-c2fe0da8e87c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - 57a41e5c-1608-4c7f-b9a5-5eb64bf74549
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "953"
+      X-Request-Id:
+      - c6fce308-0a6b-4511-ad0b-0d6458c23d4f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - 3cd52e8b-7f09-4272-bb79-745383bc6110
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"ee72cbe3c5db00c9370224d5329a3c26"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - 4fef90b7-18be-4559-8ab3-737732319b03
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "949"
+      X-Request-Id:
+      - e4d946be-059d-4d18-b05c-c7037cd5fb85
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "950"
+      X-Request-Id:
+      - bc621d1a-0370-4899-a759-0d356ea6a655
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3PSsUvmKzyrUWwPs","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"2caeb44a45bdd3e1b9ca725597e11d89"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - 2636776e-537d-450a-8a07-375b31db9b61
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - 5b6f0d42-54ad-4224-a464-ec51f8dc4d6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 388fa4c5-f36f-4555-9b01-052a362496b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 2eb6907a-9dc5-4323-96d0-e2d2060b0ca0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - cd271c9d-1fa4-4198-bc9f-652b7db6d6c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:25 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - a3167687-ad4a-4645-a351-df06968bcd4d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:26 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "941"
+      X-Request-Id:
+      - c9e1fa35-55f0-4df7-b69a-ba55d1e7c77a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_Cl2BRgFD3HyC4QzB"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "348"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:26 GMT
+      Etag:
+      - W/"42d99e9412c0a650b6892c563dbdc014"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - 7d7ee2d9-e32e-4855-8ee2-9b23270e763b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t"},"properties":{"associations":[]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
+    method: PATCH
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7225,9 +5922,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:26 GMT
       Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7235,9 +5932,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "940"
       X-Request-Id:
-      - 57856cd9-9412-4126-a3e3-b58b08cd3c2c
+      - 0568bf0a-54fe-4174-a123-c8106a78570e
     status: 200 OK
     code: 200
     duration: ""
@@ -7247,10 +5944,1284 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "333"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:31 GMT
+      Etag:
+      - W/"edb3d993766620ac4eb338f869824c82"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "939"
+      X-Request-Id:
+      - 3f2eab81-5271-4b6a-bad2-db34fffcf601
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "333"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:36 GMT
+      Etag:
+      - W/"edb3d993766620ac4eb338f869824c82"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "938"
+      X-Request-Id:
+      - 6e5b7a85-70b2-43b1-bc21-3d1321188e6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "937"
+      X-Request-Id:
+      - 3a2f6b89-1215-4c1a-8150-7c215b40a391
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "936"
+      X-Request-Id:
+      - 8bd0545b-67ca-41df-9ba8-c9e2af8a21eb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "935"
+      X-Request-Id:
+      - 0550b6b2-097d-496b-b109-8f834f41bea2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "934"
+      X-Request-Id:
+      - 82b539d4-773c-432e-95ed-45db8b0c75f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"ee72cbe3c5db00c9370224d5329a3c26"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "933"
+      X-Request-Id:
+      - ecb6f1ab-3885-4967-adee-3013f69aea5e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "932"
+      X-Request-Id:
+      - bde410b4-7e2e-4888-b1fb-17c79d1bb16a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "931"
+      X-Request-Id:
+      - bbbf654e-5216-45e3-9056-da4d5c9da489
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "930"
+      X-Request-Id:
+      - a97e0292-9971-4ee7-bcd8-1487680a33e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "929"
+      X-Request-Id:
+      - 44f7fcfc-d664-435b-be6d-453f9df6bfd7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3PSsUvmKzyrUWwPs","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"2caeb44a45bdd3e1b9ca725597e11d89"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "928"
+      X-Request-Id:
+      - 09f6b82c-e97a-4a65-bc86-9cf2e1b22b26
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "928"
+      X-Request-Id:
+      - 9df8f4de-d4aa-43c5-85fa-ba7e075f0afd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "926"
+      X-Request-Id:
+      - 19135c30-63ce-4d1f-a15b-3b26d74bdeaa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "926"
+      X-Request-Id:
+      - bbae059c-7dcf-4524-bf5a-32de43d3f6e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "924"
+      X-Request-Id:
+      - 5e9af139-4ba3-453c-84de-920dafd42a90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "923"
+      X-Request-Id:
+      - f7ed7af8-5406-4198-85e5-7632a3b0c8cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:46 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "922"
+      X-Request-Id:
+      - cd216b9e-a601-4991-aa15-b75c66def962
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"ee72cbe3c5db00c9370224d5329a3c26"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "920"
+      X-Request-Id:
+      - 26d2e6d2-0b16-473e-b5c4-97c66787a7f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "919"
+      X-Request-Id:
+      - ddb51bdc-7876-4ff6-be55-ed3de1568004
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "921"
+      X-Request-Id:
+      - db4b84f0-507e-4919-862a-aba292da8202
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":["vm_7tOuR5eK7zhFKEO2"],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "342"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"c52b9d5eb12e99e0884ada76eab09157"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "918"
+      X-Request-Id:
+      - ef41d99b-1c0a-4202-bfe8-4477d29fd5c8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "917"
+      X-Request-Id:
+      - 1b85fee1-4853-4a1a-835c-58a54e26eacb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "916"
+      X-Request-Id:
+      - 52b1b16c-5da7-43ab-ac21-b50ff60c8272
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "915"
+      X-Request-Id:
+      - 0f574d63-d3ef-4367-b873-fbe1e784b2fa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3PSsUvmKzyrUWwPs","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"2caeb44a45bdd3e1b9ca725597e11d89"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "914"
+      X-Request-Id:
+      - 2474de93-3078-456f-a9d9-2053fb8d7659
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "913"
+      X-Request-Id:
+      - ae0439a7-965f-4864-86b3-dde7e856339d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "912"
+      X-Request-Id:
+      - 360f3b80-93c8-4fbf-b33c-d595179607f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "910"
+      X-Request-Id:
+      - a5ca0f92-3f9d-49b4-a98b-c71cd85c80ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:47 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "911"
+      X-Request-Id:
+      - 18d21cab-a408-403b-82b7-93391b6f2293
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo"},"properties":{"associations":[]}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
+    method: PATCH
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7265,9 +7236,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:47 GMT
       Etag:
-      - W/"89fdacdee7589a1027bffe10d8f28296"
+      - W/"3f6e2c1242d8c935fd0a9caf26b79f4c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7275,9 +7246,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "909"
       X-Request-Id:
-      - ef315efc-6d68-4f5d-965d-a9e9e09ecf4f
+      - ced9a7b9-7c8e-4535-991a-96ae7941242c
     status: 200 OK
     code: 200
     duration: ""
@@ -7287,10 +7258,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
     method: GET
   response:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0},"annotations":[]}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7305,9 +7276,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:46:52 GMT
       Etag:
-      - W/"7c6dfb421b2a055ffc24529d7eb5e643"
+      - W/"b7f7cde31f777b7b014635e3511fdcda"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7315,9 +7286,373 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "908"
       X-Request-Id:
-      - 64733f79-141a-4337-b0a4-f8d052995cd6
+      - 537133fc-1a89-4d62-a1ae-d9f538d2aabf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"configuring","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:46:57 GMT
+      Etag:
+      - W/"b7f7cde31f777b7b014635e3511fdcda"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "907"
+      X-Request-Id:
+      - 657768ea-0d02-4235-bc0a-787de23f4ba0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"3f6e2c1242d8c935fd0a9caf26b79f4c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 2b2cdb29-1179-4193-8a45-6a29a028557a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"3f6e2c1242d8c935fd0a9caf26b79f4c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 92a9848d-6d56-40bb-b063-70e876d9294b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"3f6e2c1242d8c935fd0a9caf26b79f4c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - ef38eb19-2bef-4491-a036-3747e97f735f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - d2f0aa69-1bac-416f-bd89-bcdfe9762740
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"690c6d4153dd750f9e64f9d16c9c0953"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - b57b022d-f2b7-4175-bd04-f45061d8e435
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "759"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"ee72cbe3c5db00c9370224d5329a3c26"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 4c29d31a-1e7e-4cb2-b537-576f4e6d5480
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"3f6e2c1242d8c935fd0a9caf26b79f4c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 37edadea-5dbd-4847-ac99-f18223052a76
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "995"
+      X-Request-Id:
+      - 8e576580-ca75-45e3-9805-b374e3910bdd
     status: 200 OK
     code: 200
     duration: ""
@@ -7328,19 +7663,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7353,9 +7688,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:47:07 GMT
       Etag:
-      - W/"d9d7205734c183987dbc62b7bbd39664"
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7363,9 +7698,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "991"
       X-Request-Id:
-      - 9cc9b49c-fe7d-48eb-9fe0-f72c93f35ed6
+      - ec28e591-ec8b-4b24-8247-608ea9ca742f
     status: 200 OK
     code: 200
     duration: ""
@@ -7376,19 +7711,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7401,9 +7736,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:47:07 GMT
       Etag:
-      - W/"e38bff09faf7c3ffb693544d9ca511e4"
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7411,9 +7746,177 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "990"
       X-Request-Id:
-      - 93b89dc3-bb3e-4e03-b36c-cd1387ba4226
+      - 57e42cdd-00d1-4448-b216-3121668915d9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xNRPb2tWSjPPLLI8","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"e0bf52c7b206398cb852b208d2a1351f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 052cdb2d-efb5-4824-bc27-c5a91f77e7e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3PSsUvmKzyrUWwPs","name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "391"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"2caeb44a45bdd3e1b9ca725597e11d89"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - f3108935-ce38-414d-914a-6fb730aae975
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - 692af019-1d4d-4a77-8ee3-4332ec496831
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:07 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - bef86d22-5526-417e-842f-df3591b1b811
     status: 200 OK
     code: 200
     duration: ""
@@ -7424,11 +7927,355 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xNRPb2tWSjPPLLI8
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xNRPb2tWSjPPLLI8","virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-web","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:34:81:46:5d:95","state":"attached","ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "532"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"4c06a8a2f2cdd3ce2be7a094a6f4c134"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "985"
+      X-Request-Id:
+      - 7db2df12-e34f-4f9a-8aa6-152e264bc123
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3PSsUvmKzyrUWwPs
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_3PSsUvmKzyrUWwPs","virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db"},"name":"Public
+      Network on tf-acc-test-associations-jnucksep5xjz-db","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:cd:7a:e7:97:d6","state":"attached","ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "531"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"290fb2ef68921dea4cd40e7364cfe32e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 2bf79fbe-71ac-4fb9-b3cc-282a797bfb73
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"3f6e2c1242d8c935fd0a9caf26b79f4c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 8e3a67a4-8071-457a-8a05-920c2e5341c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 9c973cdc-c41d-4a9c-ae63-a7e6d78aae96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "321"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"3f6e2c1242d8c935fd0a9caf26b79f4c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 4a5d1654-2e8c-4b11-bfb6-f8fda955d1f6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "327"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"95dacf6761382c00c2ee90f4f7ba6ada"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - dfe6af12-d3dc-4573-9e8f-72afbad78cb2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"6bdfc9bc4dd527b0bbd3c82c2dd63db8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - 823f886b-4610-4d9c-86c2-e40401100bc3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"cb7be89a52aff748eaa142dafdab6b0b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - d34419ab-b7ad-4973-b27d-d7d11a7c00f0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
     method: POST
   response:
-    body: '{"task":{"id":"task_8AZH8XcgCiff49TK","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_ITaIA5jE2xjlc6f5","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7443,9 +8290,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:47:08 GMT
       Etag:
-      - W/"d5ca689f715d752e48a3c08181b34ae5"
+      - W/"0983e5094dd434d8735e6705e9c2163a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7453,9 +8300,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "949"
+      - "975"
       X-Request-Id:
-      - 2fd7a95b-3ae3-43c4-a7f4-d92cbc0b88e2
+      - 9a37fc3a-0780-4390-83bd-f4c6f3383a73
     status: 200 OK
     code: 200
     duration: ""
@@ -7466,11 +8313,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
     method: POST
   response:
-    body: '{"task":{"id":"task_0jQoPy7DN6nXQ9F0","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_iXMUlAtVIZRI0522","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7485,9 +8332,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:47:08 GMT
       Etag:
-      - W/"6e8b69b01d7e31da4e5c9b1c3e1356c1"
+      - W/"f0d3769996d0d8b72ce7baa1f0fd18df"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7495,14 +8342,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "975"
       X-Request-Id:
-      - 2140aaed-c99a-4831-bae0-9ba40cf9d221
+      - 460011ff-1929-4272-86d7-a535b351237c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0"}}'
+    body: '{"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo"}}'
     form: {}
     headers:
       Content-Type:
@@ -7512,7 +8359,7 @@ interactions:
     url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_EsVIUplvmqlrkbUH","keep_until":1734879516,"object_id":"fsv_JYCjVS82uxYXjvW0","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_JYCjVS82uxYXjvW0","name":"tf-acc-test-associations-vsjxzuoti1wu","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_JYCjVS82uxYXjvW0","size":0}}'
+    body: '{"trash_object":{"id":"trsh_b85RghgcXHezFXSL","keep_until":1739036828,"object_id":"fsv_zkK3RvT5cksonXSo","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_zkK3RvT5cksonXSo","name":"tf-acc-test-associations-jnucksep5xjz","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_zkK3RvT5cksonXSo","size":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7527,9 +8374,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:47:08 GMT
       Etag:
-      - W/"439c6accd9bfdd9de9c683671e88f849"
+      - W/"0374df0bcbb6a85e1fbec5017b0c06c6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7537,14 +8384,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "951"
+      - "977"
       X-Request-Id:
-      - 60e00d65-dd55-4e8d-bc5c-0072da3389ea
+      - b9920e76-c842-49d9-8710-741efb3aa6f3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R"}}'
+    body: '{"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t"}}'
     form: {}
     headers:
       Content-Type:
@@ -7554,7 +8401,7 @@ interactions:
     url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_249Hx0wHjwKaozmU","keep_until":1734879516,"object_id":"fsv_7UabfnD5tpKvom1R","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_7UabfnD5tpKvom1R","name":"tf-acc-test-associations-vsjxzuoti1wu-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_7UabfnD5tpKvom1R","size":0}}'
+    body: '{"trash_object":{"id":"trsh_8TZ83BHEtbHE4MFp","keep_until":1739036828,"object_id":"fsv_Q38cCtYhTiJW4I4t","object_type":"FileStorageVolume"},"file_storage_volume":{"id":"fsv_Q38cCtYhTiJW4I4t","name":"tf-acc-test-associations-jnucksep5xjz-cache","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"associations":[],"state":"ready","nfs_location":"nfs2.nlc.storage.katapult.io:/katapult/fsv_Q38cCtYhTiJW4I4t","size":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -7569,9 +8416,1029 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
+      - Thu, 06 Feb 2025 17:47:08 GMT
       Etag:
-      - W/"df98cfc3f5e1a5ba8d7dd779dfc4cf4a"
+      - W/"5782d6f6f4f576e66e262f3880cc931e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 95557fe9-c429-441f-af6d-c3197a95c43a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"trash_object":{"object_id":"fsv_zkK3RvT5cksonXSo"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_J4agUHXSVzda5yx9","name":"Purge items from trash","status":"pending","created_at":1738864028,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"b9c08d3a87b2fe0c029b539f663e7f18"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - d9ab1838-5f0e-48b2-8cc8-5a58166ba9d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"trash_object":{"object_id":"fsv_Q38cCtYhTiJW4I4t"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_NMyuXw3hUSrByiFb","name":"Purge items from trash","status":"pending","created_at":1738864028,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:08 GMT
+      Etag:
+      - W/"1bf94f34c2a9de1c5628b6ab9cf96dc2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 5364be85-e5c7-4154-9ea7-983fea04e493
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_iXMUlAtVIZRI0522
+    method: GET
+  response:
+    body: '{"task":{"id":"task_iXMUlAtVIZRI0522","name":"Stop virtual machine","status":"running","created_at":1738864028,"started_at":1738864029,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:09 GMT
+      Etag:
+      - W/"2dc81984430416f530f262127a04ee32"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 96c77ae5-5314-4057-9048-09ea2a14c98c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ITaIA5jE2xjlc6f5
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ITaIA5jE2xjlc6f5","name":"Stop virtual machine","status":"running","created_at":1738864028,"started_at":1738864029,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:09 GMT
+      Etag:
+      - W/"3dafce5f10b86c1c09c77e72520da5e5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - 960460ab-f80c-4b71-9232-ae44e08e5e4d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_b85RghgcXHezFXSL","keep_until":1739036828,"object_id":"fsv_zkK3RvT5cksonXSo","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:09 GMT
+      Etag:
+      - W/"c758da3b7fb2c04d24bca85204b5a60f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 19020528-bcb4-4ac2-8347-4a8a2dace61a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_8TZ83BHEtbHE4MFp","keep_until":1739036828,"object_id":"fsv_Q38cCtYhTiJW4I4t","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:09 GMT
+      Etag:
+      - W/"534e64785fa70956229d83030ebb2c48"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - b5fc0daa-80bb-4075-881b-a6c1299bb859
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_iXMUlAtVIZRI0522
+    method: GET
+  response:
+    body: '{"task":{"id":"task_iXMUlAtVIZRI0522","name":"Stop virtual machine","status":"completed","created_at":1738864028,"started_at":1738864029,"finished_at":1738864032,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:14 GMT
+      Etag:
+      - W/"bf701ec6771aedba991896ba5a3bb1ac"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 1e15314f-8ab8-498b-8fc8-5f009517c50d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ITaIA5jE2xjlc6f5
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ITaIA5jE2xjlc6f5","name":"Stop virtual machine","status":"completed","created_at":1738864028,"started_at":1738864029,"finished_at":1738864032,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:14 GMT
+      Etag:
+      - W/"c3a46f1ef62bbead22d565be3047c414"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 2e8cec1d-2e89-415f-b177-0913c6f22d43
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_b85RghgcXHezFXSL","keep_until":1739036828,"object_id":"fsv_zkK3RvT5cksonXSo","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:14 GMT
+      Etag:
+      - W/"c758da3b7fb2c04d24bca85204b5a60f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - d74b6e72-ddaf-405b-a191-7737a83b43e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_8TZ83BHEtbHE4MFp","keep_until":1739036828,"object_id":"fsv_Q38cCtYhTiJW4I4t","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:14 GMT
+      Etag:
+      - W/"534e64785fa70956229d83030ebb2c48"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 49e1d5da-5784-4eca-ab71-df7bd3e95d79
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:15 GMT
+      Etag:
+      - W/"5c7a7dde817588ab989390bf96e09531"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - 34e1afdb-60b7-4d77-b940-15f774a3bb4b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:15 GMT
+      Etag:
+      - W/"e6b5fb6612778a04cc050f6b68dbf0b0"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - 80f2e854-1c54-42b5-99b8-649cb7527add
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_7tOuR5eK7zhFKEO2
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_SE9rwfe5FHEnQuHu","keep_until":1739036835,"object_id":"vm_7tOuR5eK7zhFKEO2","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_7tOuR5eK7zhFKEO2","name":"tf-acc-test-associations-jnucksep5xjz-web","hostname":"tf-acc-test-associations-jnucksep5xjz-web","fqdn":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863814,"initial_root_password":"MnyzUnCRoneaDXM6","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_t1CqlATVR28s9DHn","address":"185.44.252.55","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.55/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_7tOuR5eK7zhFKEO2","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:15 GMT
+      Etag:
+      - W/"d147059e500acd6f4ef4233000097b3f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - 9e8d4caf-d758-43fa-bcca-780d8fc01276
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Cl2BRgFD3HyC4QzB
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_kjVTWm6dWmCnJqOW","keep_until":1739036835,"object_id":"vm_Cl2BRgFD3HyC4QzB","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_Cl2BRgFD3HyC4QzB","name":"tf-acc-test-associations-jnucksep5xjz-db","hostname":"tf-acc-test-associations-jnucksep5xjz-db","fqdn":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863914,"initial_root_password":"U3fTbnVUwZv5WU1M","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_uvIewAo5cCiax5V9","address":"185.44.253.157","reverse_dns":"tf-acc-test-associations-jnucksep5xjz-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.157/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Cl2BRgFD3HyC4QzB","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:15 GMT
+      Etag:
+      - W/"76400fee5c0093bd653b7fbe9ef5b0fd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - fbdc0c24-1acb-475b-a79a-db04e58966ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_t1CqlATVR28s9DHn
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:16 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - beda2831-c6fd-44a5-a7cf-650804338afd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_uvIewAo5cCiax5V9
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:16 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - 7ae1466e-8381-4eaa-a781-81b50cbbe119
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_7tOuR5eK7zhFKEO2
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_ii82GJpU7dp0YG5Q","name":"Purge items from trash","status":"pending","created_at":1738864036,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:16 GMT
+      Etag:
+      - W/"aada6659f88752bb9a4d7862028c1313"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - 8928ef2a-16fd-4608-8980-7176b0f58dea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Cl2BRgFD3HyC4QzB
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_XgKUmxzJZJUjOAQG","name":"Purge items from trash","status":"pending","created_at":1738864036,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:16 GMT
+      Etag:
+      - W/"bc25d1ef60ef83971024d062b7b89f51"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 33b4144a-8258-47e1-85c7-cea9f1febc45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_SE9rwfe5FHEnQuHu","keep_until":1739036835,"object_id":"vm_7tOuR5eK7zhFKEO2","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:17 GMT
+      Etag:
+      - W/"de73779ecb6b757d85eb2a82df35a0ce"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - ca2282a5-1cf9-46ac-a444-baf2cc90cb2c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_kjVTWm6dWmCnJqOW","keep_until":1739036835,"object_id":"vm_Cl2BRgFD3HyC4QzB","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:17 GMT
+      Etag:
+      - W/"4b303a2fdaba62aa1d5b98069e09a7d8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "954"
+      X-Request-Id:
+      - e3fa6f31-f47c-43aa-a74e-de7f503cc618
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_SE9rwfe5FHEnQuHu","keep_until":1739036835,"object_id":"vm_7tOuR5eK7zhFKEO2","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:22 GMT
+      Etag:
+      - W/"de73779ecb6b757d85eb2a82df35a0ce"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "953"
+      X-Request-Id:
+      - cc7bb0ac-4310-449f-bed7-1cd8fefb7507
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_kjVTWm6dWmCnJqOW","keep_until":1739036835,"object_id":"vm_Cl2BRgFD3HyC4QzB","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:22 GMT
+      Etag:
+      - W/"4b303a2fdaba62aa1d5b98069e09a7d8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - 62b0a476-6c00-432c-98f3-3f575a9c3362
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_b85RghgcXHezFXSL","keep_until":1739036828,"object_id":"fsv_zkK3RvT5cksonXSo","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:24 GMT
+      Etag:
+      - W/"c758da3b7fb2c04d24bca85204b5a60f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "951"
+      X-Request-Id:
+      - ce93230b-09b7-4811-9c8a-cbf2a9f1b2c9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_8TZ83BHEtbHE4MFp","keep_until":1739036828,"object_id":"fsv_Q38cCtYhTiJW4I4t","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:24 GMT
+      Etag:
+      - W/"534e64785fa70956229d83030ebb2c48"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -7581,91 +9448,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "950"
       X-Request-Id:
-      - 3414021c-d77d-48a2-9ac1-1e97fa2fcd1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"trash_object":{"object_id":"fsv_7UabfnD5tpKvom1R"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_qtsuSyL4V9vcpWSu","name":"Purge items from trash","status":"pending","created_at":1734706716,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
-      Etag:
-      - W/"ed595e45774919267890b6bd2a4ef3ae"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "946"
-      X-Request-Id:
-      - 0a55163b-84ac-4db7-b41d-ac34de876617
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"trash_object":{"object_id":"fsv_JYCjVS82uxYXjvW0"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_3BjNvXTsIYLNMBY2","name":"Purge items from trash","status":"pending","created_at":1734706716,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:36 GMT
-      Etag:
-      - W/"9ce54acbd688f20c3ab6f6eae25e51e4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "947"
-      X-Request-Id:
-      - 911e71d7-ac1b-433b-a338-3d8c54dfb2df
+      - 7a615840-aa11-465b-af13-01ff153c4cca
     status: 200 OK
     code: 200
     duration: ""
@@ -7676,699 +9459,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_0jQoPy7DN6nXQ9F0
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_7tOuR5eK7zhFKEO2
     method: GET
   response:
-    body: '{"task":{"id":"task_0jQoPy7DN6nXQ9F0","name":"Stop virtual machine","status":"running","created_at":1734706716,"started_at":1734706717,"finished_at":null,"progress":5}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "168"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:37 GMT
-      Etag:
-      - W/"e7b74fef00de06ad269cf67ed0a6e3db"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "945"
-      X-Request-Id:
-      - d4fc85f1-955d-49cf-96c9-4975bcd6260b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_8AZH8XcgCiff49TK
-    method: GET
-  response:
-    body: '{"task":{"id":"task_8AZH8XcgCiff49TK","name":"Stop virtual machine","status":"running","created_at":1734706716,"started_at":1734706717,"finished_at":null,"progress":5}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "168"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:37 GMT
-      Etag:
-      - W/"468c7059dc25152fee20bbb4a503e75c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "945"
-      X-Request-Id:
-      - 905f7708-131b-455d-9747-68b56667ca17
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_EsVIUplvmqlrkbUH","keep_until":1734879516,"object_id":"fsv_JYCjVS82uxYXjvW0","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:37 GMT
-      Etag:
-      - W/"a9d90d0c7defc91672d919dd45ee17c1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "943"
-      X-Request-Id:
-      - 606e35dd-57d5-4996-82dd-bb1d3ecb054f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_249Hx0wHjwKaozmU","keep_until":1734879516,"object_id":"fsv_7UabfnD5tpKvom1R","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:37 GMT
-      Etag:
-      - W/"ed824e9a22881a677042f834dba42a53"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "943"
-      X-Request-Id:
-      - e46d52a2-7275-4ec0-9aea-3212a113ec50
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_8AZH8XcgCiff49TK
-    method: GET
-  response:
-    body: '{"task":{"id":"task_8AZH8XcgCiff49TK","name":"Stop virtual machine","status":"completed","created_at":1734706716,"started_at":1734706717,"finished_at":1734706718,"progress":100}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "178"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:42 GMT
-      Etag:
-      - W/"20a482e180636458e9e45a81388e4c86"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "941"
-      X-Request-Id:
-      - 9322863d-fa77-4020-ac32-e45f6b96525a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_0jQoPy7DN6nXQ9F0
-    method: GET
-  response:
-    body: '{"task":{"id":"task_0jQoPy7DN6nXQ9F0","name":"Stop virtual machine","status":"completed","created_at":1734706716,"started_at":1734706717,"finished_at":1734706719,"progress":100}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "178"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:42 GMT
-      Etag:
-      - W/"9b292826e94b1a88fcd987f04eb5b8ba"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "941"
-      X-Request-Id:
-      - 6c77b4bb-7fa3-4944-ba5b-6e9c1a7cc9fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_EsVIUplvmqlrkbUH","keep_until":1734879516,"object_id":"fsv_JYCjVS82uxYXjvW0","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:42 GMT
-      Etag:
-      - W/"a9d90d0c7defc91672d919dd45ee17c1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "939"
-      X-Request-Id:
-      - 5a69c153-abb2-4d79-919f-350e59d0115d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_249Hx0wHjwKaozmU","keep_until":1734879516,"object_id":"fsv_7UabfnD5tpKvom1R","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:42 GMT
-      Etag:
-      - W/"ed824e9a22881a677042f834dba42a53"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "938"
-      X-Request-Id:
-      - f3776487-aeac-4472-86fb-0ff931fff347
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:43 GMT
-      Etag:
-      - W/"b1c525e1332272b08a072c37ac2cb213"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "937"
-      X-Request-Id:
-      - 4c87ce98-5448-4041-a8a1-78e09103b6cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:43 GMT
-      Etag:
-      - W/"d397172d906af19ec221538e2001035e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "937"
-      X-Request-Id:
-      - 5f1511f0-a771-4877-8b5a-b596e3a2b8b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_heORtn6n0n7gtd6u
-    method: DELETE
-  response:
-    body: '{"trash_object":{"id":"trsh_VgZQMXCcBZTjaTRK","keep_until":1734879523,"object_id":"vm_heORtn6n0n7gtd6u","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_heORtn6n0n7gtd6u","name":"tf-acc-test-associations-vsjxzuoti1wu-web","hostname":"tf-acc-test-associations-vsjxzuoti1wu-web","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706516,"initial_root_password":"2BDZaLW9OnLm395Z","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_TYUsRxZHSTCBKzbA","address":"185.199.221.172","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-web.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.199.221.172/24","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_heORtn6n0n7gtd6u","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:43 GMT
-      Etag:
-      - W/"3bb11974a30f8dffa09321ea49d7a22a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "934"
-      X-Request-Id:
-      - d5f0db15-d329-4b42-820a-04af6e5b8be9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_CVYIEGWjGgTxO0oo
-    method: DELETE
-  response:
-    body: '{"trash_object":{"id":"trsh_8YxR58ifot2dNSR1","keep_until":1734879523,"object_id":"vm_CVYIEGWjGgTxO0oo","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_CVYIEGWjGgTxO0oo","name":"tf-acc-test-associations-vsjxzuoti1wu-db","hostname":"tf-acc-test-associations-vsjxzuoti1wu-db","fqdn":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","description":null,"created_at":1734706605,"initial_root_password":"PbwizmkBoxdEQIcj","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_kT0YlUGdJt20NROI","address":"185.44.253.66","reverse_dns":"tf-acc-test-associations-vsjxzuoti1wu-db.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.66/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_CVYIEGWjGgTxO0oo","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:44 GMT
-      Etag:
-      - W/"9e5c8bda21c3201f314791e76e4dba7a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "935"
-      X-Request-Id:
-      - bf12e6a6-cc00-4a3b-a440-d0addc7a0df7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_TYUsRxZHSTCBKzbA
-    method: POST
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:44 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "933"
-      X-Request-Id:
-      - a5d10870-ad67-47ef-9d27-20ddea28527b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_heORtn6n0n7gtd6u
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_gjrhPvg0u5Hz1iHN","name":"Purge items from trash","status":"pending","created_at":1734706724,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:44 GMT
-      Etag:
-      - W/"076296b4fccebfce46531a4923c7b4ea"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "931"
-      X-Request-Id:
-      - c36147b7-79f9-412d-9395-2bbb2807e0cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_kT0YlUGdJt20NROI
-    method: POST
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:44 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "932"
-      X-Request-Id:
-      - f2200185-c46d-4ba9-9020-b6f8f9df5604
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CVYIEGWjGgTxO0oo
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_mhMVSjLOYrIJtLoW","name":"Purge items from trash","status":"pending","created_at":1734706724,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:44 GMT
-      Etag:
-      - W/"521d21fab5aec3070e4dd0e37c69ad9a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "930"
-      X-Request-Id:
-      - e859a1b1-8f9e-4d70-9285-400c87cdc9d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_VgZQMXCcBZTjaTRK","keep_until":1734879523,"object_id":"vm_heORtn6n0n7gtd6u","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_SE9rwfe5FHEnQuHu","keep_until":1739036835,"object_id":"vm_7tOuR5eK7zhFKEO2","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -8383,9 +9478,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:45 GMT
+      - Thu, 06 Feb 2025 17:47:32 GMT
       Etag:
-      - W/"8b48dd384f450e758199971c002ba210"
+      - W/"de73779ecb6b757d85eb2a82df35a0ce"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -8393,9 +9488,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "929"
+      - "949"
       X-Request-Id:
-      - 3e5ca436-bf39-4d96-a4af-49381e5ec27a
+      - 268d39f7-2b16-4ab7-8732-bae4ca7e2412
     status: 200 OK
     code: 200
     duration: ""
@@ -8406,11 +9501,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CVYIEGWjGgTxO0oo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Cl2BRgFD3HyC4QzB
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_8YxR58ifot2dNSR1","keep_until":1734879523,"object_id":"vm_CVYIEGWjGgTxO0oo","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_kjVTWm6dWmCnJqOW","keep_until":1739036835,"object_id":"vm_Cl2BRgFD3HyC4QzB","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -8425,9 +9520,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:58:45 GMT
+      - Thu, 06 Feb 2025 17:47:32 GMT
       Etag:
-      - W/"2d41ea6d664ce7a583e37bf906576cf2"
+      - W/"4b303a2fdaba62aa1d5b98069e09a7d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -8435,93 +9530,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "928"
+      - "948"
       X-Request-Id:
-      - bb0661f9-f334-492e-b827-2dbf11cdd13d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_VgZQMXCcBZTjaTRK","keep_until":1734879523,"object_id":"vm_heORtn6n0n7gtd6u","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:50 GMT
-      Etag:
-      - W/"8b48dd384f450e758199971c002ba210"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "927"
-      X-Request-Id:
-      - d4554a97-226e-4650-8dd3-590f5dad56b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_8YxR58ifot2dNSR1","keep_until":1734879523,"object_id":"vm_CVYIEGWjGgTxO0oo","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:50 GMT
-      Etag:
-      - W/"2d41ea6d664ce7a583e37bf906576cf2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "926"
-      X-Request-Id:
-      - 695e8751-c55f-41c6-a819-b85d6a4e66a4
+      - 8544bfa7-783b-4134-ba8a-d4e366f5181f
     status: 200 OK
     code: 200
     duration: ""
@@ -8531,253 +9542,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_EsVIUplvmqlrkbUH","keep_until":1734879516,"object_id":"fsv_JYCjVS82uxYXjvW0","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:52 GMT
-      Etag:
-      - W/"a9d90d0c7defc91672d919dd45ee17c1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "925"
-      X-Request-Id:
-      - eae2e2e0-c92d-4df5-b62b-3dc90bf04578
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_249Hx0wHjwKaozmU","keep_until":1734879516,"object_id":"fsv_7UabfnD5tpKvom1R","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:58:52 GMT
-      Etag:
-      - W/"ed824e9a22881a677042f834dba42a53"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "924"
-      X-Request-Id:
-      - 19d153ed-ad44-4384-91f6-08d7d680579d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_heORtn6n0n7gtd6u
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_VgZQMXCcBZTjaTRK","keep_until":1734879523,"object_id":"vm_heORtn6n0n7gtd6u","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:00 GMT
-      Etag:
-      - W/"8b48dd384f450e758199971c002ba210"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - 3712a182-1413-4565-96fb-2ce153a83211
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_8YxR58ifot2dNSR1","keep_until":1734879523,"object_id":"vm_CVYIEGWjGgTxO0oo","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:00 GMT
-      Etag:
-      - W/"2d41ea6d664ce7a583e37bf906576cf2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - 9e96367e-71a8-47fc-9d83-ce7a7f755f90
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_EsVIUplvmqlrkbUH","keep_until":1734879516,"object_id":"fsv_JYCjVS82uxYXjvW0","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:02 GMT
-      Etag:
-      - W/"a9d90d0c7defc91672d919dd45ee17c1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "997"
-      X-Request-Id:
-      - 86569a3d-8b62-4a21-b0ce-7889e8544c7b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_249Hx0wHjwKaozmU","keep_until":1734879516,"object_id":"fsv_7UabfnD5tpKvom1R","object_type":"FileStorageVolume"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "140"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:02 GMT
-      Etag:
-      - W/"ed824e9a22881a677042f834dba42a53"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "996"
-      X-Request-Id:
-      - 7873ff15-8546-46cb-9518-4d5bfe40623e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_heORtn6n0n7gtd6u
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Q38cCtYhTiJW4I4t
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -8796,7 +9561,465 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:59:10 GMT
+      - Thu, 06 Feb 2025 17:47:34 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 43f6b756-c742-4ccc-95d7-0e4cf9024ab4
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_b85RghgcXHezFXSL","keep_until":1739036828,"object_id":"fsv_zkK3RvT5cksonXSo","object_type":"FileStorageVolume"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "140"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:34 GMT
+      Etag:
+      - W/"c758da3b7fb2c04d24bca85204b5a60f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - e5fee5a1-574d-4ab6-8c14-1a69d0a75f0b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_7tOuR5eK7zhFKEO2
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - bdcd8059-d610-4ffd-8b7c-f0d74b1cdf92
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_kjVTWm6dWmCnJqOW","keep_until":1739036835,"object_id":"vm_Cl2BRgFD3HyC4QzB","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:42 GMT
+      Etag:
+      - W/"4b303a2fdaba62aa1d5b98069e09a7d8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - 83360043-1eda-44f8-922a-cc388f3a15b2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_t1CqlATVR28s9DHn"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:42 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - 0034ad10-3956-43d1-85e5-e8f885c28b58
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - 63a9fec3-cb7e-422b-b7e5-05389d9d4979
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_kjVTWm6dWmCnJqOW","keep_until":1739036835,"object_id":"vm_Cl2BRgFD3HyC4QzB","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:47:52 GMT
+      Etag:
+      - W/"4b303a2fdaba62aa1d5b98069e09a7d8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "941"
+      X-Request-Id:
+      - 1ee64a2c-3b31-477f-baca-07dc2314e1cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Cl2BRgFD3HyC4QzB
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:48:02 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 55b0cec6-bbc7-4dd3-a1df-b1cef331290a
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_uvIewAo5cCiax5V9"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:48:02 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 09201562-cfda-42a8-92d4-8c9ec230c28e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
+      storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "167"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:48:02 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 6fee3371-97ec-4466-a9c6-1f21d76e7949
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_Q38cCtYhTiJW4I4t
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:48:02 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - 1d5e5a0a-2682-4e76-9731-9feddc9013d7
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
+  response:
+    body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
+      storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "167"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:48:03 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -8808,7 +10031,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "995"
       X-Request-Id:
-      - 0e767b3a-514f-4c54-9663-4f5757a61405
+      - 7c0cd69e-faf2-4439-b1ed-2dc2017b3be5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -8816,56 +10039,13 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_8YxR58ifot2dNSR1","keep_until":1734879523,"object_id":"vm_CVYIEGWjGgTxO0oo","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:10 GMT
-      Etag:
-      - W/"2d41ea6d664ce7a583e37bf906576cf2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "993"
-      X-Request-Id:
-      - 0ee2f751-15ce-48f4-9057-2898fa9ad601
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"ip_address":{"id":"ip_TYUsRxZHSTCBKzbA"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
-    method: DELETE
+    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_zkK3RvT5cksonXSo
+    method: GET
   response:
-    body: '{}'
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -8874,398 +10054,25 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Cache-Control:
-      - max-age=0, private, must-revalidate
+      - no-cache
       Content-Length:
-      - "2"
+      - "152"
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Dec 2024 14:59:10 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
+      - Thu, 06 Feb 2025 17:48:03 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
       - Accept-Encoding
+      X-Api-Schema:
+      - json-error
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
       - "994"
       X-Request-Id:
-      - 349c7021-5708-4544-ab28-309dbde3c147
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:12 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - c631a425-5667-4cbc-8d1d-51912a697e8a
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:12 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "992"
-      X-Request-Id:
-      - af48c806-5240-4243-92d4-a35f7e825ee8
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_8YxR58ifot2dNSR1","keep_until":1734879523,"object_id":"vm_CVYIEGWjGgTxO0oo","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:20 GMT
-      Etag:
-      - W/"2d41ea6d664ce7a583e37bf906576cf2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "990"
-      X-Request-Id:
-      - 6b4c1b42-02c3-464d-a0cd-d3e2b7698663
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_CVYIEGWjGgTxO0oo
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:30 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - 223b984d-4e42-4aaa-8d8e-0278ea364ec6
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: '{"ip_address":{"id":"ip_kT0YlUGdJt20NROI"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:31 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "988"
-      X-Request-Id:
-      - dcce662a-3f04-4499-883b-a56b967753ff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
-      storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "167"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:31 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "987"
-      X-Request-Id:
-      - 45b26a9d-f213-4432-9d25-f0a64b3b5be0
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_7UabfnD5tpKvom1R
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:31 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "986"
-      X-Request-Id:
-      - c287660f-49a4-4547-971d-d1c02200c7bc
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/file_storage_volumes/file_storage_volume?file_storage_volume%5Bid%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"error":{"code":"file_storage_volume_not_found","description":"No file
-      storage volume was found matching any of the criteria provided in the arguments.","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "167"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:31 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "985"
-      X-Request-Id:
-      - 47365365-5013-4950-b5fc-7f4f9ad007ae
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/trash_objects/trash_object?trash_object%5Bobject_id%5D=fsv_JYCjVS82uxYXjvW0
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Dec 2024 14:59:31 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 4c45f30b-7071-4ce6-b57c-b84703f1d1b9
+      - f3b8e9f8-1725-4791-a9ae-618dbb90838c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/v6provider/testdata/LoadBalancer_resource_type_change.cassette.rand_id
+++ b/internal/v6provider/testdata/LoadBalancer_resource_type_change.cassette.rand_id
@@ -1,1 +1,1 @@
-OYC6mUzBtm1V
+SW8ogezHazO5

--- a/internal/v6provider/testdata/LoadBalancer_resource_type_change.cassette.yaml
+++ b/internal/v6provider/testdata/LoadBalancer_resource_type_change.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:36:34 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "831"
+      - "999"
       X-Request-Id:
-      - 719ad800-480b-4d07-a4ea-f78cfa671037
+      - 9dd23f9f-4890-4075-94f5-67b95520f88c
     status: 200 OK
     code: 200
     duration: ""
@@ -51,11 +51,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -70,9 +70,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:36:34 GMT
       Etag:
-      - W/"284f789e4a5a63b6991dce0700a9f2c4"
+      - W/"157be7c3d010e2b60dc648804bf2692e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "830"
+      - "999"
       X-Request-Id:
-      - a704c8e0-319a-416b-a5da-779e47fe887a
+      - 4dace915-f1a8-4526-8276-3a997dc1794f
     status: 200 OK
     code: 200
     duration: ""
@@ -93,11 +93,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_D3LXSzEp2R1V4jM3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_htCBe3ylPFueU2J2
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -112,9 +112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:36:35 GMT
       Etag:
-      - W/"284f789e4a5a63b6991dce0700a9f2c4"
+      - W/"157be7c3d010e2b60dc648804bf2692e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -122,9 +122,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "813"
+      - "997"
       X-Request-Id:
-      - 5be8449c-85ff-4c2c-812b-7b46697ca461
+      - b4f6ba6d-2479-4f7d-9ca6-a787bc7514df
     status: 200 OK
     code: 200
     duration: ""
@@ -139,7 +139,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"185-44-253-75.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"185-44-253-173.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -152,13 +152,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "558"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:36:35 GMT
       Etag:
-      - W/"8216ab6c9850b6ba206281f2a3793771"
+      - W/"3acf812a1aba594996f5f4514a76436a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -166,9 +166,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "818"
+      - "996"
       X-Request-Id:
-      - 7926d069-7b35-466b-bb26-1920db451685
+      - 3c730f22-e032-4b1d-bdcb-ee59398ed80b
     status: 200 OK
     code: 200
     duration: ""
@@ -178,10 +178,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_BqJchqR47wHzFhNA
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_8IpRh1QxcJjjxFW3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"185-44-253-75.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"185-44-253-173.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -194,13 +194,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "576"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:36:35 GMT
       Etag:
-      - W/"a7141a7f657c5d0543d144c71d7d41ee"
+      - W/"3c6b6cf0344d2f8c65d3d301d4e4ab52"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -208,9 +208,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "808"
+      - "995"
       X-Request-Id:
-      - 2f0cdaec-b776-410f-a5dc-5b1b0708b5f3
+      - 5d74a6a9-8976-4868-b835-7cf61632ff5e
     status: 200 OK
     code: 200
     duration: ""
@@ -221,11 +221,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_BqJchqR47wHzFhNA
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_8IpRh1QxcJjjxFW3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"185-44-253-75.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"185-44-253-173.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -238,13 +238,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "576"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:36:35 GMT
       Etag:
-      - W/"a7141a7f657c5d0543d144c71d7d41ee"
+      - W/"3c6b6cf0344d2f8c65d3d301d4e4ab52"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -252,15 +252,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "805"
+      - "994"
       X-Request-Id:
-      - 74a8bcc1-d67a-4bf5-a85a-95680bcbc223
+      - 3785f518-5fe8-42d8-8a61-b1cdc8f9a39e
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_BqJchqR47wHzFhNA</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-famous-faint-magnesium</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_8IpRh1QxcJjjxFW3</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-tasty-yellow-watermelon</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -268,11 +268,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_Mu5jCsyX62Pv5KwF","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_aXhJoJWG0qGNDiTg","state":"pending"},"virtual_machine_build":{"id":"vmbuild_aXhJoJWG0qGNDiTg","state":"pending"},"hostname":"tf-famous-faint-magnesium","annotations":[]}'
+    body: '{"task":{"id":"task_oQZyYtSQdcpOgmfK","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_0FRgM6F8v6AbTvnq","state":"pending"},"virtual_machine_build":{"id":"vmbuild_0FRgM6F8v6AbTvnq","state":"pending"},"hostname":"tf-tasty-yellow-watermelon","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -283,201 +283,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "281"
+      - "282"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:36:35 GMT
       Etag:
-      - W/"9feebe68b6f421eca9090773f69e5479"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "804"
-      X-Request-Id:
-      - f3554cc7-ab5c-4e41-badd-ce36462704c2
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_aXhJoJWG0qGNDiTg
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_aXhJoJWG0qGNDiTg","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.75\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-famous-faint-magnesium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:50 GMT
-      Etag:
-      - W/"9edbb712c5e36d61981cd074bb1b9916"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "769"
-      X-Request-Id:
-      - 99b01680-dca1-4437-8c71-40fc4e2f1836
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_aXhJoJWG0qGNDiTg
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_aXhJoJWG0qGNDiTg","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.75\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-famous-faint-magnesium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:55 GMT
-      Etag:
-      - W/"c86913d2e19b4bed1be7284a135b67a8"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "690"
-      X-Request-Id:
-      - 0a184e1e-d58b-4350-be42-40a223f386e1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_aXhJoJWG0qGNDiTg
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_aXhJoJWG0qGNDiTg","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.75\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-famous-faint-magnesium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:05 GMT
-      Etag:
-      - W/"c86913d2e19b4bed1be7284a135b67a8"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - 00964e62-66ad-46df-84f4-dd6364955b8c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_aXhJoJWG0qGNDiTg
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_aXhJoJWG0qGNDiTg","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.75\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-famous-faint-magnesium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:15 GMT
-      Etag:
-      - W/"c86913d2e19b4bed1be7284a135b67a8"
+      - W/"de740fb1d33362f154b8ce8c917f9f95"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -487,9 +299,9 @@ interactions:
       X-Ratelimit-Remaining:
       - "993"
       X-Request-Id:
-      - 10176831-14b9-4b78-bc02-8341f331afcc
-    status: 200 OK
-    code: 200
+      - 1dceeab9-5ff4-419a-8a94-864ff5e63990
+    status: 201 Created
+    code: 201
     duration: ""
 - request:
     body: ""
@@ -498,18 +310,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_aXhJoJWG0qGNDiTg
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_0FRgM6F8v6AbTvnq
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_aXhJoJWG0qGNDiTg","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_0FRgM6F8v6AbTvnq","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.75\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-famous-faint-magnesium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.173\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-tasty-yellow-watermelon\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863395},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -522,9 +334,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:25 GMT
+      - Thu, 06 Feb 2025 17:36:37 GMT
       Etag:
-      - W/"d88a316191eedbe0ef97c4ef2c72b8d5"
+      - W/"b50025279e7ec1558fcf027aaee6a300"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -532,15 +344,156 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "988"
+      - "992"
       X-Request-Id:
-      - bc82b5a5-1ebf-49c2-a6d1-e284a2c3b478
+      - c889be99-16e5-4e4e-a23a-04cd57647cae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_0FRgM6F8v6AbTvnq
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_0FRgM6F8v6AbTvnq","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.173\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-tasty-yellow-watermelon\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863395},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:36:42 GMT
+      Etag:
+      - W/"8f732e6145a25ad8817afb4c7c76545a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - de10e88f-19f7-4277-b258-7fd694638d9b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_0FRgM6F8v6AbTvnq
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_0FRgM6F8v6AbTvnq","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.173\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-tasty-yellow-watermelon\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863395},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:36:52 GMT
+      Etag:
+      - W/"8f732e6145a25ad8817afb4c7c76545a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 8a5bf0f1-ceaa-4386-9e7c-a57ba1a0e1c8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_0FRgM6F8v6AbTvnq
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_0FRgM6F8v6AbTvnq","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.173\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-tasty-yellow-watermelon\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1738863395},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:02 GMT
+      Etag:
+      - W/"28331d7f6b2144e15a21ee7cb71d475a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 5eec6ccf-0c7f-4a15-ab34-70b8e75a5231
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t"},"properties":{"tag_names":["web"]}}
+      {"virtual_machine":{"id":"vm_168HSPmDtWynYdad"},"properties":{"tag_names":["web"]}}
     form: {}
     headers:
       Accept:
@@ -548,19 +501,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -573,9 +526,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:25 GMT
+      - Thu, 06 Feb 2025 17:37:02 GMT
       Etag:
-      - W/"9d1e9631b9051f34fd8be9c41f4fd049"
+      - W/"741269186591c5b2c2748ed917f1a1d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -583,9 +536,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "986"
+      - "998"
       X-Request-Id:
-      - 257c3523-ea0d-469c-ba41-6b5a5e0023d5
+      - 89fa55aa-6040-41ee-b171-d49ef1724be4
     status: 200 OK
     code: 200
     duration: ""
@@ -596,19 +549,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -621,9 +574,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
+      - Thu, 06 Feb 2025 17:37:04 GMT
       Etag:
-      - W/"9d1e9631b9051f34fd8be9c41f4fd049"
+      - W/"741269186591c5b2c2748ed917f1a1d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -631,9 +584,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "975"
+      - "997"
       X-Request-Id:
-      - 3a5a2bfb-cb9b-4bdd-95ab-b08fabb65b2d
+      - b138e8dd-29bd-4f86-aea0-8da54b0fef7b
     status: 200 OK
     code: 200
     duration: ""
@@ -644,19 +597,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -669,9 +622,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:32 GMT
+      - Thu, 06 Feb 2025 17:37:04 GMT
       Etag:
-      - W/"4bd2da0096a557676ee2e844015d01b8"
+      - W/"741269186591c5b2c2748ed917f1a1d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -679,9 +632,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "884"
+      - "996"
       X-Request-Id:
-      - 33d393d6-8f84-41df-a593-cdcb8ad4eb2c
+      - e9b6d46f-8ce5-4d67-83f5-7dc4b5883cb0
     status: 200 OK
     code: 200
     duration: ""
@@ -689,64 +642,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:33 GMT
-      Etag:
-      - W/"4bd2da0096a557676ee2e844015d01b8"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "882"
-      X-Request-Id:
-      - 2f97544a-4934-4641-940c-6ebb64825f82
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_XjFK7exQxUz2z20y","name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rWoDY6PNWPdldFOu","name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -757,13 +660,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "374"
+      - "377"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:33 GMT
+      - Thu, 06 Feb 2025 17:37:04 GMT
       Etag:
-      - W/"bf4b7d45601d7505fc12c70f660f0d0b"
+      - W/"afa75f849208e71d2d8da50547f02b64"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -771,9 +674,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "880"
+      - "995"
       X-Request-Id:
-      - f1d19ec6-e904-4910-9fad-450ce1a8bcce
+      - a40271d2-1b8a-4ee7-aad6-6a9487644c0e
     status: 200 OK
     code: 200
     duration: ""
@@ -781,16 +684,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_XjFK7exQxUz2z20y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_XjFK7exQxUz2z20y","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"},"name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:86:ee:ca:1e:6c","state":"attached","ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -801,13 +702,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "500"
+      - "503"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:33 GMT
+      - Thu, 06 Feb 2025 17:37:04 GMT
       Etag:
-      - W/"1a632093adda4d3199d1803244f423cf"
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -815,14 +716,58 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "879"
+      - "994"
       X-Request-Id:
-      - 1675d0a2-fab0-4826-baf6-3194ac9697e4
+      - d88cd42f-ad30-422b-8e10-1eb5a78a6436
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","resource_ids":["vm_TyVIL6hMyuhHAu3t"],"resource_type":"virtual_machines"}}'
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:04 GMT
+      Etag:
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 451adb4a-2b88-49ec-bd5a-7ccebe97023b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-resource-type-change-SW8ogezHazO5","resource_ids":["vm_168HSPmDtWynYdad"],"resource_type":"virtual_machines"}}'
     form: {}
     headers:
       Content-Type:
@@ -832,18 +777,18 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
     method: POST
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_TyVIL6hMyuhHAu3t"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_168HSPmDtWynYdad"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -856,9 +801,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:34 GMT
+      - Thu, 06 Feb 2025 17:37:06 GMT
       Etag:
-      - W/"b29b6a44acef9e4b1d9404f5735ffa07"
+      - W/"973e43083d81569a73a6da8f3b353512"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -866,9 +811,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "876"
+      - "992"
       X-Request-Id:
-      - dda946d4-eafa-4242-8c90-c42e8942fbf3
+      - e4c5871e-e3b2-4dff-94b6-7eb501258d6e
     status: 201 Created
     code: 201
     duration: ""
@@ -878,21 +823,21 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_TyVIL6hMyuhHAu3t"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_168HSPmDtWynYdad"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -905,9 +850,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:07 GMT
       Etag:
-      - W/"b29b6a44acef9e4b1d9404f5735ffa07"
+      - W/"973e43083d81569a73a6da8f3b353512"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -915,9 +860,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "874"
+      - "991"
       X-Request-Id:
-      - f14a0cfc-16fd-4dd9-bfee-c8dd4f4927b8
+      - 74f0ae29-bb26-4ce1-a4df-0766985af1e6
     status: 200 OK
     code: 200
     duration: ""
@@ -927,21 +872,21 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_TyVIL6hMyuhHAu3t"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_168HSPmDtWynYdad"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -954,9 +899,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:07 GMT
       Etag:
-      - W/"b29b6a44acef9e4b1d9404f5735ffa07"
+      - W/"973e43083d81569a73a6da8f3b353512"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -964,9 +909,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "873"
+      - "990"
       X-Request-Id:
-      - 1c41e508-0aae-418a-b685-f49bbad7836a
+      - 08b17366-8695-4c4a-bdc2-9cd4c1dd2b11
     status: 200 OK
     code: 200
     duration: ""
@@ -977,11 +922,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_D3LXSzEp2R1V4jM3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_htCBe3ylPFueU2J2
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -996,9 +941,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"284f789e4a5a63b6991dce0700a9f2c4"
+      - W/"157be7c3d010e2b60dc648804bf2692e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1006,9 +951,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "872"
+      - "989"
       X-Request-Id:
-      - 6f70477f-1e03-4068-a710-5a82ec85a500
+      - 1ed6a2e6-0764-44f0-920a-0c40dbb923e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1018,12 +963,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_BqJchqR47wHzFhNA
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_8IpRh1QxcJjjxFW3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1034,13 +979,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "727"
+      - "731"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"b16c168c8ee904734118a89825945815"
+      - W/"b3c314fe0049cae4b65eff3c99b0e86c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1048,9 +993,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "871"
+      - "989"
       X-Request-Id:
-      - ce330921-f89f-459b-a0eb-d7b532a03e33
+      - a572b39d-3d02-447a-a836-13073ebf3438
     status: 200 OK
     code: 200
     duration: ""
@@ -1061,19 +1006,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1086,9 +1031,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"4bd2da0096a557676ee2e844015d01b8"
+      - W/"741269186591c5b2c2748ed917f1a1d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1096,9 +1041,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "870"
+      - "987"
       X-Request-Id:
-      - e444fb6f-0fa0-4a8f-8f5a-e30c7a4e1a95
+      - 762fef2c-5d4f-4573-bceb-ce4e4253516c
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,16 +1051,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_XjFK7exQxUz2z20y","name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rWoDY6PNWPdldFOu","name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1126,13 +1069,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "374"
+      - "377"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"bf4b7d45601d7505fc12c70f660f0d0b"
+      - W/"afa75f849208e71d2d8da50547f02b64"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1140,9 +1083,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "869"
+      - "986"
       X-Request-Id:
-      - 052ff8c6-5bdf-4f4d-aa27-e66513285097
+      - 9083a5c0-4299-4a86-a114-eec7d3ab3c11
     status: 200 OK
     code: 200
     duration: ""
@@ -1150,16 +1093,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_XjFK7exQxUz2z20y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_XjFK7exQxUz2z20y","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"},"name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:86:ee:ca:1e:6c","state":"attached","ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1170,13 +1111,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "500"
+      - "503"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"1a632093adda4d3199d1803244f423cf"
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1184,9 +1125,53 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "866"
+      - "985"
       X-Request-Id:
-      - 7fd4a923-2dad-47d9-a580-87ca443fb4b3
+      - b4b3fa88-9fe2-4d9e-a989-a2a1ba31785c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:08 GMT
+      Etag:
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 4d3ab396-9ebd-494a-9d6c-592d27f29509
     status: 200 OK
     code: 200
     duration: ""
@@ -1196,21 +1181,21 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_TyVIL6hMyuhHAu3t"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_168HSPmDtWynYdad"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1223,9 +1208,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"b29b6a44acef9e4b1d9404f5735ffa07"
+      - W/"973e43083d81569a73a6da8f3b353512"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1233,9 +1218,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "865"
+      - "983"
       X-Request-Id:
-      - 3427229d-0e38-4987-94ae-3de7b074d20d
+      - 062a441a-65a9-43b0-9d82-4a0138ea65de
     status: 200 OK
     code: 200
     duration: ""
@@ -1246,11 +1231,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_D3LXSzEp2R1V4jM3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_htCBe3ylPFueU2J2
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1265,9 +1250,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"284f789e4a5a63b6991dce0700a9f2c4"
+      - W/"157be7c3d010e2b60dc648804bf2692e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1275,9 +1260,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "863"
+      - "982"
       X-Request-Id:
-      - cf22c78f-82ef-4f08-92c3-b0c1706fdc76
+      - 233c6ac0-d3b5-4480-9e75-728d2a8d5e6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1287,12 +1272,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_BqJchqR47wHzFhNA
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_8IpRh1QxcJjjxFW3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1303,13 +1288,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "727"
+      - "731"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"b16c168c8ee904734118a89825945815"
+      - W/"b3c314fe0049cae4b65eff3c99b0e86c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1317,9 +1302,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "863"
+      - "981"
       X-Request-Id:
-      - 14560440-2144-4be6-bccb-dc039e6d8e3c
+      - 0f205f61-beb0-4a71-af37-133d02b02da1
     status: 200 OK
     code: 200
     duration: ""
@@ -1330,19 +1315,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1355,9 +1340,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"4bd2da0096a557676ee2e844015d01b8"
+      - W/"741269186591c5b2c2748ed917f1a1d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1365,9 +1350,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "860"
+      - "979"
       X-Request-Id:
-      - 97f87637-c605-436f-b674-a7344b43a47d
+      - cf47e41c-413d-4d67-8398-823082d6b9d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1377,21 +1362,21 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_TyVIL6hMyuhHAu3t"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_168HSPmDtWynYdad"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1404,9 +1389,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"b29b6a44acef9e4b1d9404f5735ffa07"
+      - W/"973e43083d81569a73a6da8f3b353512"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1414,9 +1399,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "861"
+      - "980"
       X-Request-Id:
-      - cbd7fb36-a129-40d2-b934-4703bc2da356
+      - 1d8a4d8e-eae9-4c18-abe8-d25769827242
     status: 200 OK
     code: 200
     duration: ""
@@ -1424,16 +1409,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_XjFK7exQxUz2z20y","name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rWoDY6PNWPdldFOu","name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1444,13 +1427,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "374"
+      - "377"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"bf4b7d45601d7505fc12c70f660f0d0b"
+      - W/"afa75f849208e71d2d8da50547f02b64"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1458,9 +1441,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "859"
+      - "978"
       X-Request-Id:
-      - 444a0678-a4d6-4b02-a375-e14317d6feaf
+      - 3337d5d4-b932-4809-9a84-442ca009a04f
     status: 200 OK
     code: 200
     duration: ""
@@ -1468,16 +1451,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_XjFK7exQxUz2z20y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_XjFK7exQxUz2z20y","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"},"name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:86:ee:ca:1e:6c","state":"attached","ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1488,13 +1469,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "500"
+      - "503"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:08 GMT
       Etag:
-      - W/"1a632093adda4d3199d1803244f423cf"
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1502,14 +1483,58 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "857"
+      - "977"
       X-Request-Id:
-      - 0ab84b72-21f1-4bd5-a435-1fccf9047f39
+      - 34d68923-f81c-45a9-928c-21f5f32b1f68
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap"},"properties":{"resource_ids":["vmgrp_D3LXSzEp2R1V4jM3"],"resource_type":"virtual_machine_groups"}}'
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:08 GMT
+      Etag:
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - f3f9c828-a001-4e5c-943e-92a48d4e7063
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1"},"properties":{"resource_ids":["vmgrp_htCBe3ylPFueU2J2"],"resource_type":"virtual_machine_groups"}}'
     form: {}
     headers:
       Content-Type:
@@ -1519,9 +1544,9 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: PATCH
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_D3LXSzEp2R1V4jM3"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}],"resource_ids":["vmgrp_htCBe3ylPFueU2J2"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -1535,9 +1560,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"0258c1d3cd6cc82cb02eff8133ad99bd"
+      - W/"7b27d2f04b35ada33edcff7787cb5de7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1545,9 +1570,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "856"
+      - "975"
       X-Request-Id:
-      - 6ef53696-a9ee-4a5a-a226-d17ba85e7eea
+      - 675200ab-df49-4dd8-8d40-529a29a6d1a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1557,12 +1582,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_D3LXSzEp2R1V4jM3"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}],"resource_ids":["vmgrp_htCBe3ylPFueU2J2"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -1576,9 +1601,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"0258c1d3cd6cc82cb02eff8133ad99bd"
+      - W/"7b27d2f04b35ada33edcff7787cb5de7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1586,9 +1611,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "855"
+      - "974"
       X-Request-Id:
-      - 7ee936e8-ee34-4ab5-96e6-bd596a4ff973
+      - 7019e6a0-763f-44fa-a6a4-7d6727c9b9bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1598,12 +1623,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_D3LXSzEp2R1V4jM3"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}],"resource_ids":["vmgrp_htCBe3ylPFueU2J2"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -1617,9 +1642,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"0258c1d3cd6cc82cb02eff8133ad99bd"
+      - W/"7b27d2f04b35ada33edcff7787cb5de7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1627,9 +1652,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "854"
+      - "973"
       X-Request-Id:
-      - 79041cc6-5bbf-426a-b214-8d695db56417
+      - a359b3a5-01d5-463f-bba0-de5ba0a6e26d
     status: 200 OK
     code: 200
     duration: ""
@@ -1640,11 +1665,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_D3LXSzEp2R1V4jM3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_htCBe3ylPFueU2J2
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1659,9 +1684,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"284f789e4a5a63b6991dce0700a9f2c4"
+      - W/"157be7c3d010e2b60dc648804bf2692e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1669,9 +1694,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "853"
+      - "972"
       X-Request-Id:
-      - 8c52eece-7e02-4da3-8d8e-8dd0f592eca3
+      - 031ac800-f302-41be-abd1-34e470c8dff4
     status: 200 OK
     code: 200
     duration: ""
@@ -1681,12 +1706,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_BqJchqR47wHzFhNA
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_8IpRh1QxcJjjxFW3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1697,13 +1722,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "727"
+      - "731"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"b16c168c8ee904734118a89825945815"
+      - W/"b3c314fe0049cae4b65eff3c99b0e86c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1711,9 +1736,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "853"
+      - "971"
       X-Request-Id:
-      - 328bb822-e50d-435e-9658-7f0e99e54a0d
+      - 7f5f1cd2-5489-4861-b7cf-17ce10600d82
     status: 200 OK
     code: 200
     duration: ""
@@ -1723,12 +1748,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_D3LXSzEp2R1V4jM3"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}],"resource_ids":["vmgrp_htCBe3ylPFueU2J2"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -1742,9 +1767,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"0258c1d3cd6cc82cb02eff8133ad99bd"
+      - W/"7b27d2f04b35ada33edcff7787cb5de7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1752,9 +1777,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "851"
+      - "970"
       X-Request-Id:
-      - 1c5323f1-40cc-4928-ab6d-fac3c038b992
+      - 3d2593ca-6062-4452-8f56-39b3b2830765
     status: 200 OK
     code: 200
     duration: ""
@@ -1765,19 +1790,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1790,9 +1815,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"4bd2da0096a557676ee2e844015d01b8"
+      - W/"741269186591c5b2c2748ed917f1a1d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1800,9 +1825,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "850"
+      - "969"
       X-Request-Id:
-      - 6bafd719-f1ed-4df7-94bb-841a61da9bf0
+      - 499d2e41-bdc9-4daf-8455-b0bccfdc66c7
     status: 200 OK
     code: 200
     duration: ""
@@ -1810,60 +1835,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_XjFK7exQxUz2z20y","name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "374"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
-      Etag:
-      - W/"bf4b7d45601d7505fc12c70f660f0d0b"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "849"
-      X-Request-Id:
-      - fd98ce6a-e566-41ed-bde1-033dfb2ed243
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_XjFK7exQxUz2z20y
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_XjFK7exQxUz2z20y","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"},"name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:86:ee:ca:1e:6c","state":"attached","ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rWoDY6PNWPdldFOu","name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1874,13 +1853,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "500"
+      - "377"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"1a632093adda4d3199d1803244f423cf"
+      - W/"afa75f849208e71d2d8da50547f02b64"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1888,9 +1867,51 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "848"
+      - "968"
       X-Request-Id:
-      - 31d86c28-21d5-4f5c-8b8c-47c77e8002dc
+      - d9746f08-3ed5-409b-89f5-b0c6a1a3579b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:09 GMT
+      Etag:
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 2a0af7f9-be94-461e-b079-ab61c6b10f7e
     status: 200 OK
     code: 200
     duration: ""
@@ -1901,11 +1922,55 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_D3LXSzEp2R1V4jM3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:09 GMT
+      Etag:
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - bad16758-293a-4c6c-b086-0a7681e149c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_htCBe3ylPFueU2J2
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1920,9 +1985,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"284f789e4a5a63b6991dce0700a9f2c4"
+      - W/"157be7c3d010e2b60dc648804bf2692e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1930,9 +1995,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "847"
+      - "963"
       X-Request-Id:
-      - 9cf92bac-055c-46cc-95a1-24046e0614c7
+      - 9eea537c-8de1-401e-a8d0-e8d75415c677
     status: 200 OK
     code: 200
     duration: ""
@@ -1942,12 +2007,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_BqJchqR47wHzFhNA
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_8IpRh1QxcJjjxFW3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1958,13 +2023,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "727"
+      - "731"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"b16c168c8ee904734118a89825945815"
+      - W/"b3c314fe0049cae4b65eff3c99b0e86c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1972,9 +2037,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "847"
+      - "965"
       X-Request-Id:
-      - 0665629e-a0f9-4c06-a342-baf13b3f5ad6
+      - d3702b35-f6fd-4f98-8e5d-1fd87ddbbf1e
     status: 200 OK
     code: 200
     duration: ""
@@ -1984,12 +2049,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_D3LXSzEp2R1V4jM3"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}],"resource_ids":["vmgrp_htCBe3ylPFueU2J2"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -2003,9 +2068,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"0258c1d3cd6cc82cb02eff8133ad99bd"
+      - W/"7b27d2f04b35ada33edcff7787cb5de7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2013,9 +2078,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "847"
+      - "965"
       X-Request-Id:
-      - 67a969f2-e77d-4bc9-8ad3-b4072a6b2e62
+      - 1358f6d7-f524-4cb0-9199-b0f6351dab28
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,19 +2091,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2051,9 +2116,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"4bd2da0096a557676ee2e844015d01b8"
+      - W/"741269186591c5b2c2748ed917f1a1d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2061,9 +2126,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "844"
+      - "962"
       X-Request-Id:
-      - 0f186981-c310-4225-a10f-bead26ce20d4
+      - c6fc6871-30e9-4609-9f37-61be800072fd
     status: 200 OK
     code: 200
     duration: ""
@@ -2071,16 +2136,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_XjFK7exQxUz2z20y","name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rWoDY6PNWPdldFOu","name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2091,13 +2154,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "374"
+      - "377"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"bf4b7d45601d7505fc12c70f660f0d0b"
+      - W/"afa75f849208e71d2d8da50547f02b64"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2105,9 +2168,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "843"
+      - "961"
       X-Request-Id:
-      - db0aa36f-3557-41dd-bee5-c1365664c428
+      - d23c452f-1fd5-45a0-bc19-2eb1a0755a94
     status: 200 OK
     code: 200
     duration: ""
@@ -2115,16 +2178,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_XjFK7exQxUz2z20y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_XjFK7exQxUz2z20y","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"},"name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:86:ee:ca:1e:6c","state":"attached","ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2135,13 +2196,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "500"
+      - "503"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:09 GMT
       Etag:
-      - W/"1a632093adda4d3199d1803244f423cf"
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2149,14 +2210,58 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "842"
+      - "960"
       X-Request-Id:
-      - 4866eba4-4abf-41a4-b20c-8bcdb1d4bded
+      - 7979543d-fe0b-47ab-a5d5-12f839bc0fac
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap"},"properties":{"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"resource_type":"tags"}}'
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:09 GMT
+      Etag:
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - 5b11372d-c3d4-4a73-9dc4-7b4927419dda
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1"},"properties":{"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"resource_type":"tags"}}'
     form: {}
     headers:
       Content-Type:
@@ -2166,10 +2271,10 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: PATCH
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2182,9 +2287,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:10 GMT
       Etag:
-      - W/"da5b3abbfc715d6d9febb56964623241"
+      - W/"925b07c3200e007d10f5e8b4444c0c84"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2192,9 +2297,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "841"
+      - "958"
       X-Request-Id:
-      - c827b664-b332-4ca7-8b88-11406e938ad7
+      - e8bc2547-9413-4e12-83ea-69e37792ea2c
     status: 200 OK
     code: 200
     duration: ""
@@ -2204,13 +2309,13 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2223,9 +2328,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:10 GMT
       Etag:
-      - W/"da5b3abbfc715d6d9febb56964623241"
+      - W/"925b07c3200e007d10f5e8b4444c0c84"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2233,9 +2338,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "839"
+      - "957"
       X-Request-Id:
-      - dc43542c-4e70-4d8c-aadb-cf6ec0596e9c
+      - a1d1b509-2fab-466e-bf9f-0c7e3d867bdc
     status: 200 OK
     code: 200
     duration: ""
@@ -2245,13 +2350,13 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2264,9 +2369,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:10 GMT
       Etag:
-      - W/"da5b3abbfc715d6d9febb56964623241"
+      - W/"925b07c3200e007d10f5e8b4444c0c84"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2274,51 +2379,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "837"
+      - "956"
       X-Request-Id:
-      - 5d1e3637-4fd1-4a3c-b0f3-5b8c20eda893
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_BqJchqR47wHzFhNA
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "727"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
-      Etag:
-      - W/"b16c168c8ee904734118a89825945815"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "834"
-      X-Request-Id:
-      - 4267fdc6-bb67-442c-b8bb-f10b0c28ed54
+      - 18ca4ebf-e2f2-4c18-a2ce-7809400b0d6c
     status: 200 OK
     code: 200
     duration: ""
@@ -2329,11 +2392,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_D3LXSzEp2R1V4jM3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_htCBe3ylPFueU2J2
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2348,9 +2411,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:10 GMT
       Etag:
-      - W/"284f789e4a5a63b6991dce0700a9f2c4"
+      - W/"157be7c3d010e2b60dc648804bf2692e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2358,9 +2421,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "832"
+      - "954"
       X-Request-Id:
-      - 5a9b6574-86db-4180-b1c3-f0d5de917d1a
+      - baffa699-3ec8-49a8-80bc-38bc7c50f352
     status: 200 OK
     code: 200
     duration: ""
@@ -2370,13 +2433,55 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_8IpRh1QxcJjjxFW3
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_0wAGxyzH9zWywXgF","address":"185.44.254.125"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVmlHUWF6RWNrTU1Zb0dhcC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM0WhgPMjA3NDEyMTIxNTQ4MzRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAM1V3rXxUi+uaTGLgd2+zI93xBzEUyQwRuU7\nqM7apZpwPq0iiLgOBF8L9aJCQIxHXlOS+MEpUstcKqf0E2RQ9L9gGDOsOTKGNFkW\ndM3Xnbyj82BJkZmUrTrXCUqO6QBSZCbcC4ffuTWKXLgu9uTqdmBaBmrBSQkce+uI\ng1DTfYCZq0Ai950Zm8nOyxdf6Mxj19CNmwYlJwUXE2Be1NEPFUq/bKFJCnN+oS6F\n7Gn5VPD76e36Gday5YMbb8lkETYaLHuW/g5GmN/AVG4ua8JSg5SAFuumwfmS96qz\n7kV8ebbkq/5L2/MSN5dUwmsVCOdXwrj4Gup8sPoxE76jtE/WfvuJT1jeLEJ0Nsa/\nKPAJX8p9V6nFv+odB198FRKSicWYgFhgWaNB/3rRT9qXgOpoAmZegBe3vN3pQw/V\nhfd3WoBImyyMTBvgm6rbHn9XmG17YMxV6XP4o9X4WW7Xu2YCc22kcZ7nF3ONNte3\nQBjS1g4wMcd3Cr6l6kVwgp5kKkU5qRF7p8UCwfu3dK9ayPioi9oFKDwxem3qfG8g\nSJXVr6/xjMqALuvMAX4VFFzZhodTfYf4ROgsAQfMLN7PC6cJX17NkuWE5gwwZtUf\nj9oXZIraKfT64mc9bUFjGh813IVZm56WXwzzEyFumMu0S75ngYi28euweucYSv9W\nNSVlzskhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nRo4TA/1SPl7PbBqPoFNTWPyL5TATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5GjhMD/VI+Xs9sGo+gU1NY/Ivl\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9WaUdRYXpFY2tNTVlvR2FwLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAPD7ocmXvhPEG\nImjlQDHc0OBqgH+3KI+bAjf9bX6pigmeSxmWLzfuY6I+Q2WrQCaAWZq+M0Pm8zAd\nbbTGMufRCu0TDCMQWsswJrmdmMS+jLsovUQgrB50uzeiwn4LseovYla5Q3y77SFf\nCTyFO2dNMo7Ov6ivQC6nWh+zRd+5iH4eftE2G4Jgf6Nh8yyL5FbsttTBzlctjkGq\noJn2/lWa3N/WWeMNUKMQ2zn/f7Pup2PRZ9wTeuEklCLrsTJglztnsnhB35NesZ0w\nKzMILPcFs7fK9dOais9mSsJ0quqQxaBR2NBV1dYpbHsOrO4su8CWwvqEoBpTOJYa\nCWg7jrn+RHnpWTZsW49hE/XawbL79SPK48wvIy7NcrN7tHmL1tZ3wDiT8d5HCrx/\nelZwipK3pWT7lDhz2w//k6XwoYYUzvKiEjQXNPED5wsOCDJIyton7SNa2sK/pdSl\nNusBbe3Um/cYEsu0eWcSuRT6HJCArnHv/MDfUC/hZHmqca5lxQAiNAZgF4e6GfG5\nRebWPkg4mkXsn086bJrhar8t6BB6ul19mo7GlBYpVGM0uifNwft+6n4yGVawSnGM\nN4kB5dMP6ZrSEOJFcXAGLtMnVBMp7UyZwLXyYV7B58x0otumYt8mf3/q9bEEt3f4\nEb0DS90kjRwn7aslZ5I/YwxUB6wPFB0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzVXetfFSL65pMYuB3b7Mj3fEHMRTJDBG5TuoztqlmnA+rSKI\nuA4EXwv1okJAjEdeU5L4wSlSy1wqp/QTZFD0v2AYM6w5MoY0WRZ0zdedvKPzYEmR\nmZStOtcJSo7pAFJkJtwLh9+5NYpcuC725Op2YFoGasFJCRx764iDUNN9gJmrQCL3\nnRmbyc7LF1/ozGPX0I2bBiUnBRcTYF7U0Q8VSr9soUkKc36hLoXsaflU8Pvp7foZ\n1rLlgxtvyWQRNhose5b+DkaY38BUbi5rwlKDlIAW66bB+ZL3qrPuRXx5tuSr/kvb\n8xI3l1TCaxUI51fCuPga6nyw+jETvqO0T9Z++4lPWN4sQnQ2xr8o8Alfyn1XqcW/\n6h0HX3wVEpKJxZiAWGBZo0H/etFP2peA6mgCZl6AF7e83elDD9WF93dagEibLIxM\nG+Cbqtsef1eYbXtgzFXpc/ij1fhZbte7ZgJzbaRxnucXc40217dAGNLWDjAxx3cK\nvqXqRXCCnmQqRTmpEXunxQLB+7d0r1rI+KiL2gUoPDF6bep8byBIldWvr/GMyoAu\n68wBfhUUXNmGh1N9h/hE6CwBB8ws3s8LpwlfXs2S5YTmDDBm1R+P2hdkitop9Pri\nZz1tQWMaHzXchVmbnpZfDPMTIW6Yy7RLvmeBiLbx67B65xhK/1Y1JWXOySECAwEA\nAQKCAgABbHpq7mAt7UqUmcgd/T7GXOPQI5VZqiMHtQpGhZIXOCGFyk2X4chVJLcA\njRniTx61O3mRlKOFaPTGbYUSkZQiMpH1uRiRbt2fONkOUf5+6m/GJ7nEeUPakAH5\nZsnF+IxHZQhdxLxFmy6+5oZ25Qr1P+fiUXJGnPsH/E5AHyNJjbyNU+C90bRjPxWT\nP9U++48+xoiVZOhjGuXwabVAjiyiiXbA8d8fw2Lt42cAVMaqasNpuhhNRTgdrgZF\np3W4whAzutg1SaHcOqVrOSkCnoID43/P2lFnKrDLGcx0Zg34VG1pNJCdxsR6E7qg\nYEjg78UYIBJHCh52XE+WfLnulskScA8PLMimlbLKXseoNUva92g7IL32+lFQD35D\nrMpU5yUwe+rguoIb5G69TDe6YuKhRoo2Zn7KyOIWzPWRdgnVO/ivRxQML1Lm5GJa\nzKyee5d72gUbgM4p/nAWxQAUlMpFupACZqdxetPhM9vNi6M38ZlBl6QL5Qf4Qw00\nbzhne71Uw4CyW3ppLqgia24kws3hKV7IzYR8nl4UBf764f4M5z07f66Bits6huW0\nedofFy+Tubvm+ftO/quiyGImXkmJvdXc2Yf+ls9M6rX56Qvfm4z1HQq9zCHn2dzV\n1CUwLYfSJ5wXUyB2o/f6qS0iyuSCBC8EG6G+bioAVx1ae/IW9QKCAQEA/cwNkzvT\n+8LAgyCS6XubRLJ3AELYWPltA35K5hg57gfq1M/ro5EgtdiDILOU54zfhA45ap4v\nAOL8857R0Wsc1WnZ0j5HX4vhLY65Lv93Ql9f2zcTIqjR1yJEAcaH1xw70zyGHZ7F\nUOallXVJAm57Ume2XaVtuO0rv+khgSkbJeFu8GjSwVmwzIhKpP/NcbILVNeNKyhl\n3iXz2FiTuICYJ4kk7RJTggVnW/WFiXus8omHWsr+rj/DvjPH5/YGCjE4nYbs6ee1\nB3aJiQ0FeYGFSv/xA+II3NeBR4wzCLA68oV8UKZnArzW8WSTFyRh3zoByANIgT2F\ndj0M7lWsPJReXQKCAQEAzx4iHXPEs90xbsRAO1HAL3kwiH/nNsTrfc4JChktUPAp\nsaR9C/SI173p3in+uj3B6Q1LneaEpqCRnHLntmN5h/0ed8UaMsy4YZqP6zy3ki0R\nrrCUztgnbFSUdl0jKO9Wh1HxToMTBKqxIRW+5l4jeJm+uAtMqCW7XK1+tn8B52EB\n/HTfeONX4j9mIQXzbJKPx8WfyORVl5yKWyMDfbJqHHhQ4mbhCjgm/VgX7RIpf5vW\n8GfoJfHqcf1XTXdS6btBKM4hyltGInmsnsl2wfg/rMw3s0rSmCY261RCGYowjX1P\n5YesP2uwWsWKutg6Grl4jbwBasH4ejw729zh6xOBlQKCAQEAmqu0yjn34sK5mDBN\n2EUgRymMJHiYaQD5UtuwwbGZ/FqO3ssoDDLyAGDG6TMIWGUeAti4XSWx95ReHAp6\nTGo+1EECIoMZ9DzHKoCEkwPVpnmBbZOO8dx4peeYEozvVEU8oGuOQJb2IWuvFfq4\nV+cE+R+DoGalC8Jem0J0zMZEaT2N4q2/Y15JxRx6gTvz9IpRJY+H1Pl1u4Ddrses\nnxCfqdiGzIQSqHaqmvxyOWtJ5zWxa7+ynnb10AC2n8Lrw2Jj4nzL/XDcfoPbJc7t\nuzMYDLEWLQuf4xbjDrt+jpj4E70OGgiPVrfHNq3Yho4Bp40ucLqvgTQBFiH2s3k6\n0mCJcQKCAQEAoicYVHCnhp3dLrhNBWQaj9BUs/lXHuUK7YKaRyKw/NYZ/m8mS27W\nl/mimIHOYScqonf7RJMONZouhgrb6Ep3AoWkDebtfOoUTK4CkQwHOFU6q8apqktG\niiSp2wVOGqVO3EDGKE6sXBH6/UkWHSuEn83WqCaIjHiF+KgINX64Eds7/9fMgcuT\nqZkzLxWGn/Eayi+pylEhxcIT/AgsmoNNWh7ETIx5EVQnCl+m079NaA+tNqhS8yoz\n/6x1ZjvOWRl2iSjhAZl2DlWuVN6rsG7YA0QbM66Xs/DvPEzKN06edpeuLqiKrVh1\nSIux8liJHRUqEeUoQtm73I892gNTiITMBQKCAQEAnApvK0JxZVrpkZDkj3FxBykN\nFNCmxcH7PG9Z2M4dFuhPvaPjNS+IAl8pZQu9m2VKLWbU6N8BZHibbBlYLtDJTEzQ\neTRlBoFs7VXtScbxeK9c9IYKHnZRLyFsh75ShLc6a0SCAyKVL0z3pC/rPKxBpXgA\nlaI984rmDpUJ80RS/x+kI4aqUgxijotrireNzWGdwPI8Ky1ZMIglOld6VTFIiW7z\nDzsU0IM/2Dti4I1P7ERjZSEaPW/Wpa4B2zWyAwT405IXIfwXqE1utA0Q5SmV/dIC\nXrrAbgNkV5RXL+GAD6+lg9o722EqWua4yITWadVBeRZQ4Qj0vksUvtFXUhAGMg==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "731"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:10 GMT
+      Etag:
+      - W/"b3c314fe0049cae4b65eff3c99b0e86c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - 6b5d1ac8-377a-4f65-93f1-d72181f66c42
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_J7srsq8FH2F5zTG6","address":"185.44.255.69"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfVHFKcGdqMk82YUhROHlFMS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzA2WhgPMjA3NTAyMDYxNzM3MDZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALdAJXeCnFLDO7oBy3Y1hCO7VQIOGxf/o3f1\nLAnYtcNxS9I6DQKexDr2Efha797ItaPqeKtU2YfYV9Hggs+q2NZgmnlzoRtkiqSG\n0d2MUdGLT4ssQqCUMwtY7LQzK75RXTxhsQVUGr9P0j9QV7xdtel3y4KOzOQquMip\ncj/M3zJe0djhN9gxzoqNMN4Ct5foZO/m5DCp7AAD9FAx+SbbD6xMgbvV+3U9s7MP\nmB7U/9xBDhNHonHP/odGMAjLqZ1+cPi1GI3IFENlj1kQnq+YbK2DTt3ifY+bKIqO\nkwQGyEFYq9c7+KciCD0OtdvbeljLMmfNcaHQ+DUjJ7Sk6Rho23JALvRd7FBUInVF\n5Zvo1lEYYFN+Mm1HyoXPDaBLZUGppYz8vMnqDVhFNfD0MV722JMmg6QCgFiPNcgi\nDYrIBg4DU+T9TFqSHqnJcgTJJ9TKDiJOxGTEBH1Bq180ELROZ4fB0wfEfb+5VBb1\nje12kZajFvjL286KgHGDiHvqUnH0eZs7HLQrhVOaZiGM+qJqUTjalksHemqIH3NX\nj0qSvMa1ZuZWBU4rQKms2SKC3ziGCmDcBouWbzxIOoaBDfbVL7C3oNmrfzS0lBNA\nqtc3WoplKgZ2pNP/Tx6NjYZxCDrWsiwxUMfJ5jVruww0YbUM6Fd/DQd0GPiZGOw2\neymhHWRLAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSr\n+N7Ek/raqLxDfJbFb2R5ZfSrVTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFKv43sST+tqovEN8lsVvZHll9KtV\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9UcUpwZ2oyTzZhSFE4eUUxLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYACKF0Mu0Ikq\n4x44atTY55cb8X2l/gEu+0u78wYXrWe9BuRpYCmeDJQOuUUMR8FVZd7dBROWnheH\ndZLIgg5h2+xlaSrEjhaZDI7wmTYZXW29SwhYlOfJsq+afQ0BSHbV+SpbpBIf3TDC\nwppHEhzdkzH+MOh2SRBIbjftrh0y3ulz91RdjvAVvSWcUlmN/Ly4v3yMl2wBMCSb\nXbIeHiI5ddbFwYK9qN5P3nchFRXzapWAxV26j0LCIgMT2/yoxD5Wtp8s7FfdguNd\nci5Wp1A+Lak7dpV99wQHGexWx/77T1A9kXBixRrYbkVuQQuodaf2Ww6sPAujNwE1\nMUgPrb7tTE493tgb72HcKzmHKOQUh/klFwJqbYrunKny4BIkGNj4KJsNX/79JPP9\nKC0sbB9EMs+K7SygDOXdLT98RlI3SwlDjt9Ei26/qYqYcLP5AHnfv63BOwIPvPBO\nvAARvJrzacAwsAn2zpT6989wQz5U3IRjh88rTHsYHhs0CXoCg/SNxyBbtL4jJDMb\nBN/gPDfTaACe08SJbcchwYy2xe+FBi6lphR70L/Ljy4HBequ61XvqNH1CnfNmddr\nlwsYqR1P2xAJQ/EOEW/HMAcUvQLy6VIv4ZjDWjLKc+KCoGNTCei/JOk/iHwsI3eg\n3vn+XO2awdemm99vcXwQyWaO3rOwiLk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAt0Ald4KcUsM7ugHLdjWEI7tVAg4bF/+jd/UsCdi1w3FL0joN\nAp7EOvYR+Frv3si1o+p4q1TZh9hX0eCCz6rY1mCaeXOhG2SKpIbR3YxR0YtPiyxC\noJQzC1jstDMrvlFdPGGxBVQav0/SP1BXvF216XfLgo7M5Cq4yKlyP8zfMl7R2OE3\n2DHOio0w3gK3l+hk7+bkMKnsAAP0UDH5JtsPrEyBu9X7dT2zsw+YHtT/3EEOE0ei\ncc/+h0YwCMupnX5w+LUYjcgUQ2WPWRCer5hsrYNO3eJ9j5soio6TBAbIQVir1zv4\npyIIPQ6129t6WMsyZ81xodD4NSMntKTpGGjbckAu9F3sUFQidUXlm+jWURhgU34y\nbUfKhc8NoEtlQamljPy8yeoNWEU18PQxXvbYkyaDpAKAWI81yCINisgGDgNT5P1M\nWpIeqclyBMkn1MoOIk7EZMQEfUGrXzQQtE5nh8HTB8R9v7lUFvWN7XaRlqMW+Mvb\nzoqAcYOIe+pScfR5mzsctCuFU5pmIYz6ompRONqWSwd6aogfc1ePSpK8xrVm5lYF\nTitAqazZIoLfOIYKYNwGi5ZvPEg6hoEN9tUvsLeg2at/NLSUE0Cq1zdaimUqBnak\n0/9PHo2NhnEIOtayLDFQx8nmNWu7DDRhtQzoV38NB3QY+JkY7DZ7KaEdZEsCAwEA\nAQKCAgBIy3CWwwm6TtgBEglzEdtGHnqscFIO/HxBgOFXoADEfNMz1d+pNMya53lI\nAUfcZjrRvKjm1rP7JNPuCZOtTx8IOiPjLy3Gpe/1X6Eqsz0lUoPss05cX8LPNSoC\ng3lTBxtUizI4/aoKaXkJsa7IoylKb04mtPdrhBUXkUhTU90uM0CFOSJn/ZEgtOm+\np7Gq5KSEMGJhen7HmsqIuPFSoB7fwRygM2bKshIahY1WYiKpqiYfPounToq7zgPy\n2oSsjbfu9HGmkN6Lz2JcbR+8fX5ehxTjS7+5Nleqguyf4tnWK5VH0Qj7y6ceKiPQ\nDKXTdBS364LCVzLiWO7C8eeuzKivU/6t+iXJ17HWG5KzdSI4E5RHvLY8LOjf7dd7\nIBfPKmIOYoW3QHyX56ytFXG5z4WgREIfAZOO679/ReDzQwZ4mSDiTNpFxdxL7Q7C\n7pGKxSaJRZ7YIcYprMR5WsGjnL4OvBMbFOOcH1zhKXDw55qHfSVNeIzfrOkzaTax\njg28gwfMvOYXyz3LwQu0EiMaxLiR/BRR/TW/RmTkikAzUk4tIZQXBQCZefxbyPkJ\nvQj13s04hCztS4G1WWaKpCHRjIOEdlFGDkxoFoG6/ofJORimdJGtZzIX+3EpSOuJ\nBFaqrVGTJ9Y7/1z64p65ORGBISJcRkz3eUmDkXcwx9nHaEHMoQKCAQEA2XFLojoE\nk9unTeUtH7LS3+VUIPV8QAXNL8uPQTfKNjPBdlmE9US9/QHkmhuvl1Jr+MveKHSR\nvy1xWCWpS0pO9pPu6uZCI1R/oyQUMmV6VTeuCmgF67oarHVZELa21AqfHLmA5hdx\ncS7rJ412yKPgkKDz95UNiYdMx4bZ7dKHnEO19DeAnWf4+Mqir7lJxxTRzMzSTmgu\nU+7BqyjFaYoJp7zMHoyZGnF/aQGHk1RpwDM0DLb2uThPtf+kQLQhdiNZdyLfLXZ6\nnWk0Oon4nVGkqU1A44Zu7Vgv30TsvdNDOgUciseW5vAGqeUoN0CpvcNU1JTWH4rN\n4RyEaEl3PLXIUwKCAQEA1764rLZ8J9gQXnToZ8/W0hKxUULpVFb+NxH97ZK8tvy7\nX3x78SWVG2qxuiDc7aj3CTF1EHpCNSdxB7IuB6QhYv4xIhtWKjYs9+JxPBJnInEH\nh2cwhiPsM1Q2A56abuuTSmYi8V7/4Zf/yaeMK203+R9msQzVZnG3WEGj0+AeagaA\nXFzxxuVpltroykPz91Eu5jwHXoxrPrXO2PAhqaVIQYNkhqcnsksRHjZA5r6Pr0q5\nE+7dzaD1O7e/HsaIqxai80OVr4K8EV4biRSeoyRCDnX0gp+XvGJOBgwqY2wzYQFO\n4mgxKnWyyG17cXgvVQKejnO7CIO8M9azxGoRjviVKQKCAQEAnzREnFK+Z0O8C1xw\n3XSg0S2nmzoh7v5QbV4tVSLz+xuJ2o1QvAPI1yY7qln7BmBijZc24Yf37nHnOxLY\nETgm+IL3uyU754JGsbwIzZ1fJGXQF+5x51YrkXmZ7JLa6gWc2fs4VT9039nqctsw\nzVavZTVzayLG9psJrE0f4vDyOYeaAWVh1d36fK5gzyhqzEiCE+EjWiUNRobZZehE\nIjHfP+EL0pI+xw2yq79i9IwpoX/b7DNKEfMY6bhzGqzIkybuqjvuC+tjez078GB0\nlzrfxNW7XNtg/IZFBsQAUjwMTL7RVwsrgYrcVihieZHutfH+emc/H3kRpHCswW6I\nzvqJ4QKCAQB7Ye9rltFaWA7EdkeTVyGb8mTF/GZEfZvVEs0N2SVj4RWnfiHDv6KO\nk24g7DptEHx3HXm9eq3yiCP0Ksp4RD1zx7uBrfCRI3qEKVRo7n1dDRcpMLJnhJPI\npxhc6Y+Yb9FEczT4pUPhWHRIdzGKhGPGbVblWlmQxOf96UwwF7RNHnq6V81N2lWQ\nmJEZW9NiVWNk+F+eit+qdX9eQbZ+tq+kB+ituVrSdGvNw2lKjSDPNwSxiaH/v1WA\nWY1LpG70qXV3eedZAINdy1wkAU7YLhw4+Oxk57B3ZCELBFoZkf+wMndStBOqHLWq\nOjKmqf0nuN/EyBrmu7AeVWNpqN9xzGhBAoIBAEQAC/ss8XizVis6QKuvBUEPcfgf\nNhgdcgxSxKMXOthbDNZCQ+/3/zy1jxUn9WLFcdRfbe9NTm8Wkw6sVhSzdN5JjXxc\nmsFOcDeG8zZPhrL6Gtdm5LDZ/PHgwrjPDlyDdrcbihGH7dD2xOdbs/MlfiXPLaEK\nQUw6X/jaPh+r+Vp0XVZ6Ll9PiHXYB57J2U3jHbLaYoNulmqn64/hrJyeuh1+ZAWZ\nOlHChGUA+SqMhuq3ph6oEF6UAy+CvEHvj9QZ+bPiD1ndUgMa3W1kF7tWIeqs4jB+\nbxL6mnsOPB8zG6Q+uVZFd8G70LpMZG4H7PdK91HooiaO0YycjWcHS9S9Vm8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_168HSPmDtWynYdad","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2389,9 +2494,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:37:10 GMT
       Etag:
-      - W/"da5b3abbfc715d6d9febb56964623241"
+      - W/"925b07c3200e007d10f5e8b4444c0c84"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2399,9 +2504,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "834"
+      - "953"
       X-Request-Id:
-      - 165c71dc-aa0c-41c7-a8e1-7b889dab54ba
+      - 5b789c28-2002-446a-aaee-5f27cd305f4b
     status: 200 OK
     code: 200
     duration: ""
@@ -2412,19 +2517,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2437,9 +2542,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
+      - Thu, 06 Feb 2025 17:37:10 GMT
       Etag:
-      - W/"4bd2da0096a557676ee2e844015d01b8"
+      - W/"741269186591c5b2c2748ed917f1a1d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2447,9 +2552,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "831"
+      - "952"
       X-Request-Id:
-      - 319e240a-973f-482d-972f-d7787c19b7ea
+      - 2ff9f676-cd1c-488e-beb9-eda2091709b9
     status: 200 OK
     code: 200
     duration: ""
@@ -2457,16 +2562,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_XjFK7exQxUz2z20y","name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_rWoDY6PNWPdldFOu","name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2477,13 +2580,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "374"
+      - "377"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
+      - Thu, 06 Feb 2025 17:37:10 GMT
       Etag:
-      - W/"bf4b7d45601d7505fc12c70f660f0d0b"
+      - W/"afa75f849208e71d2d8da50547f02b64"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2491,9 +2594,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "829"
+      - "951"
       X-Request-Id:
-      - 54661e64-21f0-4182-a092-f5db69a4c515
+      - 207bdf86-da64-4373-902b-581d6f1f1cc7
     status: 200 OK
     code: 200
     duration: ""
@@ -2501,16 +2604,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_XjFK7exQxUz2z20y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_XjFK7exQxUz2z20y","virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium"},"name":"Public
-      Network on tf-famous-faint-magnesium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:86:ee:ca:1e:6c","state":"attached","ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2521,13 +2622,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "500"
+      - "503"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
+      - Thu, 06 Feb 2025 17:37:11 GMT
       Etag:
-      - W/"1a632093adda4d3199d1803244f423cf"
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2535,9 +2636,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "827"
+      - "950"
       X-Request-Id:
-      - fb3e5a74-39ee-48f4-b677-f626688515ae
+      - c784e37c-dfd1-42fb-bc1e-7cc1e1efd9c2
     status: 200 OK
     code: 200
     duration: ""
@@ -2548,11 +2649,55 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_D3LXSzEp2R1V4jM3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_rWoDY6PNWPdldFOu
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_rWoDY6PNWPdldFOu","virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon"},"name":"Public
+      Network on tf-tasty-yellow-watermelon","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:93:71:73:90:17","state":"attached","ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:11 GMT
+      Etag:
+      - W/"fbf745a51efd224c71f7212a2c20fec3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "949"
+      X-Request-Id:
+      - ff42dee9-8e6d-47b2-9057-b3e16751564e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_htCBe3ylPFueU2J2
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_D3LXSzEp2R1V4jM3","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_htCBe3ylPFueU2J2","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863394}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2567,9 +2712,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
+      - Thu, 06 Feb 2025 17:37:11 GMT
       Etag:
-      - W/"284f789e4a5a63b6991dce0700a9f2c4"
+      - W/"157be7c3d010e2b60dc648804bf2692e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2577,104 +2722,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "824"
+      - "948"
       X-Request-Id:
-      - e2eb35d7-6d0f-446a-9c08-5f8a75f635d0
+      - 2797bb62-1d10-40eb-8223-8c42747e3aea
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"4bd2da0096a557676ee2e844015d01b8"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "823"
-      X-Request-Id:
-      - 80ef9c7f-3c47-47ad-9ad7-d35cbf146d27
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
-    method: POST
-  response:
-    body: '{"task":{"id":"task_vcLsg9Z8AbaBkUJ4","name":"Stop virtual machine","status":"pending"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "88"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"bd6a83b694fd141b962273e699642ad4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "820"
-      X-Request-Id:
-      - d4fd6455-e7f3-45f6-a472-5482bf46f321
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap"}}'
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1"}}'
     form: {}
     headers:
       Content-Type:
@@ -2684,7 +2739,7 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: DELETE
   response:
-    body: '{"load_balancer":{"id":"lb_ViGQazEckMMYoGap","name":"tf-acc-test-resource-type-change-OYC6mUzBtm1V","api_reference":null}}'
+    body: '{"load_balancer":{"id":"lb_TqJpgj2O6aHQ8yE1","name":"tf-acc-test-resource-type-change-SW8ogezHazO5","api_reference":null}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2699,9 +2754,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
+      - Thu, 06 Feb 2025 17:37:11 GMT
       Etag:
-      - W/"c032a9e315b23061b6ac355b9ac86b7f"
+      - W/"c9cfbc10ce9a422a9ebd9fd18a91d234"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2709,9 +2764,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "822"
+      - "947"
       X-Request-Id:
-      - 16e05377-41d7-40b6-acc2-1c9d3be1b093
+      - 5bf76385-0dfc-4b8c-9f63-852d043e4dd2
     status: 200 OK
     code: 200
     duration: ""
@@ -2722,11 +2777,101 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_vcLsg9Z8AbaBkUJ4
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"task":{"id":"task_vcLsg9Z8AbaBkUJ4","name":"Stop virtual machine","status":"running","created_at":1734018517,"started_at":1734018517,"finished_at":null,"progress":5}}'
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:12 GMT
+      Etag:
+      - W/"741269186591c5b2c2748ed917f1a1d8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 3a30b74c-6d51-4740-9ba1-57ffdc120456
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
+    method: POST
+  response:
+    body: '{"task":{"id":"task_ThTIJo3iIjQ41ulL","name":"Stop virtual machine","status":"pending"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "88"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:12 GMT
+      Etag:
+      - W/"115a0040219df5ceed193da6779f1f28"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 1e9a2fca-6d7e-447a-9b0c-ce82ec07e333
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ThTIJo3iIjQ41ulL
+    method: GET
+  response:
+    body: '{"task":{"id":"task_ThTIJo3iIjQ41ulL","name":"Stop virtual machine","status":"running","created_at":1738863432,"started_at":1738863433,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2741,9 +2886,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
+      - Thu, 06 Feb 2025 17:37:13 GMT
       Etag:
-      - W/"dd08eb399dfb01719cc0ebe4ba73da7f"
+      - W/"b7ebe4a297717c9409f10e5246214ab7"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2751,9 +2896,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "803"
+      - "944"
       X-Request-Id:
-      - 40adc9e3-4a0a-430e-b2a0-61c99813319c
+      - 80c16774-9828-477b-a8fd-90e3afcb6da6
     status: 200 OK
     code: 200
     duration: ""
@@ -2764,11 +2909,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_vcLsg9Z8AbaBkUJ4
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_ThTIJo3iIjQ41ulL
     method: GET
   response:
-    body: '{"task":{"id":"task_vcLsg9Z8AbaBkUJ4","name":"Stop virtual machine","status":"completed","created_at":1734018517,"started_at":1734018517,"finished_at":1734018519,"progress":100}}'
+    body: '{"task":{"id":"task_ThTIJo3iIjQ41ulL","name":"Stop virtual machine","status":"completed","created_at":1738863432,"started_at":1738863433,"finished_at":1738863435,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2783,9 +2928,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:43 GMT
+      - Thu, 06 Feb 2025 17:37:18 GMT
       Etag:
-      - W/"905063bc12f48638a3ca7c95c9c4b26c"
+      - W/"f5e280a889024ec81913825b05541881"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2793,9 +2938,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "789"
+      - "943"
       X-Request-Id:
-      - 131feb8e-6bd0-4c45-8cb0-1252d70603b4
+      - 8fb2c9de-32dc-4934-bdf1-38297df0ddb5
     status: 200 OK
     code: 200
     duration: ""
@@ -2806,19 +2951,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2831,9 +2976,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:44 GMT
+      - Thu, 06 Feb 2025 17:37:19 GMT
       Etag:
-      - W/"450314495a7ea4003409e6d436a1d8a8"
+      - W/"3c0281bb9147aa2bcd0ffb3b188404f6"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2841,9 +2986,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "784"
+      - "942"
       X-Request-Id:
-      - db2afcda-554e-4858-b99f-7045d67b92e5
+      - a04e028b-9970-48a7-aa05-f7bd61e0605c
     status: 200 OK
     code: 200
     duration: ""
@@ -2854,19 +2999,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_168HSPmDtWynYdad
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_FyXtk2sTjNVOWwXm","keep_until":1734191324,"object_id":"vm_TyVIL6hMyuhHAu3t","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_TyVIL6hMyuhHAu3t","name":"tf-famous-faint-magnesium","hostname":"tf-famous-faint-magnesium","fqdn":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"CIQVRzSyonp15sm0","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_u4GVSlvb4P8y3ViO","keep_until":1739036239,"object_id":"vm_168HSPmDtWynYdad","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_168HSPmDtWynYdad","name":"tf-tasty-yellow-watermelon","hostname":"tf-tasty-yellow-watermelon","fqdn":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863400,"initial_root_password":"GT0pZsO1ctACMxuX","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_BqJchqR47wHzFhNA","address":"185.44.253.75","reverse_dns":"tf-famous-faint-magnesium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.75/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_8IpRh1QxcJjjxFW3","address":"185.44.253.173","reverse_dns":"tf-tasty-yellow-watermelon.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.173/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_TyVIL6hMyuhHAu3t","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_168HSPmDtWynYdad","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2879,9 +3024,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:44 GMT
+      - Thu, 06 Feb 2025 17:37:19 GMT
       Etag:
-      - W/"533bb54e6cbaf2e1986e98ad356ab134"
+      - W/"47ae973179edaf4bd1b023ba87b0592d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2889,9 +3034,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "783"
+      - "941"
       X-Request-Id:
-      - faa8f5b9-2ce0-438a-b337-78dbd07b35f4
+      - eb73ba90-8d2f-48b9-83a2-217250d57b2f
     status: 200 OK
     code: 200
     duration: ""
@@ -2902,8 +3047,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_BqJchqR47wHzFhNA
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_8IpRh1QxcJjjxFW3
     method: POST
   response:
     body: '{}'
@@ -2921,7 +3066,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:45 GMT
+      - Thu, 06 Feb 2025 17:37:20 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2931,9 +3076,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "782"
+      - "940"
       X-Request-Id:
-      - e671313c-159d-43c0-b807-adb5be81b213
+      - 9a610515-68f4-4c81-a6ed-960a916c5081
     status: 200 OK
     code: 200
     duration: ""
@@ -2944,11 +3089,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_168HSPmDtWynYdad
     method: DELETE
   response:
-    body: '{"task":{"id":"task_o8FjBJZxujCFrYe1","name":"Purge items from trash","status":"pending","created_at":1734018525,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_3Yv74TVhXFhOdqJR","name":"Purge items from trash","status":"pending","created_at":1738863440,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2963,9 +3108,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:45 GMT
+      - Thu, 06 Feb 2025 17:37:20 GMT
       Etag:
-      - W/"80797481e8a84c0a40dda76fd5008877"
+      - W/"462f408129eeda9d132a5fb44dd1e606"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2973,9 +3118,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "781"
+      - "939"
       X-Request-Id:
-      - a887d91a-9baa-49ce-b294-18c27436c63d
+      - 4cd4c889-e9f4-4638-90c0-b43c615a73b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2986,11 +3131,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_FyXtk2sTjNVOWwXm","keep_until":1734191324,"object_id":"vm_TyVIL6hMyuhHAu3t","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_u4GVSlvb4P8y3ViO","keep_until":1739036239,"object_id":"vm_168HSPmDtWynYdad","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3005,9 +3150,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:46 GMT
+      - Thu, 06 Feb 2025 17:37:21 GMT
       Etag:
-      - W/"6d2bd53727620e52c6f1a2a864135563"
+      - W/"b957f7244dabb4fc712149ebccabb9ee"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3015,9 +3160,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "778"
+      - "938"
       X-Request-Id:
-      - 7818e708-f82a-42e7-bca3-319943cea29e
+      - 002d5abc-1f4a-4106-907f-59831e15ffeb
     status: 200 OK
     code: 200
     duration: ""
@@ -3028,8 +3173,50 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_TyVIL6hMyuhHAu3t
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_168HSPmDtWynYdad
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_u4GVSlvb4P8y3ViO","keep_until":1739036239,"object_id":"vm_168HSPmDtWynYdad","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:26 GMT
+      Etag:
+      - W/"b957f7244dabb4fc712149ebccabb9ee"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "937"
+      X-Request-Id:
+      - 5a88bcf5-3595-49f4-a70b-d47b388c9085
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_168HSPmDtWynYdad
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -3048,7 +3235,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:51 GMT
+      - Thu, 06 Feb 2025 17:37:36 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3058,14 +3245,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "776"
+      - "936"
       X-Request-Id:
-      - 1ff3b918-0e8f-402d-9571-03205587cc10
+      - 00330890-2060-4fd1-909b-f114c176ce44
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"ip_address":{"id":"ip_BqJchqR47wHzFhNA"}}'
+    body: '{"ip_address":{"id":"ip_8IpRh1QxcJjjxFW3"}}'
     form: {}
     headers:
       Content-Type:
@@ -3090,7 +3277,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:51 GMT
+      - Thu, 06 Feb 2025 17:37:36 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -3100,9 +3287,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "775"
+      - "935"
       X-Request-Id:
-      - f7b7c687-eaea-4323-9679-480496ad153b
+      - d49da298-98ff-4836-a68f-761599419a59
     status: 200 OK
     code: 200
     duration: ""
@@ -3112,7 +3299,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_ViGQazEckMMYoGap
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_TqJpgj2O6aHQ8yE1
     method: GET
   response:
     body: '{"error":{"code":"load_balancer_not_found","description":"No load balancer
@@ -3131,7 +3318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:51 GMT
+      - Thu, 06 Feb 2025 17:37:36 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3141,9 +3328,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "774"
+      - "934"
       X-Request-Id:
-      - b39cddc1-813d-409e-b636-29dfe291eda9
+      - faae277b-1f40-4ed7-b755-b0e2d1ee6129
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/v6provider/testdata/LoadBalancer_tag.cassette.rand_id
+++ b/internal/v6provider/testdata/LoadBalancer_tag.cassette.rand_id
@@ -1,1 +1,1 @@
-BjeyakxMJTN2
+I5r2kO3RJUQG

--- a/internal/v6provider/testdata/LoadBalancer_tag.cassette.yaml
+++ b/internal/v6provider/testdata/LoadBalancer_tag.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:10:19 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "831"
+      - "998"
       X-Request-Id:
-      - 761a1f94-0d8a-4df8-b839-68c1fe20cb28
+      - 4ae4c9ab-ec95-4945-a50a-d06ad424b331
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"185-44-254-93.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"185-44-254-5.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -65,13 +65,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "558"
+      - "555"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:10:19 GMT
       Etag:
-      - W/"20fdebc9196759aed43ec19fe18970c9"
+      - W/"81ffe213baf166e9d5052ca84b0cb5b1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -79,9 +79,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "816"
+      - "997"
       X-Request-Id:
-      - 01efce2c-da6d-4001-8019-8e0ea090fe97
+      - 83c07d2f-fc8d-427a-8464-d9d83beda195
     status: 200 OK
     code: 200
     duration: ""
@@ -91,10 +91,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_YSQN2KIwSfYPLZSO
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_aXEnNQr6XYRUYd8S
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"185-44-254-93.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"185-44-254-5.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -107,13 +107,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "576"
+      - "573"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:10:19 GMT
       Etag:
-      - W/"040f3ca892eab112c5f0177221361aa7"
+      - W/"a7b51ba27de65d72813c83229a379520"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -121,9 +121,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "803"
+      - "996"
       X-Request-Id:
-      - 69507fb1-913e-45f6-aef7-6027a706ac43
+      - 1d0d2059-829d-47b8-84e6-7890de24f7d9
     status: 200 OK
     code: 200
     duration: ""
@@ -134,11 +134,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_YSQN2KIwSfYPLZSO
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_aXEnNQr6XYRUYd8S
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"185-44-254-93.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"185-44-254-5.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -151,13 +151,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "576"
+      - "573"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:10:19 GMT
       Etag:
-      - W/"040f3ca892eab112c5f0177221361aa7"
+      - W/"a7b51ba27de65d72813c83229a379520"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -165,15 +165,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "802"
+      - "995"
       X-Request-Id:
-      - 1521e458-aced-43d2-97ac-4ee01808af9c
+      - 9caacc8f-c5dc-4bfc-b954-c9aa99ceacec
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_YSQN2KIwSfYPLZSO</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-magnificent-kind-daisy</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag></Tags></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_aXEnNQr6XYRUYd8S</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-rainbow-ancient-cheetah</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys><Tags><Tag>web</Tag></Tags></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -181,11 +181,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_VFQst59Tanzgl81L","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_imJpHPaTky9kszbP","state":"pending"},"virtual_machine_build":{"id":"vmbuild_imJpHPaTky9kszbP","state":"pending"},"hostname":"tf-magnificent-kind-daisy","annotations":[]}'
+    body: '{"task":{"id":"task_A5OwHssHtzQ0b1Pi","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_76v26MLLPOfJu5TV","state":"pending"},"virtual_machine_build":{"id":"vmbuild_76v26MLLPOfJu5TV","state":"pending"},"hostname":"tf-rainbow-ancient-cheetah","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -196,13 +196,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "281"
+      - "282"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:10:19 GMT
       Etag:
-      - W/"b446d1b8aaf5ce2badcb23890bf31ccd"
+      - W/"eb4cd4057c4f5d8cfab30b50524241c1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -210,14 +210,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "801"
+      - "994"
       X-Request-Id:
-      - 3be0c590-d3f0-4975-bbb8-8e83b94f6ac4
+      - 2f9f0eb8-0904-422c-98aa-53271aa04b1d
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-tag-BjeyakxMJTN2-1","resource_ids":["tag_NqAjIfOyzSMyuFPS"],"resource_type":"tags"}}'
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-tag-I5r2kO3RJUQG-1","resource_ids":["tag_NqAjIfOyzSMyuFPS"],"resource_type":"tags"}}'
     form: {}
     headers:
       Content-Type:
@@ -227,9 +227,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
     method: POST
   response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -243,9 +243,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:50 GMT
+      - Thu, 06 Feb 2025 17:10:20 GMT
       Etag:
-      - W/"de398dae0e356aeefb9f92df72a1e0b2"
+      - W/"eeabd1bfbab07fe1f1575acc45436345"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -253,9 +253,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "823"
+      - "999"
       X-Request-Id:
-      - 03d79050-740b-4da8-b8ce-89fea338b11e
+      - 64b79b09-ec96-4758-a2b3-b7583edd9332
     status: 201 Created
     code: 201
     duration: ""
@@ -265,12 +265,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Px0MdfXYD7HgsZtF
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_uyiatLDg1fvrodMz
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -284,9 +284,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:50 GMT
+      - Thu, 06 Feb 2025 17:10:20 GMT
       Etag:
-      - W/"de398dae0e356aeefb9f92df72a1e0b2"
+      - W/"eeabd1bfbab07fe1f1575acc45436345"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -294,9 +294,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "779"
+      - "993"
       X-Request-Id:
-      - ad8a636e-c369-4e12-9e2b-378170d3a719
+      - 88ccf58e-d409-496a-8694-826b23752eae
     status: 200 OK
     code: 200
     duration: ""
@@ -307,18 +307,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_imJpHPaTky9kszbP
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_76v26MLLPOfJu5TV
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_imJpHPaTky9kszbP","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_76v26MLLPOfJu5TV","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-kind-daisy\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.5\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-rainbow-ancient-cheetah\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738861819},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -331,9 +331,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:50 GMT
+      - Thu, 06 Feb 2025 17:10:21 GMT
       Etag:
-      - W/"3080660c510e4fb87971a907391c3d00"
+      - W/"bf9b564ae5b5aa23db8edfdc9164bd36"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -341,14 +341,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "768"
+      - "991"
       X-Request-Id:
-      - 90493482-ed07-4e65-8b49-6f963097eb65
+      - c7aa8416-5e03-4d1c-92c5-118a6da87ab6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-tag-BjeyakxMJTN2-alt","resource_ids":[],"resource_type":"virtual_machines"}}'
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","resource_ids":[],"resource_type":"virtual_machines"}}'
     form: {}
     headers:
       Content-Type:
@@ -358,9 +358,9 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
     method: POST
   response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -374,191 +374,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:55 GMT
+      - Thu, 06 Feb 2025 17:10:23 GMT
       Etag:
-      - W/"f0cb36967b5896c6aeed6654cacde3fa"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "775"
-      X-Request-Id:
-      - 3dc5d481-caa5-47a8-9cde-9c4ecc3235dc
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_2uVTlEe5FHOgxBRm
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:55 GMT
-      Etag:
-      - W/"f0cb36967b5896c6aeed6654cacde3fa"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "694"
-      X-Request-Id:
-      - 6c16d625-be06-4202-a858-ef9c4e85566c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_imJpHPaTky9kszbP
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_imJpHPaTky9kszbP","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-kind-daisy\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:55 GMT
-      Etag:
-      - W/"6658a5388a75b2b20b3749b8c9817b4d"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "689"
-      X-Request-Id:
-      - 8f2afd56-8505-4c0b-a994-1fc256e158b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_imJpHPaTky9kszbP
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_imJpHPaTky9kszbP","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-kind-daisy\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:05 GMT
-      Etag:
-      - W/"6658a5388a75b2b20b3749b8c9817b4d"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "998"
-      X-Request-Id:
-      - c9252a46-04e3-4c7c-b134-8061ade602fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_imJpHPaTky9kszbP
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_imJpHPaTky9kszbP","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-kind-daisy\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:15 GMT
-      Etag:
-      - W/"6658a5388a75b2b20b3749b8c9817b4d"
+      - W/"593871d11f0174813133e165d92a3076"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -568,29 +386,23 @@ interactions:
       X-Ratelimit-Remaining:
       - "992"
       X-Request-Id:
-      - e393aa14-2fe4-4076-a95e-e9a6acb4b9e3
-    status: 200 OK
-    code: 200
+      - e6ff48ce-61b2-4f37-b34c-1d80698942fe
+    status: 201 Created
+    code: 201
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_imJpHPaTky9kszbP
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_RcACnJ5mZyozZdlA
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_imJpHPaTky9kszbP","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.93\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-kind-daisy\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1734018468},"annotations":[]}'
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -603,9 +415,150 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:25 GMT
+      - Thu, 06 Feb 2025 17:10:23 GMT
       Etag:
-      - W/"d229a460ab0d4e62d79620f94f9f7d5e"
+      - W/"593871d11f0174813133e165d92a3076"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - f8422118-9374-4598-a7c3-87cfa01f5140
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_76v26MLLPOfJu5TV
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_76v26MLLPOfJu5TV","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.5\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-rainbow-ancient-cheetah\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738861819},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:26 GMT
+      Etag:
+      - W/"bf9b564ae5b5aa23db8edfdc9164bd36"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - e7d0c328-b3cd-4862-950f-0a2fd615dbca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_76v26MLLPOfJu5TV
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_76v26MLLPOfJu5TV","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.5\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-rainbow-ancient-cheetah\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738861819},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:36 GMT
+      Etag:
+      - W/"e11053dbf3ab0a78f8deafb18de3f8a6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 087fea16-592c-44a1-b6ed-b3bb095a545e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_76v26MLLPOfJu5TV
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_76v26MLLPOfJu5TV","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.5\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-rainbow-ancient-cheetah\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n  \u003cTags\u003e\n    \u003cTag\u003eweb\u003c/Tag\u003e\n  \u003c/Tags\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","state":"allocating"},"created_at":1738861819},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:46 GMT
+      Etag:
+      - W/"2b2574940712e7549a4f593925e67632"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -615,13 +568,13 @@ interactions:
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - 31af70b3-5e0e-44b8-84d1-30394774f96f
+      - ac987f95-6897-4ef3-b0e6-9b8da84c1bc4
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y"},"properties":{"tag_names":["web"]}}
+      {"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI"},"properties":{"tag_names":["web"]}}
     form: {}
     headers:
       Accept:
@@ -629,19 +582,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/virtual_machines/_
     method: PATCH
   response:
-    body: '{"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"allocating","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -654,9 +607,57 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:25 GMT
+      - Thu, 06 Feb 2025 17:10:46 GMT
       Etag:
-      - W/"5604894125c7c3ff959d100192543236"
+      - W/"d420fbd23a4cf40df924ba8fc088a73c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 017de78c-415c-4ccd-b4b6-6ec11ccf94fe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"starting","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:48 GMT
+      Etag:
+      - W/"f6354110b3baface8c8106a18d87ef30"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -666,7 +667,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - 18345b59-aa62-4a31-8f1a-70f6d97d04bd
+      - cc927717-9f43-4fd3-9a5d-8a2ea7448d41
     status: 200 OK
     code: 200
     duration: ""
@@ -677,19 +678,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -702,9 +703,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
+      - Thu, 06 Feb 2025 17:10:53 GMT
       Etag:
-      - W/"5604894125c7c3ff959d100192543236"
+      - W/"d519e970a45ed16a40252dfa226a7a55"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -712,9 +713,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "974"
+      - "984"
       X-Request-Id:
-      - eb10009d-dc71-4bf5-8911-0473319ed88f
+      - 24580bc5-19c5-435b-a305-a2eaacaf1fb3
     status: 200 OK
     code: 200
     duration: ""
@@ -725,19 +726,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -750,9 +751,433 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
+      - Thu, 06 Feb 2025 17:10:53 GMT
       Etag:
-      - W/"5604894125c7c3ff959d100192543236"
+      - W/"d519e970a45ed16a40252dfa226a7a55"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 48b744b8-90f1-4fbb-b803-625f95986ea3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_PLdaBUbRa8nees3k","name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "375"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:53 GMT
+      Etag:
+      - W/"2bb25bc3f7c573329389242e094369b2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - c8f25d05-4157-4be8-83a2-e7700c9e3331
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_PLdaBUbRa8nees3k
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PLdaBUbRa8nees3k","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"},"name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:09:ca:7c:1b:dd","state":"attached","ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "501"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:53 GMT
+      Etag:
+      - W/"1598e57a006913ec288bf3b027376678"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 023bfe65-27a2-4933-a4e2-c9c23303c58a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_PLdaBUbRa8nees3k
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PLdaBUbRa8nees3k","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"},"name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:09:ca:7c:1b:dd","state":"attached","ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "501"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:53 GMT
+      Etag:
+      - W/"1598e57a006913ec288bf3b027376678"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - abdae59c-2c04-4c33-bc9c-cc35b87e44ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_uyiatLDg1fvrodMz
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_fC4FiL8uMmClY6NI","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"9833ca5bbc5d333639fce4cd8327d1c8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 9ab20f0a-82b2-4668-a0af-5a24d26fd0ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_RcACnJ5mZyozZdlA
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"593871d11f0174813133e165d92a3076"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 9c7460f0-38ea-4691-a29a-df641a95214b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_aXEnNQr6XYRUYd8S
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "727"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"8726789380aa162af147ea5e9975167e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - f6a1b52e-f786-4d39-8a01-5405cdd97b22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_uyiatLDg1fvrodMz
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_fC4FiL8uMmClY6NI","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"9833ca5bbc5d333639fce4cd8327d1c8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - ff9a843e-4505-4bd9-81db-1ab47788975b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_RcACnJ5mZyozZdlA
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"593871d11f0174813133e165d92a3076"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 6b1ef611-fef6-4209-b4c1-b5a18ec817fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"d519e970a45ed16a40252dfa226a7a55"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 51c027cc-47c6-4c8d-b061-4e04400d613f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_PLdaBUbRa8nees3k","name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "375"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"2bb25bc3f7c573329389242e094369b2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -762,7 +1187,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "973"
       X-Request-Id:
-      - 90a7fdaa-fa4a-48ed-ac39-187ca5723e32
+      - 6da4ec55-5a77-4bd1-92b1-7b94c8129506
     status: 200 OK
     code: 200
     duration: ""
@@ -770,16 +1195,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_PLdaBUbRa8nees3k
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_5Kx4CeyJF3vtgWY3","name":"Public
-      Network on tf-magnificent-kind-daisy","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PLdaBUbRa8nees3k","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"},"name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:09:ca:7c:1b:dd","state":"attached","ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -790,13 +1213,229 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "374"
+      - "501"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:10:54 GMT
       Etag:
-      - W/"651a730357c543621a77ba20b26cce4b"
+      - W/"1598e57a006913ec288bf3b027376678"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 0ea62b8b-b315-4dd7-9f07-79454a4ec595
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_PLdaBUbRa8nees3k
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PLdaBUbRa8nees3k","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"},"name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:09:ca:7c:1b:dd","state":"attached","ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "501"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"1598e57a006913ec288bf3b027376678"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - c848bf71-90dc-482f-a7dd-6aa319bb411d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_aXEnNQr6XYRUYd8S
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "727"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"8726789380aa162af147ea5e9975167e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - 9159cf38-7de1-48b3-830d-69a22a32ca43
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_uyiatLDg1fvrodMz
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_fC4FiL8uMmClY6NI","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"9833ca5bbc5d333639fce4cd8327d1c8"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - ec0c7f90-35df-4000-81f3-a8a69df99340
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_RcACnJ5mZyozZdlA
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"593871d11f0174813133e165d92a3076"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 044cf7ef-3d9c-4290-9058-f18da49ee44e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"d519e970a45ed16a40252dfa226a7a55"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -806,7 +1445,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "968"
       X-Request-Id:
-      - 184f5508-2a4f-40a7-808d-94bf302394ee
+      - 76450d4b-551e-46fe-a1e7-331d7d8d30f2
     status: 200 OK
     code: 200
     duration: ""
@@ -814,16 +1453,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_5Kx4CeyJF3vtgWY3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_5Kx4CeyJF3vtgWY3","virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy"},"name":"Public
-      Network on tf-magnificent-kind-daisy","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:ff:8e:8c:0b:11","state":"attached","ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_PLdaBUbRa8nees3k","name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -834,13 +1471,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "500"
+      - "375"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:10:54 GMT
       Etag:
-      - W/"749b5e3458e15b93e0a44d0054131024"
+      - W/"2bb25bc3f7c573329389242e094369b2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -850,7 +1487,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "966"
       X-Request-Id:
-      - 8530ad39-9745-4fcd-90a4-45fdf45a7c1d
+      - 2d81b23e-2afb-4284-bf40-61fa7a88c41b
     status: 200 OK
     code: 200
     duration: ""
@@ -859,14 +1496,102 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Px0MdfXYD7HgsZtF
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_PLdaBUbRa8nees3k
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PLdaBUbRa8nees3k","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"},"name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:09:ca:7c:1b:dd","state":"attached","ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "501"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"1598e57a006913ec288bf3b027376678"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - f6572689-16bb-4497-ab94-e2fea7235938
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_PLdaBUbRa8nees3k
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PLdaBUbRa8nees3k","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"},"name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:09:ca:7c:1b:dd","state":"attached","ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "501"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:54 GMT
+      Etag:
+      - W/"1598e57a006913ec288bf3b027376678"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - c5278047-5b52-434a-bc8c-54aae77ab0f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz"},"properties":{"resource_ids":[],"resource_type":"virtual_machines"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
+    method: PATCH
+  response:
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -879,9 +1604,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:10:55 GMT
       Etag:
-      - W/"b2b6ec7a0bfab776f64cffad1aaebc7d"
+      - W/"e17d48af59d681de6be202c65b205907"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -891,7 +1616,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "963"
       X-Request-Id:
-      - 3e197cbd-808f-4554-a54b-81f2548db6a9
+      - 43ab48d2-1ad3-4edc-89d0-3ba1967b39bf
     status: 200 OK
     code: 200
     duration: ""
@@ -901,12 +1626,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_2uVTlEe5FHOgxBRm
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_uyiatLDg1fvrodMz
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
       RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
@@ -920,9 +1645,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:10:55 GMT
       Etag:
-      - W/"f0cb36967b5896c6aeed6654cacde3fa"
+      - W/"e17d48af59d681de6be202c65b205907"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -932,7 +1657,50 @@ interactions:
       X-Ratelimit-Remaining:
       - "962"
       X-Request-Id:
-      - f5f38f6a-5f67-420f-bbe2-618dcb5ca1b4
+      - 573a2283-2e0d-4b9e-a037-2cb7cd89aa09
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA"},"properties":{"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"resource_type":"tags"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
+    method: PATCH
+  response:
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_fC4FiL8uMmClY6NI","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:55 GMT
+      Etag:
+      - W/"99207306b7f43f7fd9d10e7d6db75718"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - 8a284020-6a09-46dc-93d7-f57be1c72b88
     status: 200 OK
     code: 200
     duration: ""
@@ -942,12 +1710,135 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_YSQN2KIwSfYPLZSO
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_RcACnJ5mZyozZdlA
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_fC4FiL8uMmClY6NI","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:55 GMT
+      Etag:
+      - W/"99207306b7f43f7fd9d10e7d6db75718"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - dc1b50fa-2e97-4986-9d36-bc1a1d3bd8a9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_uyiatLDg1fvrodMz
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:55 GMT
+      Etag:
+      - W/"e17d48af59d681de6be202c65b205907"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - db0f5621-9ae7-437e-b1b8-a944a19dbf19
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_RcACnJ5mZyozZdlA
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_fC4FiL8uMmClY6NI","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:55 GMT
+      Etag:
+      - W/"99207306b7f43f7fd9d10e7d6db75718"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - 1ab1c824-b8b9-41a7-86d5-9fe2401af5c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_aXEnNQr6XYRUYd8S
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -962,9 +1853,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:10:55 GMT
       Etag:
-      - W/"e5de10040cb0291aa5eba35f27a8b37c"
+      - W/"8726789380aa162af147ea5e9975167e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -972,9 +1863,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "957"
       X-Request-Id:
-      - 88894215-a6f5-44b2-9f1c-7e449f0b030b
+      - 38175748-1a94-4128-b6e5-f7346a5f11c6
     status: 200 OK
     code: 200
     duration: ""
@@ -984,13 +1875,13 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Px0MdfXYD7HgsZtF
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_uyiatLDg1fvrodMz
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_f1CWVVONynnHAtwk","address":"185.44.252.172"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdXlpYXRMRGcxZnZyb2RNei5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIwWhgPMjA3NTAyMDYxNzEwMjBaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANcbZYjabYiCYpKs0UzXYCD1BPQMbBjo3xyl\nvBg+azlyrwM/x6pKqL0tVL/U+6PRU+UyIn+PrVbdaNkaSD5eGrC1N8eweBaByp7j\nMlRhjruxFaTEjxC2NrQczUJDExyyEFmRP3EGsx9dFKI1HI4MYhVkGYIRva7ZDnQd\nA2fTpfQKXbHMrIdUBA/+i75wDyRbqcJO0pagLfUHhMBCRYn5pib9xJ81dJbRv+Ls\nwJdr6J4dbUwKSGdweTaDos89p5T+Cs7NGuqLgXnWwxS/pQQK72Q6I+7Udlmys1zi\nfecpr3FbewTkUOCkjlsm8RcSFPGvXueUr+vD4PVGUIX81/ilnvlKGsZK35jUQPke\nPpmn/6ChUTF7BlyvEUjph07eOjbVv6kk72hH91uqQTJ90qhW0BvLujVvXwIpZS3B\n2lu9Y13ZvSMpTzmSa4r1oplSndE0bOnrLGKQJf7UvkMeTFqykyT1Lqw5je6yebbU\nMca8XJmZQkmFNMYbJggEzwl9eQ3S5QTa3qhh2N1VcNWRPfLTjIR8BaI7xajokOUL\nG+v68ADvFKEoOBkexf+J1nXI0DKkuUuq5EulsF/phVzJBwZXW1OSztnnDrq6oZGX\nRZEeT0/EZiKk2DIzddueB9r1ldotR4gtoSeFwijSM/mLXor2M0oyY8vN7kH9yR4k\ncAp6LqADAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRx\njsO3dQ3HMWXNDPrUEn9AMVAVazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFHGOw7d1DccxZc0M+tQSf0AxUBVr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl91eWlhdExEZzFmdnJvZE16LmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRJ17zrWwk1S\nrOJ0pVZaM7cvTD1irBOVK0PVCac7KPFguFQsKqW5w/Wq8W8O/BFklX9kywgVc4gC\nlWYSKKLc8B5fNT9jtGKPR0lmsCfGRhhTbkHzRCmxlzaJqhXeiPZusmm23IeDzIWE\n6zdV2RvhfuO4yLGgB8BuNUVsr6yLLlqlt6f4CLr5sXpQa4PO/H0Wlqqb/q0goK6L\n5Wk9jy5kwUREZ/OzZefX8uplfAkXgxIPxCN9rU2DzfyA2z6DyY21OK25exNUu1Q9\neqRgzNoTxsHAUxbSX0TMq8j6koH+xGlYCEaFB5HnOvE6WeXKOytfXue92CTCaqcZ\nqVtWKLEQ6zqwU7TQJs49E6ecyB+uEOL8RKmktnxWKGz+MoNO+6/bu/MKp7pIsa81\nRaw5Q3T3msFuM+1Yqnsi55I/7Ttro57A2J7lHAxU9T7HhKlUri24jmREgC3yuH2i\n0kinb6aVtwNhEntk1IvNq0NcTMZUlRnGpzJ92piy/j6d/SSyC07uA/TFq2Mxpecl\n2p5aTy72ChBGFj3TWHRhHqf1UZfhUvMR/s0Cob+WLKhG1IrXztu5tA4oykoze3RT\nnZ/JK2jKrUPkGepAPSoukphNmipIUuWQ1J81L+sv8LKP6pEkw/5ImudIg5XCTwBd\nK8wpy10r/FLuKfSvlYuCtKy8SlU4miA=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA1xtliNptiIJikqzRTNdgIPUE9AxsGOjfHKW8GD5rOXKvAz/H\nqkqovS1Uv9T7o9FT5TIif4+tVt1o2RpIPl4asLU3x7B4FoHKnuMyVGGOu7EVpMSP\nELY2tBzNQkMTHLIQWZE/cQazH10UojUcjgxiFWQZghG9rtkOdB0DZ9Ol9Apdscys\nh1QED/6LvnAPJFupwk7SlqAt9QeEwEJFifmmJv3EnzV0ltG/4uzAl2vonh1tTApI\nZ3B5NoOizz2nlP4Kzs0a6ouBedbDFL+lBArvZDoj7tR2WbKzXOJ95ymvcVt7BORQ\n4KSOWybxFxIU8a9e55Sv68Pg9UZQhfzX+KWe+UoaxkrfmNRA+R4+maf/oKFRMXsG\nXK8RSOmHTt46NtW/qSTvaEf3W6pBMn3SqFbQG8u6NW9fAillLcHaW71jXdm9IylP\nOZJrivWimVKd0TRs6essYpAl/tS+Qx5MWrKTJPUurDmN7rJ5ttQxxrxcmZlCSYU0\nxhsmCATPCX15DdLlBNreqGHY3VVw1ZE98tOMhHwFojvFqOiQ5Qsb6/rwAO8UoSg4\nGR7F/4nWdcjQMqS5S6rkS6WwX+mFXMkHBldbU5LO2ecOurqhkZdFkR5PT8RmIqTY\nMjN1254H2vWV2i1HiC2hJ4XCKNIz+YteivYzSjJjy83uQf3JHiRwCnouoAMCAwEA\nAQKCAgAAzOF1/ri38Hg/wHSE5dY949DRZvcYqUvPNk9QAxzGBBxiQDX/dwilWjT9\nrmQDSi+W44wHpSK0Id3BKl0Ix7PaDXU4K9AT5rFjdvKZ0sUZA1cnxkgb+/mRy6ZN\n2qRdunc0xhq80mq52/r21t4U1IyhihOi4sBYarFS6EVkzlTzO/346osyc7MSK38c\nmxvLUFX+MD84qpQ73FEiSqd/PxZfAG8KAppnnJSAr83QTRP6pp8LUIx6v2CMEzWj\nXMDcsoyavrOcxMkbXsZaCOkrGIP8f6Tg6hnIn/wVL+M1CCLWzUwqCqlsXzWyYXTg\ngkOMBKbZ6Lk2K4PmQGKN+mYD+aXGQ5Z194L9nwLZZRVRT1rGRh0jK5x+wDo0eZVs\neQpagS+ZDh0WRxk6SmO6icHlwqH6u08Fvc1piTb6m3DvBleVqT5UhM60EGSsFVCz\nAWH9T5oAU/yQ0JGeLLkdUl71XNDucCTZuDghwAIO4ALTQK+OLldi5mMQc+mIbO2M\ne4bllppDbzAlT7WvS4lwlVxjAiJtvxSpiywscBwedB6gYyqcPY/pnzKJfvhRWAyP\nBxmcbV1sj4Kj9Yg8zOdoxve/j8PxcS7zmVrG4/PXZGwCd1rMdzbhaLTif2tPnEz1\nA2dK7uBHvp67dRJbHtYyzk+ZD8yx7frE6Gp+ZpI7MiPNRaqO/QKCAQEA6ynqmRLg\nIxCak8Xrp8bs81ndCAm9YeRQBwIJWYfyQIbvw31E2LQQ0yc/O+lOqYiKFBM9yBJB\ncBCP9jeG32G5cPPPU0Xb0bOEU0a6392Jfu43f3iWbl1N42Qdb9HNeKHPVWqaZD+S\nP9nu4qLrVpkU+2z75Fcf1Mn1rQ7eCeKJMnzvuMm1P17mTdqgdXnBpj7Te1DMRcDD\nw+YGEQzOl6IYweJzAwR+AMr6u4FO3CdXHnKtXANsDF9ojferGm4s7+AUTQoQlGzl\ntuaw+L75+2xISwcAywWtJySKXrY9wBC+J6/3d7sT05Edr34BKozc+5VtqKA02AR4\ntbWRAhkW6kgpZQKCAQEA6iqLlMwOm1jjmUv/AxuFE4ykVIqAy7wSIRiMP8KrQaWp\nD2eUGpDATj6Y+xxtPkODEPoIHGCFRXnmUoFFREGuvSMrGHjKUNTsOZjziPqyLY4r\nWL2hS4Aq5dl81psHQEiPHUaTP1OkkZ9g+yWXJIWJ+XQb/wtQNTnyAxYBYEqhJj/M\nN1h+ZdlTXOgl61PQvTSecddaElAyXPPFtCghR6jSH2L7dbOqVUu0zbwi6H1CFvfH\nf3zQuBTyqNnL4jC0HlVob4a4jY6AbpN+hwGLutgE1eyQWUBelS4dVdISa0S2WsJ7\n/gQXwGLjCYdGaSTuIV5G617q7tebBJHIlrSo4L7BRwKCAQAhFlu4v+wjYuGs6wsW\nJyoNr1YnHF+2F06fPc0c+MDADXxMsCJwrx0y6HHANzpnJhvvaSmnLdJhNyNaTEPA\nyFo0J0nDeK/OGIkEwo3mk6AV6OSMHeZkjuI3nU16/zT+xR2L8hzZAAzOyRYQc0XT\ngGRwX8wtO4jyApx7hfz9vQ76uJNuF4tV6D9VMu6iuMfjYTGWRy8GnXGt7X5rBbdH\npHoBRaBTC13DNMwEd9Qlq69ZTF9R8/VO5Fmsp+0+IcRW19tjX4gnqg7EJj8+MHix\nxHGDhO+6oQjU2hJR8yhLDtACe4LBKORIP0HDAGKfnwQ0rbipIiltP2vQfURy3B7a\nRd71AoIBAEQWet+ZNeYVwpggcNYGentkuaObYjfbR6o36Q/hGsrL0IyaIYZX8JLP\nwMvDSECCgOm+yfz2U8oP19jFnc5rCtQUFcPX23wFbWqR/r4lpwl3/UKgYPYDHnYW\n9yWvjjwy3Oo2Szpup7twDFL6ayhDbAsMp9dRAtF3N9eN3niROqpUgpzVLmuO9Z5e\nIih7Bob9ddTEOXx5tSsx9pqb0JF1lSNrNJLU2wJSMRBhVAUl5sGm6ms3b7kW3jga\nnB3462amjude1OrUNKPyXygCWw7JIR7S2mYZQWc/MWhy3Mg0ApIBWuxRZFacakeq\n/d40zskFELn/r3AjYP/DJAAuJ6yxyqECggEBAORD7r7VP3PGyW6ta/kLGmK+NE3P\n64pv3HKBALlpYfwHPVScxfQnTRZQ+AgAjax+Ocq8hRTcrhxjWL1tiKdev7myGsgn\n2GfJioMsPr5Eu8Yp0DM+zl1/OHtAjSWmcswVCFvPi7EKLDweJ3NgiL17vH5yQHIH\n9aOhAnls6Fve3rRPG/zVnqbkKSJmXOBPBili+vxlUFIMyS5Nz7jiZ+a2fHbFd1HD\n+GlkFy0kS/KhWcMMNL7qyo8SNw0K1XDngPzZ++6Yk/Z528/bQWBf2WOB1nUoWwo0\nIUbpgePOTocqYablFVM7YO8wi8fNtAlir7I3nU+5qzCyM4LrOxneBBoKmqI=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1003,9 +1894,50 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:10:55 GMT
       Etag:
-      - W/"b2b6ec7a0bfab776f64cffad1aaebc7d"
+      - W/"e17d48af59d681de6be202c65b205907"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "956"
+      X-Request-Id:
+      - 91bab0d8-b71c-433d-b286-ff037de65c4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_RcACnJ5mZyozZdlA
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_xTqlDlsJLHcpbifu","address":"185.44.255.46"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUmNBQ25KNW1aeW96WmRsQS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTcxMDIzWhgPMjA3NTAyMDYxNzEwMjNaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAOXjx5aRs2Ioy5y60BrWtBQ7+d9fYOhYq+zL\ndKXUBKdo0LVg7GE59TvxNDijZcTzXlrlO6ww3scwnEm0bTpdr1j0Mvdqt+cSHNz2\nC6H53sMlVtiOulXxKJq795YnampcOwDvoqpXn01Olarw0k31fMbE8DZ+fauL4fSu\nnktAWvKvpsRINVjqnoZHELlLvVz/HjXse/sg2EEREAbXlf7JO0A27ILmfrPqqXNl\ne/gAMNKqI/bV+nxuMn+FWAbkhtfaPCA+LVo14YdXuB0LyG5Mni+brSwCLrWSLcPu\n5NrBJA1KrSIkwicHuTfCWZ6SYgjlpNY2EC4Ald0pVcUCgvLJGVpPfcQj5MSnrXv1\nyFCxjC56xoTMz88ZWBe1zcSyxiPedFr0jWt76UpNlwmrcapxkYEQ5rBmkJ2z4oY7\ndnwT3xjN9/Ll+msVToXQDSo6NOzO5+3rHHWOruJkO6zBWZVYFoTE8zcnL68uTq6Y\nW4yA4++zpcfKSlEYnTQTkdm8sJOstfqCPf04D0uirLwglZ/b9omeGFaA6x20HYsn\nTi/pCeC+XTjHbG3/HAgMrVxjrI+6gYh8o7TFhvj1DIFyNdxFqvF1/59aAPPFvBOl\njYqOf92pyhCUsh8vXfOt7N8qeIszO3EYdRBLtuXOaHSgJxTi4uSNt9j55z20wrm3\nmCzaiU0nAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTo\n/ysk54B4tveVyeMk+ssmkNomgTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOj/KyTngHi295XJ4yT6yyaQ2iaB\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9SY0FDbko1bVp5b3paZGxBLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEADaz2XR43zxPt\nZ5SGb0NscSHgr2HgtWVUjcGPA1vLyadEs712FC4E+wagqV1EJkkRA/LjmoPxYceB\n+AMxGkX8lGuC/Q4e6HhrCY1hmrpE7TOxVPAyTqLV35yCMuzOWnXHwv4ClG+6HLsE\nnNWYlhIfaK4u0o2A9BbnFST78GMk+Le5wezySWlS9LamYKxv3zebJ4g3CsHrU+4P\nOtjpDhgQGu1geJwUzvwuwpsHBDCJpjNoh7ll2NPcTtps2HqCNEm/2hXPPWbgyped\ngHUVoA9oYwARmBNXym0+ZeYlz7Zc6qWr3i3WFJiWSNf6NCZM9TQperEOgHiBuflI\nLY8PEZ+8uuwmu6PWOAPrbHV5y/Xax8v/GQekfl3GMuaEg0rXvUJALqrouS9MAtvP\n2Q+lZiP2L51g42PJYlq4mhfTViaVi/C11WCaKiUJ0a9u5fyzmsfb15j6lTapu179\nQndRIGyh+cPQ4KYqChQCKbGx/Ol0OdLTuZHyKc5+0y36RldDKlnLlqySdkfRGCNv\nQofSqKFlggDYsinpqW08zhWttvn5CbCh/4qH+0kpAWmDkgKmvh/eBV2afCoak3bg\n8KAaJchwbX8ckoLHAHQ0VsckfaRe+d7ywcjoCXzp8gPrG4GzxLBaEhvaw8gGtIEy\ncoAcqUmujMQTtabp5fNIqaTNRNCU08U=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA5ePHlpGzYijLnLrQGta0FDv5319g6Fir7Mt0pdQEp2jQtWDs\nYTn1O/E0OKNlxPNeWuU7rDDexzCcSbRtOl2vWPQy92q35xIc3PYLofnewyVW2I66\nVfEomrv3lidqalw7AO+iqlefTU6VqvDSTfV8xsTwNn59q4vh9K6eS0Ba8q+mxEg1\nWOqehkcQuUu9XP8eNex7+yDYQREQBteV/sk7QDbsguZ+s+qpc2V7+AAw0qoj9tX6\nfG4yf4VYBuSG19o8ID4tWjXhh1e4HQvIbkyeL5utLAIutZItw+7k2sEkDUqtIiTC\nJwe5N8JZnpJiCOWk1jYQLgCV3SlVxQKC8skZWk99xCPkxKete/XIULGMLnrGhMzP\nzxlYF7XNxLLGI950WvSNa3vpSk2XCatxqnGRgRDmsGaQnbPihjt2fBPfGM338uX6\naxVOhdANKjo07M7n7escdY6u4mQ7rMFZlVgWhMTzNycvry5OrphbjIDj77Olx8pK\nURidNBOR2bywk6y1+oI9/TgPS6KsvCCVn9v2iZ4YVoDrHbQdiydOL+kJ4L5dOMds\nbf8cCAytXGOsj7qBiHyjtMWG+PUMgXI13EWq8XX/n1oA88W8E6WNio5/3anKEJSy\nHy9d863s3yp4izM7cRh1EEu25c5odKAnFOLi5I232PnnPbTCubeYLNqJTScCAwEA\nAQKCAgAaUJhhpLxPFv1hAO9eYHJM7fqcdkYDrVbCFx37TMmFl5VrFbT+giG6DVJd\neLK8YzagmqSEgYmWwnqOuJ+s3S7RCg76zFVQbCiFUIgkr+ivF4tD5GlG+ivG3o+o\n4/Ul8fhyaHvgb4GVhKfUNpcpg67B7/wmjhR45Qe7OEZ4CwioxrDaagDqnzIAi9+f\nCPZG+rsCEC0MTNuu7bLocu1sCgEwHg61AzPAs4gBuhMBNesLdPIDSMYl+n/pofa2\nv0UCLgHQ7QfIT5Tz0aI1IkqnTuTn7TQwQ/BbKhL2s9YFhl3ymY2M9Ck3SjE07+3N\n8tKpqGPV02rHC/EbrPtw6ZMvaGlFehfAvdLeq//y+sidoriEeZWl29khtkE7KFu0\nxLgYINQhoO0NYB2Gz0lf5GcCNRcsJ36pQvfSZ0gWWvCt19sytHwx4eSFeQDlezeY\nflhAj2SKaAAKvelw6dZRb9MFllyJY3v+ra5qbMOpoN1r0muCKd6wIqFocnOyVP27\noxr2ja3wl5gV3Ohz99kNj0QEAqzszYnQbrupNSziCE/pYVxxh3Xg/0bwkKNLJhGd\nFmmD+HHyDk9DBHYe6UT6eCvdleepShGs2yg8czDkIKxb5gqLJNeR6VlSG97sN8yy\ntik3TCOV7/2SSbcCzfm/ofSdZZxrBobg9oxnjMuLlbPV+K/N8QKCAQEA/hWKH2px\n6Ldhz3022fWf+Yj9kaEZWTZjsKzt6faSqCKHA4Ru2RnYvBvpFVUaP3v0hk96c3u0\nvoVduwtAw2Tnb7cTgRD89BLTcJb5bDyqnqUzvLpAuACtoDYZUg0rMJ0hQB6HUMk/\nWwWNe3sS6DGMA9tPcksMKkmFWx6cj+VS/SFNR32Sr4ulmQOmGSaD7GUSQAxDicvL\nHF0QLNc2f+TflH5gKIg2Qm/fZ1CQFcj8YdECBfqefH3cicmej3+0brxAHpIPX1RA\nwvrYUtKuvJEcpXGQ3McHAftOrMmj6b4igJ5XQoNMdHJsXZqLJ63doZMk2GgfUiMx\n0VNrBdhAZ77P0QKCAQEA55+JmxFPNQM6xskfIaPKXL7C8zaS33o3DR+1Y9V+PcdJ\nnp9tj6zcSgi0rew+hRAtZSrjpxgGg0pBBP5InzU8SxWSkfXJvM1XvpIzN9WLmQm6\nc+pBJd3yfzH1Hk3ikusM8WumeEkwJcwCDuDTsR56Ovr9boSmW15O9ZmUZ2rSR+0k\nYxqjbmRk8gc5FlgVF8lnUBSSe619RwDciPpyErTOKU4Msh4MQ8ofQrWmBVR84GEK\n3Bpu9Qg+w4vgjeZGQ5+Z+CtVhHZlpW2qcvHB9OsdBCOromZ5i+HNeBa9x7HpzCkE\nNwYlKr57X/Y7kAug4xNzdqlFAGSW/IfNRzm+cQNDdwKCAQEA2RsQlb1/rakcc437\nk4w08KTkfk5YeYlm720kMZlWQUKXeSLtEKbsMffrVyYLspk5HJbG++yFSZJtv8hi\nw1LyCtw1V0Br1CZN81OdtqWz6LEiny3K5S73LQFs61aDRBvPcJllaFs9vonlFdDZ\nG/xSNm1r2i5UK8H8qBplDvOV0ONmxCKBd2xsyG18vNrTOOg4CvAvuYugdxDyJE6U\nq/2mKZ0+jwOs0WIEU6RcKbE+LlrITtGSIK/vBPF5ggZN550FcNm/NuaoG7L5qvOJ\nCWk5QAjlDjEmRMQ2up/lZnHny10BFL1aU9n9zJGkO/hte4Veo2d889NM2x9bQHhC\nuCMsMQKCAQAsOGktEcDtfhBao0suQPcBfen6RREFWW/pMYSP6tKPONz1S7q/E2F7\nQO49xjypas0/41BTNmMH7cU8DtAOlTtNmnDBLQu23/1AhOkCX+Km9RSDzNVjRVxm\nrEL/5h67reRqswK1NEPc83XxITtJNWhgmkqILwsTpo2slgWfOOWslbm8sflBuikL\njBV6Dpb4U5tFzqeotRaV17RC8o2UxLAXcq850kLFLnGJauSnX9n3fI92NhW48joJ\nW0sjzDLd9jqPBrbs8y20x5sjFsTQ3ZJMmALMnoPWEOYJZ04UMgNQ1wPW/XVbE8K6\nL2hvt8ifkbcZkHd7+7hXvhWS45NYQCdBAoIBADaRK+9Ke3RMXWwwKHeLhwl6YjES\nXaIyC21kyjUmQTv8nflJUc9BCFF4qqikj9GgiL2iDeSPbdpOmN25PhCbqDLPrDFy\nfm1Qbcb+a8abFuwIfIB0Zi225qHVXU3FjAnmRXtNos84LgrdZutNk3qu2mfjoejq\nT5wwLSxNppozTUWPKK2BtUJIzzEIz/HIlR+JemlQ3iyBEXmWvhXdvYI/ZueDTp+g\nV0gk6PlQiFlcHWMXNpVh8OncR13Xm4txQe18Baym3JB0/2/X2u8iroKrrox50OOm\nZ8kGrjy9etRH5QexqkuqafSn1+IppZqul02xIqybqQMderDfYEikZkJCCj8=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_fC4FiL8uMmClY6NI","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:55 GMT
+      Etag:
+      - W/"99207306b7f43f7fd9d10e7d6db75718"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1015,7 +1947,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "954"
       X-Request-Id:
-      - d5db116c-c145-4d9a-bdfb-9d81640d73f9
+      - 4ee60bda-02e1-41ce-b4ff-a8fc4fa8d050
     status: 200 OK
     code: 200
     duration: ""
@@ -1023,15 +1955,22 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_2uVTlEe5FHOgxBRm
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1044,9 +1983,137 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:10:55 GMT
       Etag:
-      - W/"f0cb36967b5896c6aeed6654cacde3fa"
+      - W/"d519e970a45ed16a40252dfa226a7a55"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - d7b7824c-4e01-4081-925d-9f3cf8be42fd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_PLdaBUbRa8nees3k","name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "375"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:55 GMT
+      Etag:
+      - W/"2bb25bc3f7c573329389242e094369b2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "953"
+      X-Request-Id:
+      - 5f1cafc9-9cfb-473d-b234-992fd19f415c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_PLdaBUbRa8nees3k
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PLdaBUbRa8nees3k","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"},"name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:09:ca:7c:1b:dd","state":"attached","ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "501"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:55 GMT
+      Etag:
+      - W/"1598e57a006913ec288bf3b027376678"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "952"
+      X-Request-Id:
+      - 253287d5-a694-4ec0-82a3-7b825358ad41
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_PLdaBUbRa8nees3k
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PLdaBUbRa8nees3k","virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah"},"name":"Public
+      Network on tf-rainbow-ancient-cheetah","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:09:ca:7c:1b:dd","state":"attached","ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "501"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:10:55 GMT
+      Etag:
+      - W/"1598e57a006913ec288bf3b027376678"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1056,7 +2123,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "951"
       X-Request-Id:
-      - c1e1d6d6-4400-4899-af7a-248496418e0b
+      - d5c31769-d4c5-450c-92cf-f9ddf55c1e99
     status: 200 OK
     code: 200
     duration: ""
@@ -1067,19 +2134,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1092,9 +2159,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:10:56 GMT
       Etag:
-      - W/"5604894125c7c3ff959d100192543236"
+      - W/"d519e970a45ed16a40252dfa226a7a55"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1104,7 +2171,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "950"
       X-Request-Id:
-      - 3ecf493f-18ec-4c0e-8785-87bfbebfa56c
+      - 92342826-a9c5-43f2-975b-a0cca239de2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1115,917 +2182,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_5Kx4CeyJF3vtgWY3","name":"Public
-      Network on tf-magnificent-kind-daisy","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "374"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"651a730357c543621a77ba20b26cce4b"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "945"
-      X-Request-Id:
-      - 4d274b68-4152-44a8-a2a1-e8871441fd31
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_5Kx4CeyJF3vtgWY3
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_5Kx4CeyJF3vtgWY3","virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy"},"name":"Public
-      Network on tf-magnificent-kind-daisy","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:ff:8e:8c:0b:11","state":"attached","ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "500"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"749b5e3458e15b93e0a44d0054131024"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "944"
-      X-Request-Id:
-      - 6f307d4a-82f6-408e-8c88-100f55f1d670
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_YSQN2KIwSfYPLZSO
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "727"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"e5de10040cb0291aa5eba35f27a8b37c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "941"
-      X-Request-Id:
-      - 459eb82a-4ff2-493a-a8e9-c9ae624c32b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Px0MdfXYD7HgsZtF
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"b2b6ec7a0bfab776f64cffad1aaebc7d"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "942"
-      X-Request-Id:
-      - 2262f882-baff-41e0-bed1-97803ae24f28
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_2uVTlEe5FHOgxBRm
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"f0cb36967b5896c6aeed6654cacde3fa"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "940"
-      X-Request-Id:
-      - 749f176e-eff9-4895-813f-835ead42bb27
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"5604894125c7c3ff959d100192543236"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "940"
-      X-Request-Id:
-      - c6384453-932c-4b46-b3f0-fcdf12fe3d5f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_5Kx4CeyJF3vtgWY3","name":"Public
-      Network on tf-magnificent-kind-daisy","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "374"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"651a730357c543621a77ba20b26cce4b"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "936"
-      X-Request-Id:
-      - 43534093-216c-4d68-83ed-1cc969cb5b0e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_5Kx4CeyJF3vtgWY3
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_5Kx4CeyJF3vtgWY3","virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy"},"name":"Public
-      Network on tf-magnificent-kind-daisy","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:ff:8e:8c:0b:11","state":"attached","ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "500"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"749b5e3458e15b93e0a44d0054131024"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "935"
-      X-Request-Id:
-      - a5d39a8f-806a-4d4d-899c-b88971b06646
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF"},"properties":{"resource_ids":[],"resource_type":"virtual_machines"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
-    method: PATCH
-  response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"35f3136b0c94aaa164da8d380ef6b7da"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "931"
-      X-Request-Id:
-      - 49e535a2-30ac-4ce5-86c9-14a61371dff4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Px0MdfXYD7HgsZtF
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"35f3136b0c94aaa164da8d380ef6b7da"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "930"
-      X-Request-Id:
-      - ce42a467-8ae2-4fec-8a1a-03e2963f48e4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm"},"properties":{"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"resource_type":"tags"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
-    method: PATCH
-  response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"ef801f90cfb02a7381432d13735e36f0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "926"
-      X-Request-Id:
-      - f91bb2c2-1f34-4e0a-a4c7-70bdb7dd070d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_2uVTlEe5FHOgxBRm
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"ef801f90cfb02a7381432d13735e36f0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "922"
-      X-Request-Id:
-      - 13e1cb6c-7c64-48ea-8e19-1a50099f84af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Px0MdfXYD7HgsZtF
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"35f3136b0c94aaa164da8d380ef6b7da"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "920"
-      X-Request-Id:
-      - 60488dea-f08f-4ada-ab8d-220a1fcf9b2b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_2uVTlEe5FHOgxBRm
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"ef801f90cfb02a7381432d13735e36f0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "919"
-      X-Request-Id:
-      - 3dca6886-c186-470b-9ca7-95a01962eabf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_YSQN2KIwSfYPLZSO
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "727"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"e5de10040cb0291aa5eba35f27a8b37c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "915"
-      X-Request-Id:
-      - 9149de8b-3b21-46cd-9c3a-4c5ab57b5d02
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Px0MdfXYD7HgsZtF
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_g9SFxpQruw9kyQ45","address":"185.44.254.42"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfUHgwTWRmWFlEN0hnc1p0Ri5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMPpgnKNIaAoC2vWyksd2igUaZq1r5G8Veq/\nJDqIqtSVIFt3F91VTtdpuLAcGsl9WNqDS1FfLPPkxxa+1sQxI00FwXxIeoH9jlD6\n3E6yablG+UzJYu+eZaVkyx23wA9aDkbw4duQ8WugjKZTZ54rYOtPwSYOQ1e14Eqq\nMh1PeAN+8fgOzkVf9ZMIaF/pGAG3EkSvTjBAxAQQu6n2id1tCIwLIqlGr5Vt6TYt\nj4niAyMLwvdJ0c+xzne6s67iW+9vmktcpoS4Kxkty2CSz53xdK/uu8EgARJc+mAM\nScyf0pl2Ypxe0lsXFZXAajZ3VhJWavSb6AblLVjv90pJmV8fvSUK43jHsfktDgcq\nykFXnGxuNQyCWj6+9gAgqdQVE0atY5+mIrBj4OXql6fsw961NhWqsr/riDzEDzpi\n/BtdgHzc8jGwPUum4TKeNXiNOtQ7rPeAUPMxD5+FK3L+gKy+xo/IEvemIM0fC80j\n6cJ58PfVvgklzLS7B8bZAkLqRvpxh9zWo8TSTlWmgQ+xDKu1Yq+gSQXueqteo5er\nA9AwpOSU5RSKShQDn/3GjikeHCqyccz7KF0J+uticr76WReNuzEDF3hJHJvHfl58\nAaCxkpcpM/6783Ir+SJrzG91St00RZGaJP4D2nsjXjD/YPmbzRgf/Egl2FZPDKbQ\nVPSi2yUHAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRS\nJsYKoQHTyOoAbP3sjXIgkSH4fzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFFImxgqhAdPI6gBs/eyNciCRIfh/\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9QeDBNZGZYWUQ3SGdzWnRGLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAtrWXc+hreYLX\nRLiYzZz2Y5A33mH2RfFE4RrO/Vymos4yB0C+VIhE9363FYE7MB3UF9cSzKwAbh/e\n3KvADaGYy8zbQ1PKlqpy1GG/rOUxXaYBq0GyyfgcljidXzimj8ws0ilytCTNpuIE\nmwaNCyNxDEpAlQDRJm5mCy+Lmf0cNz/iruAtCgE5jvKy/PeeF9wFxAlt1MpJAArR\nlYHpVCVbdI7WMNwomNeBof/ntYD3oAI/ZJf0KgkNcNOHdkUf2MgW3J06Lwmuvm8Y\n1GsnI+Lkgykyu9x4wldc3WjfiDlxWM0RDZHG5lb6s8Ak0YwmQUGYKYdWlic3zyAU\nyWEKxjq5GfWebYq3YRTgTFsO7OGhMM2OP4xt21TvdT0JQ1J0006n0xIYo+KHxXkp\nkSLBSkbJBLa6jTb89fqlqLSjwS5b64ZWlQ3VZgBnkGsWEjNki92X/9xZTtwcPp9E\ne9dzgrrwYOPnywYgHnqEKhydXdUcBPnGsyqn3pmgr6d7SDYvcZx4/BzEakCYLowm\nx/1lQiqfXLK4S65a/JlmoEUaKOrU1ovrbgwk4qod4rYTdp6R0C4y3COWZQJP3UBb\nZpkHIvqIEYWG/F9tkvEqpIhm33gMrDVIR0eyldonP7+lI5ZYZA90dSVqC/p6QXky\nbQSo8VFswZb2jTwjWl/GmZZqEPAvNc4=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAw+mCco0hoCgLa9bKSx3aKBRpmrWvkbxV6r8kOoiq1JUgW3cX\n3VVO12m4sBwayX1Y2oNLUV8s8+THFr7WxDEjTQXBfEh6gf2OUPrcTrJpuUb5TMli\n755lpWTLHbfAD1oORvDh25Dxa6CMplNnnitg60/BJg5DV7XgSqoyHU94A37x+A7O\nRV/1kwhoX+kYAbcSRK9OMEDEBBC7qfaJ3W0IjAsiqUavlW3pNi2PieIDIwvC90nR\nz7HOd7qzruJb72+aS1ymhLgrGS3LYJLPnfF0r+67wSABElz6YAxJzJ/SmXZinF7S\nWxcVlcBqNndWElZq9JvoBuUtWO/3SkmZXx+9JQrjeMex+S0OByrKQVecbG41DIJa\nPr72ACCp1BUTRq1jn6YisGPg5eqXp+zD3rU2Faqyv+uIPMQPOmL8G12AfNzyMbA9\nS6bhMp41eI061Dus94BQ8zEPn4Urcv6ArL7Gj8gS96YgzR8LzSPpwnnw99W+CSXM\ntLsHxtkCQupG+nGH3NajxNJOVaaBD7EMq7Vir6BJBe56q16jl6sD0DCk5JTlFIpK\nFAOf/caOKR4cKrJxzPsoXQn662JyvvpZF427MQMXeEkcm8d+XnwBoLGSlykz/rvz\nciv5ImvMb3VK3TRFkZok/gPaeyNeMP9g+ZvNGB/8SCXYVk8MptBU9KLbJQcCAwEA\nAQKCAgBSUgJgQ/FHLMxvyddC7Q5IHRuqyIE3iZ3If/ynI9o0bV0lUcuTU09HsMLM\nLWMMG0GEv/qb/JQU/6KwagwwcD1XFf4RTRs9F9//IwoDf3BxS+NhYpXR/grUDqBS\nom1vhfXN1VXyPttS0CmJki5OBgg5mE+ewAuIBYJznURlkIjrXyIpi38dI4868yN4\nead+wQBKICeImw5Cbw2MA242vqQCxIMSAgOxlHeULlzMIU4UIdMQudIRpbMOGEN8\nTt02pPx+gjXuOrzRXa7Bq67VvSm862G1as9Ieg0y4rb35ohFt7sD3cwiPnbxb+Kx\ndD+UgP98PS6oBxCg+GQ+sOJjWCDPfaZrcnHy/SJwd8ynX2iieBGlH3Aau/Mq+EjF\nDKyA1IaeGN5SPbriHUa4clqe0oVwPy18LLr0NIRB7WcDlEr4nDe3boS1AVRzwyOP\nLSYuJ/S9JgKFQ5cX6m9/35drWFHToUOurPynOAmuUWtsHi+d3THXApmnCqczYvJ2\nsvRjrd6AOiqCZSeOi5dIy5JlaDqqqpuLQWzQu/e/t55bfCOn3xOERPqfsrA4irEm\nMXEeVH2KkLLLE6x5otKJZ8FpUoT4bgFp9mC6u5dAwV1J6ET4dm1q6NjZG89UmjqN\nQ/C0BroISL1TyCH340tAchBXCW00hcTiEhgUAoIZqHPINOqHIQKCAQEA4lK2GO05\nzCS2xgF7HpFkLdprYWXwufoAlJ3At4dypqDQBVFGvw3C8SArI5N2nr3eDsqTCIRP\nP0Eo1T2FLG/0kG3Pkvo+WlDwq8rkB1nVaoQgdlIAKKElFSFMuWdklRG+amRLRmb4\nWe3Ygx4ijdPLJ6/AKEzialYaSDK4RgWu4680mg0kZ2mx1nYIK/QkVqC6zHoNgmSw\nE7SysA+4D/h2WG86u3NTQ0sr23FXkNdRqR0WJdCpxGSEIYQQWdxRh7eID5r3G1oz\nxNDA0s2bsIy/LygQ4hqTL7ssJWPgniZU7OnamnTk+4EGqtwzNku+Z7J66BH4x4nj\nbD3VRUqNBEmaeQKCAQEA3Zn0HLFl5sOX9DcEUjeeP8IMYPT0MtpbGgDVWJYPB4dF\nqHlncw+QS/21jq/r6qBG4uVDKJi2/e5EQjHG0UVdJzxzwaMH42jQEl1SH2Jslfio\nFgc/k8KmrG75RBUuziCeGKegmUHe1ze9dDaJKzNkYB5r5yBaOTWf5x5SPMcZceZu\n7azNYJfklAcyG3q5qDKByKapxFgAh0xq6GqEpbq6Zx4B44Yl8CIk3p8M/I0n9xfG\n2509ACrVZu8NR09qmtgukPdYcc0t+vZiNwt+o+KHm2SyISINLnmQ0eWr6ht6ZTxg\niVmsz408H65Mt4r8YbWG+QW8RiwIeccjZpYCeELbfwKCAQBoglcyRYFWAnIgFxj6\ncZr4DY9eZ4t05bwU5I/UcAiCZ2oHupNXsAwf+oHRKMwy22xKGkMxQJ+zjuxDI+h2\nL7CYbQzYSxQ18oBgZA1OU65YRHEVEiKeoGMWUc0zJEpvB8WNLYkRFoWCSXGcgnLk\nWTPLvL2YHoDDJ8V1J26ubvtmikZZCM6Rrl3/sXtuiIurMQdxWr8YQlSIlP2ajXeq\ncEp95ccSPlvpjDHRYJJWAQfldtf+WE+8r8nQDELcq/8+E4MR6bZH/CxBq0APWACX\n0zaJmQ/KyQjElsL49RkJDpxS1l4qyuXeOaORjKNdZDalfeaBeaMOyV6qYhc0qwtZ\nOn/JAoIBABg6JashZe+lwK4teaZ3eDCmSW4sOap5nu4n2ytVNI1xJ5d0tm+o6vCz\n6y6PYy6CmV1jDUWZ9J+sdf/6qy7j83w/qrQn28vsAJuRYlIWE6MNzWqjHjtMU6aU\nd2IPIs/cVwyA/xjiT7ed23OiJrr3Ymjzyn45VkPc7f95nCoS5mBCfiwz8Tw3PwFE\nDCFe+H9ADlpehj72FBC2tRV118y6rnhpmnFCkFFBmmBQaT4PPKhSDCakeS/UfwJC\n7mO2dgQ50FV/BUdj1DwUxcYY1p6aPJMrniHrNB+5oLCh+HqeyHHa+P7rM+55FXKt\nPqvuYQtZqkj9bIkLdV3C/MbRbbGyNYcCggEADfNs4/DXDA3tUe1wOpf1ps0YLTNm\npBimRu7xJilWgIo3lkvk+uxU4c1stVoGjjbmiRFD8b8eUGUOnpCQxdfAv143xzI9\n4PwTHpxyDSQr7oEYdn2TfaDdVhMiURaDRcnuGjYkjC3+v0rEDfSBB3+7EDDbRzuq\nEEb1ZsCjyWZFSp9izCh+fMK0ckSfx1vxDncZWBSeAlmJiEio0NzTdMsa6RebkDG7\nI68CUVWMq/OxYWKyW4bab37kBcIXMQGHe1cKlPF2vqTwimum/E1w07WXss29JMVE\ni3VI0dft1vumTpHJVp/VBCKVJwSyYRaJejW9VOhffwnl/VvgioKte9iY8A==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"35f3136b0c94aaa164da8d380ef6b7da"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "915"
-      X-Request-Id:
-      - c4358567-24c3-4fa5-adf8-45934a2adbc1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_2uVTlEe5FHOgxBRm
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null,"resource_type":"tags","resources":[{"type":"Tag","value":{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}}],"resource_ids":["tag_NqAjIfOyzSMyuFPS"],"ip_address":{"id":"ip_n6Ud6hM0853uX5y6","address":"185.44.255.70"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfMnVWVGxFZTVGSE9neEJSbS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU1WhgPMjA3NDEyMTIxNTQ3NTVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAMCkdeMTtkRnmHKwrV10lmTTkl5FLkXLfK5y\n9Uy8fI0UvZtxaTxd6s95xo72YNkxDnqn+964IYAlX6ZDwznQrm1SJLtE/4FISZyG\nS69cKUQtQ0iKJTfr1zBntUKv2p4DAdO9vvkFIcUYgDTxoTLOMthUc+6rc2g9ff2r\ndhDeaLSqlH4CIRz80ZP/W6KsNJMaNODYm1Il/bkMP9gIXMBc6pTjDf/M3ZBk/O2c\nJTLulWKaggWzq10LMAT6v6khQh6dCzWxntw0Qxs/6mxDMx40B4f+l4OSQ56HnUk3\n3DEilsE9VaBgwvG1lJzX2f/PE+yhTBWR4e3skdw2JHA9jZQ2llCPWajqrrVs74XM\nC5DJNNufi1Vs+k/m9jV3yoh+OLJ0PQZKJ4csO5McghQofp4S4omtxFf/XEMkOuSA\n7AN+8IymD1dw8d4MXqsNV4U1X1adQRX0n1Vkk0pO7wcmVrYhe2gOZ+r2aIM5W5LC\nLidI4T92WfK8ZhZOU9vzsDMYoW2xMquRrrzuR+2t220kMrM2MLRgIghWhWL3mbi/\nV2o2QVmdZgIkIk+7si+3y2k/hiXnVRX40aG1Hts9beNh0N7mm4c4UkhNfdv++3nB\nPiLUdCtwJmXGxV/g9FuvAzXLLEmDgrw+l2Lp22u1QILQRSGmFoF/m3s5HiPGLgYP\nU0eFCYkTAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT7\nU95ohs2Ryqxqhq5vZwvUSd+XzzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFPtT3miGzZHKrGqGrm9nC9RJ35fP\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl8ydVZUbEVlNUZIT2d4QlJtLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfRXVGmy/r2kA\nlQ4Ey3olSEPKd+td+rfk3dGAhocSShJA8vJ/TnBnLk1meK88BZzltJqNZtof3KIo\n5KOKgdiOpKsxNxsYXxgddFNHt79JcrMO7VTV54KCl9RXRz9EvldWJVx8oFWp1jih\nTeUgHImtsv8VedTRigoDQKlNAmVwjIUkmbFkLCErcgNlA+3qNAFgp+bNDGCdJrnt\nmiIomQCPQ9pYrpDBXDTFQJjEdppmOp9K++i/P+nru6plRF4jDj05hmz3h9ohEiGp\nJ0lS1vMhqgzJYjhpM1JIOUE2TciElMWXCtZiItVhTLANLUPe5Ae9s2w+/6KhNH8G\nZaCLEkNTR16miVEIDFTg9iK898rtoGUGrVUCcbYHWujqMOMDthTMiS/jM4HfQ9jh\nlM77tNllYpFoDVdulNfNYPjzV44Vvy4D/ngJX0ktDgoxgds3hG1e0DWgqdVHcYiO\nroRKqCVz/W+NjQnY4Jbk1mFFvu06b/IKs68CctxJLZQXEuEuBec+AOhHNv5rWMmv\nQXOqMNxN10glklzqMJokFCdWSpVvRwvMAJOvBtBNr1P3AeW6uAySid6ygjf6ovE0\nj27XeVQoGAKmB2ILrdf/bNKVQQnrKxiRat1+/Jsc+EB0bUPF3xpxtQQchBLKxlM/\nW1RcO3GYvKQBBhtg0up7YNrqwvaEfRc=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAwKR14xO2RGeYcrCtXXSWZNOSXkUuRct8rnL1TLx8jRS9m3Fp\nPF3qz3nGjvZg2TEOeqf73rghgCVfpkPDOdCubVIku0T/gUhJnIZLr1wpRC1DSIol\nN+vXMGe1Qq/angMB072++QUhxRiANPGhMs4y2FRz7qtzaD19/at2EN5otKqUfgIh\nHPzRk/9boqw0kxo04NibUiX9uQw/2AhcwFzqlOMN/8zdkGT87ZwlMu6VYpqCBbOr\nXQswBPq/qSFCHp0LNbGe3DRDGz/qbEMzHjQHh/6Xg5JDnoedSTfcMSKWwT1VoGDC\n8bWUnNfZ/88T7KFMFZHh7eyR3DYkcD2NlDaWUI9ZqOqutWzvhcwLkMk025+LVWz6\nT+b2NXfKiH44snQ9Bkonhyw7kxyCFCh+nhLiia3EV/9cQyQ65IDsA37wjKYPV3Dx\n3gxeqw1XhTVfVp1BFfSfVWSTSk7vByZWtiF7aA5n6vZogzlbksIuJ0jhP3ZZ8rxm\nFk5T2/OwMxihbbEyq5GuvO5H7a3bbSQyszYwtGAiCFaFYveZuL9XajZBWZ1mAiQi\nT7uyL7fLaT+GJedVFfjRobUe2z1t42HQ3uabhzhSSE192/77ecE+ItR0K3AmZcbF\nX+D0W68DNcssSYOCvD6XYunba7VAgtBFIaYWgX+bezkeI8YuBg9TR4UJiRMCAwEA\nAQKCAgBN4c91RBFiu10zNQGJ8GojDjQ1H5PzDK72GizY3rUeFn4He4TXroKRacKg\nJrSF6mLXrNVTuC53D+UJI4kodRknwlduTJldq5tzCApONZzLXt8+Uvd0Ecl4XN03\nvj/MtRuGfsZYB76c3+hpPyz0DNAajJ4oJjGsuXuX1DuR21EKhZIuFW9MuFuEkW77\nJ9LDjAtHwdqdjhVzPCQNk2foL0h5dAhDXBBRYbqt13xkiHdlm2CorHhB0BWUVcmp\nt3PzS3tuNEas8QYWXLNKHKrscY1/6ipYO4hR7bLlmItRZBH9wu28vpHhxY71EAEm\n/hGoj5diew2TsppPpKX7qK719lGzQQp3h7ohItFlmr6kNDVcP2Z/nRPUUEMhq8/y\nbeyONFLnhEt8+YWT2xFV9OOihvjNtTrICVn4HcLLZ9YXH2f9y5V9Z3MrbwWUK9f/\naj/HlJGzGl7E2/n7wwTKt39oBeUs+3Ytzisvt8quspcKNThMmeVPeik3h1XK6Fav\nWHX++V1IU743JzTOgCTPB/3A/1xLmDva/vHudfFVpiKv0HMIc0eWHNBt7AV6Envf\nX7acqG+E3u6gYs3Xwk/Wd4lsTpCY/Wb7LOmtp2BZ9/VWiwnK/WZuq3xYaCc3oA5V\n6eoSuR7K6L1UirMv4HJoigAaZAhDG2P///VO9C7PTR/cBKwv2QKCAQEA7ytmsPNn\nZA8kApUbQlLrzp7Q6LLQIaJUBsbojaZSES73vBPi105DW37HtZn1/7RsKZnloWft\n9oNfOu39dmQrqjhCTxNugM39sOpt6v7Fd7BBmDV1Dr/jYsaEWgmN0dYK4DdGdqjk\n0ad9FHzu01eGqM7jMOMzYNgk9cCGg5eRikoI7lUWPas14JdFgwgSxoYwm/FaRBCi\ntlp2jVNUHelKyKx44i1JIsoD1p40OwUq6nWT/c44Jt+vq/FDCiONpx65fPxetizx\ntLQ82On86mQSZbx9DTOtkDwEW+iHB700IFnGm2Q/3Y5d9dRpkbX9P4sAeVbjCYB4\nA0zvW2lumaRPSQKCAQEAzjLhm7jo835/L+bjByoggV1NX/XXc+bK0YHxk0t4dgU4\n9G+kHAMrD6BEfW3BraEOyUTHK1SJqk846wUDsfm/AQ4OAdQ0a+NabEtbvlk5uexe\n47ZJQfAjsHc9Vv+cIvAYlqPDUArZLK3cyTAlyObcUsw7dYh71ph9pEqHdtE3jlfN\n/Io1Z0rXDJy9RGTV7Iy2cEQvdAnOz9nOdsl2ZmK02bNJL1fE8cFGqvzZnnBx82+4\nVa1Jb1htFIM0Fye2ZlggR3vDPlmBC8x9AdfXZak3ZFzurDJeBh0Vk6gTsf1BBObr\nWhqxsWYFBYqmaYPeH2C71fE8iY6AntPlNbEwGX7pewKCAQEAj48zor9Xrh3QdaRe\nql7voCSALU031RiE61R1vqC43gudNE2Teb1GfSMKaR0zJft8eTQhO9MQaUnN3aeA\n3pGeDByc4K4/RB1hS9JLjCTFDuTDWsOrseDIcj/KrejSMcQS3ycOqqcSQi4QzD15\ndW4yLB2TDYMzEcxr0v9vPom6GJH77mMwaG/edSMX3GD6NCPUBabHkdeSc3a1dnsw\nIIwqEW5FWS3pmnI7/5USsOKXMgjFfjFMTzkxTzoQDYPtwQSWPkmV6C/uHZOaenFp\nGKBc0qhjP4tngQ4lZ62Zb7HIGisJJbj1BN4x1B9eBtKAYqXi8PKQcOGmKAUEH5CX\njK2t0QKCAQA/5E455VLxWAnq+tzv9GK8EwANsux+sk24G06SeHksALREMW+lamnm\nXp+6Sc8QkO42+UPJrlk113RohlY9yIghuIwojutrXrg/BB66XYVgkdhZMLuEXfeB\nD4GHOo7T2JeV3cqAO8xNZtYZ1PxwQvCUC0qFQbQ1q2yLArj03SEczyI5lU204uC9\nvLd8wM30jSleohIeH4fgqbmq3wP796vYJRCRRd31lxDhnJWF3YvBhaWVjqtJgBnU\nmE8Eub5v+fCOlc/Kuwscb9FwR8QrcQKD67Pc0YKG3G46IYNwzGtgLHlSoyDaOiVm\nMS8dVMn36Q5q3WQHr4s1K61DNNMVo1iPAoIBAQDb8hKwJ5kofWqprdftB6EqY4Mr\nyzVWWHguBerOU/lIJ4sOXiMMdn8W0HX+HTyBxF5U/B/ihS9Ul/D68s120iUtM3sB\n+gBH73OcYMndFlQoKZ7o7LaKoCCKQcScfEpcpAIXi11ZiPZp+eC1W+LP5Y6CcIQ0\nnFIiOJ31RVThGe3HuAAJCasCFoy1YH3DBGZt2Ws1shfOr38aznKJ6e926NpFY97T\nFr2zhhLkLXnXcrnu8zA4zXuZfRyIxo3DXe98q9KFQFdYNMDiXFe93H95xRHwLumY\njyO1dX61TfrSmQDOOGne8ImO6LvlSB6crzxAutBP076cDgkP2i1peF3ljvvx\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_TyVIL6hMyuhHAu3t","weight":128},{"virtual_machine_id":"vm_VYMLNNdAFlXWMJ4y","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"ef801f90cfb02a7381432d13735e36f0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "912"
-      X-Request-Id:
-      - 51ecff38-f1ff-4367-9404-b40ca46d2433
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"5604894125c7c3ff959d100192543236"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "913"
-      X-Request-Id:
-      - d240ac61-4dc4-4911-a9d5-8a81b6e86bb8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_5Kx4CeyJF3vtgWY3","name":"Public
-      Network on tf-magnificent-kind-daisy","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "374"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"651a730357c543621a77ba20b26cce4b"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "911"
-      X-Request-Id:
-      - e3e2b312-8208-439c-84e2-d62e53e90f1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_5Kx4CeyJF3vtgWY3
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_5Kx4CeyJF3vtgWY3","virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy"},"name":"Public
-      Network on tf-magnificent-kind-daisy","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:ff:8e:8c:0b:11","state":"attached","ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "500"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"749b5e3458e15b93e0a44d0054131024"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "910"
-      X-Request-Id:
-      - def9aac1-7962-4247-8dcb-44047928fbac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"5604894125c7c3ff959d100192543236"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "908"
-      X-Request-Id:
-      - 02518534-941b-4f4b-9c24-fea775f97143
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
     method: POST
   response:
-    body: '{"task":{"id":"task_bUD29pz21n6p4Oht","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_sjvzxjuA8KkSPIVZ","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2040,9 +2201,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
+      - Thu, 06 Feb 2025 17:10:56 GMT
       Etag:
-      - W/"6a38495cd3aeb40be4e57dfbc3d2ac5e"
+      - W/"36186e402f51004b1479abe4c57ae438"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2050,14 +2211,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "906"
+      - "948"
       X-Request-Id:
-      - 8519f33f-e138-4b45-8af7-7ecf3aef8dbb
+      - 1c1b25a8-6b07-4dce-9be4-d151d35901b3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm"}}'
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA"}}'
     form: {}
     headers:
       Content-Type:
@@ -2067,7 +2228,7 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: DELETE
   response:
-    body: '{"load_balancer":{"id":"lb_2uVTlEe5FHOgxBRm","name":"tf-acc-test-tag-BjeyakxMJTN2-alt","api_reference":null}}'
+    body: '{"load_balancer":{"id":"lb_RcACnJ5mZyozZdlA","name":"tf-acc-test-tag-I5r2kO3RJUQG-alt","api_reference":null}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2082,9 +2243,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
+      - Thu, 06 Feb 2025 17:10:56 GMT
       Etag:
-      - W/"69545e9ba0c273a8cf76712c50690ed7"
+      - W/"446bd77c96e570eea2814d68afe0f2ed"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2092,14 +2253,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "908"
+      - "949"
       X-Request-Id:
-      - a175d425-cc38-4379-a121-23191ed11932
+      - 8ad7d8a9-f996-40be-8906-0e064693858d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF"}}'
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz"}}'
     form: {}
     headers:
       Content-Type:
@@ -2109,7 +2270,7 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: DELETE
   response:
-    body: '{"load_balancer":{"id":"lb_Px0MdfXYD7HgsZtF","name":"tf-acc-test-tag-BjeyakxMJTN2-1","api_reference":null}}'
+    body: '{"load_balancer":{"id":"lb_uyiatLDg1fvrodMz","name":"tf-acc-test-tag-I5r2kO3RJUQG-1","api_reference":null}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2124,9 +2285,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
+      - Thu, 06 Feb 2025 17:10:57 GMT
       Etag:
-      - W/"7560babd208cd60e4e6291e16bbb1b02"
+      - W/"e9062e67bc3294d4400b3e82907c957b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2134,9 +2295,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "905"
+      - "947"
       X-Request-Id:
-      - ba6efee3-5c2d-453c-88b9-baef598f5763
+      - 6fede07f-39c5-4d4e-bb6a-066f0085cbfa
     status: 200 OK
     code: 200
     duration: ""
@@ -2147,11 +2308,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_bUD29pz21n6p4Oht
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_sjvzxjuA8KkSPIVZ
     method: GET
   response:
-    body: '{"task":{"id":"task_bUD29pz21n6p4Oht","name":"Stop virtual machine","status":"running","created_at":1734018509,"started_at":1734018510,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_sjvzxjuA8KkSPIVZ","name":"Stop virtual machine","status":"pending","created_at":1738861856,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2162,13 +2323,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "168"
+      - "162"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:10:57 GMT
       Etag:
-      - W/"a6714ad25a7b1e5aeb661351feff7c8e"
+      - W/"ee90848ef2249091b123af9253409083"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2176,9 +2337,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "896"
+      - "946"
       X-Request-Id:
-      - f63f2d77-bfea-486c-b6bc-540e03d9e992
+      - dcb02691-7d69-4a9b-8780-8c901269525a
     status: 200 OK
     code: 200
     duration: ""
@@ -2189,11 +2350,95 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_bUD29pz21n6p4Oht
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_sjvzxjuA8KkSPIVZ
     method: GET
   response:
-    body: '{"task":{"id":"task_bUD29pz21n6p4Oht","name":"Stop virtual machine","status":"completed","created_at":1734018509,"started_at":1734018510,"finished_at":1734018512,"progress":100}}'
+    body: '{"task":{"id":"task_sjvzxjuA8KkSPIVZ","name":"Stop virtual machine","status":"pending","created_at":1738861856,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:11:02 GMT
+      Etag:
+      - W/"ee90848ef2249091b123af9253409083"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - 8e2289e9-76d4-4964-babf-e01fcd11efac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_sjvzxjuA8KkSPIVZ
+    method: GET
+  response:
+    body: '{"task":{"id":"task_sjvzxjuA8KkSPIVZ","name":"Stop virtual machine","status":"pending","created_at":1738861856,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "162"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:11:12 GMT
+      Etag:
+      - W/"ee90848ef2249091b123af9253409083"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 93311688-88e0-4c5b-a53c-c4aa9dfa53cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_sjvzxjuA8KkSPIVZ
+    method: GET
+  response:
+    body: '{"task":{"id":"task_sjvzxjuA8KkSPIVZ","name":"Stop virtual machine","status":"completed","created_at":1738861856,"started_at":1738861874,"finished_at":1738861877,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2208,9 +2453,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:11:22 GMT
       Etag:
-      - W/"6759b9e17f62b5da40530767fe53dd77"
+      - W/"0523f2aa5651db8889aecda233c700a8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2218,9 +2463,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "858"
+      - "997"
       X-Request-Id:
-      - 0f88d2de-9b0c-45bd-aa33-2584ca51bfd4
+      - 8288411d-a15d-4e9a-ac23-93e64e6bd9ad
     status: 200 OK
     code: 200
     duration: ""
@@ -2231,19 +2476,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2256,9 +2501,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:11:23 GMT
       Etag:
-      - W/"786e435fcf542a4c1fc909af961b4ae9"
+      - W/"50ec33d70fdf45945a2929deb267202b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2266,9 +2511,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "840"
+      - "996"
       X-Request-Id:
-      - 4493210a-4c5b-4a63-9288-5df384889c58
+      - 99e78810-b1ac-46d5-88bb-d27d369fb0a4
     status: 200 OK
     code: 200
     duration: ""
@@ -2279,19 +2524,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_fC4FiL8uMmClY6NI
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_KNmzrxGYVac3yQmX","keep_until":1734191316,"object_id":"vm_VYMLNNdAFlXWMJ4y","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_VYMLNNdAFlXWMJ4y","name":"tf-magnificent-kind-daisy","hostname":"tf-magnificent-kind-daisy","fqdn":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018474,"initial_root_password":"36ShzD0l0wG3QQ5S","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_m05Jy91tuLoITVWb","keep_until":1739034683,"object_id":"vm_fC4FiL8uMmClY6NI","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_fC4FiL8uMmClY6NI","name":"tf-rainbow-ancient-cheetah","hostname":"tf-rainbow-ancient-cheetah","fqdn":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","description":null,"created_at":1738861828,"initial_root_password":"R0e0XecYirWe5njo","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_YSQN2KIwSfYPLZSO","address":"185.44.254.93","reverse_dns":"tf-magnificent-kind-daisy.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.93/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[{"id":"tag_NqAjIfOyzSMyuFPS","name":"web","color":"pastel_orange","created_at":1610021329}],"tag_names":["web"],"ip_addresses":[{"id":"ip_aXEnNQr6XYRUYd8S","address":"185.44.254.5","reverse_dns":"tf-rainbow-ancient-cheetah.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.5/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_VYMLNNdAFlXWMJ4y","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_fC4FiL8uMmClY6NI","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2304,9 +2549,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
+      - Thu, 06 Feb 2025 17:11:24 GMT
       Etag:
-      - W/"0511d8b4d423c794e3efa48772d2cfd3"
+      - W/"ecabccb9455f2032bda33b2324ce29f8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2314,9 +2559,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "838"
+      - "995"
       X-Request-Id:
-      - 9db6b63e-240d-4716-9b05-f7ef9f283c69
+      - f8831279-a070-4811-b9aa-1a5c2272e8bf
     status: 200 OK
     code: 200
     duration: ""
@@ -2327,8 +2572,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_YSQN2KIwSfYPLZSO
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_aXEnNQr6XYRUYd8S
     method: POST
   response:
     body: '{}'
@@ -2346,7 +2591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
+      - Thu, 06 Feb 2025 17:11:24 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2356,9 +2601,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "836"
+      - "994"
       X-Request-Id:
-      - b7187e44-b0e2-4222-bd03-ca8aefc1a696
+      - df3691ec-ff1e-4cb1-a413-561e28677d58
     status: 200 OK
     code: 200
     duration: ""
@@ -2369,11 +2614,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_fC4FiL8uMmClY6NI
     method: DELETE
   response:
-    body: '{"task":{"id":"task_WCZuijnKfXQ9DVX0","name":"Purge items from trash","status":"pending","created_at":1734018517,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_ahbWLyD0RPILoqXx","name":"Purge items from trash","status":"pending","created_at":1738861884,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2388,9 +2633,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
+      - Thu, 06 Feb 2025 17:11:24 GMT
       Etag:
-      - W/"d4d874b9b441c5f3e71c9d705bb89476"
+      - W/"3e6919d892b0260e550d1c6b1d0e0008"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2398,9 +2643,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "817"
+      - "993"
       X-Request-Id:
-      - 26131cf1-363f-47ae-8bc0-3a48bf913632
+      - 57358e4e-cf14-43b1-bb24-96984a2e8516
     status: 200 OK
     code: 200
     duration: ""
@@ -2411,11 +2656,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_fC4FiL8uMmClY6NI
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_KNmzrxGYVac3yQmX","keep_until":1734191316,"object_id":"vm_VYMLNNdAFlXWMJ4y","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_m05Jy91tuLoITVWb","keep_until":1739034683,"object_id":"vm_fC4FiL8uMmClY6NI","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2430,9 +2675,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
+      - Thu, 06 Feb 2025 17:11:25 GMT
       Etag:
-      - W/"d5475e444c29221406c9cfeb7fe9902f"
+      - W/"deac45f94897b83ae85fd7079343eb23"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2440,9 +2685,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "802"
+      - "992"
       X-Request-Id:
-      - b915c79a-f1ed-4e2b-8d2e-197afa1cd425
+      - 3844902e-e8fb-4e99-8171-f91f5ed5413e
     status: 200 OK
     code: 200
     duration: ""
@@ -2453,8 +2698,50 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_VYMLNNdAFlXWMJ4y
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_fC4FiL8uMmClY6NI
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_m05Jy91tuLoITVWb","keep_until":1739034683,"object_id":"vm_fC4FiL8uMmClY6NI","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:11:30 GMT
+      Etag:
+      - W/"deac45f94897b83ae85fd7079343eb23"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - 1080daca-e34a-451d-950c-b25950349b47
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_fC4FiL8uMmClY6NI
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2473,7 +2760,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:43 GMT
+      - Thu, 06 Feb 2025 17:11:40 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2483,14 +2770,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "788"
+      - "990"
       X-Request-Id:
-      - f6fb567c-3e1b-478c-a260-c6fb86ec05ee
+      - d91f02c8-b341-4ed4-8b52-57714c035324
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"ip_address":{"id":"ip_YSQN2KIwSfYPLZSO"}}'
+    body: '{"ip_address":{"id":"ip_aXEnNQr6XYRUYd8S"}}'
     form: {}
     headers:
       Content-Type:
@@ -2515,7 +2802,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:43 GMT
+      - Thu, 06 Feb 2025 17:11:41 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2525,9 +2812,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "787"
+      - "989"
       X-Request-Id:
-      - 8f658732-2ad2-4f4a-a90e-a2721db52662
+      - 809245f3-c437-4a2c-a81d-ece9baac2945
     status: 200 OK
     code: 200
     duration: ""
@@ -2537,7 +2824,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_2uVTlEe5FHOgxBRm
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_RcACnJ5mZyozZdlA
     method: GET
   response:
     body: '{"error":{"code":"load_balancer_not_found","description":"No load balancer
@@ -2556,7 +2843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:43 GMT
+      - Thu, 06 Feb 2025 17:11:41 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2566,9 +2853,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "786"
+      - "988"
       X-Request-Id:
-      - ab15c105-3f20-462c-af63-8fd1170521e2
+      - 4f669e58-3f40-4155-bd0f-06d5c581bc2d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2578,7 +2865,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Px0MdfXYD7HgsZtF
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_uyiatLDg1fvrodMz
     method: GET
   response:
     body: '{"error":{"code":"load_balancer_not_found","description":"No load balancer
@@ -2597,7 +2884,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:43 GMT
+      - Thu, 06 Feb 2025 17:11:41 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2607,9 +2894,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "785"
+      - "987"
       X-Request-Id:
-      - 9828aed0-5504-49a8-8c1c-48c278573d5d
+      - f861f9b1-b8de-458b-8c9f-5df128daf90d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/v6provider/testdata/LoadBalancer_vm.cassette.rand_id
+++ b/internal/v6provider/testdata/LoadBalancer_vm.cassette.rand_id
@@ -1,1 +1,1 @@
-hbTT7e49oNq4
+jwZDAdblU0XJ

--- a/internal/v6provider/testdata/LoadBalancer_vm.cassette.yaml
+++ b/internal/v6provider/testdata/LoadBalancer_vm.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "826"
+      - "933"
       X-Request-Id:
-      - bd1ab97e-2412-431a-9f91-764de10a9438
+      - 3f1cf543-bd1d-42af-bf28-4509d33b60fa
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"185-44-253-61.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"185-44-252-215.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -65,13 +65,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "558"
+      - "561"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"fd38ce251ba99aa51af69048bad2c2c1"
+      - W/"46ec67b16124607f54539a07f297920d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -79,9 +79,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "816"
+      - "929"
       X-Request-Id:
-      - 93fb573a-c673-44b6-b242-991e8804fe7a
+      - 973c8bb3-bfca-46e9-9cd5-c15f50aaf5df
     status: 200 OK
     code: 200
     duration: ""
@@ -91,10 +91,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_iKkqjUAXcWmo737E
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_7FcKAmSPwE4XCKT3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"185-44-253-61.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"185-44-252-215.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -107,13 +107,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "576"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"cd9411534f174d16b4e1c358ebbefe24"
+      - W/"36e686435604c516239cf3ab711c14e8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -121,9 +121,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "800"
+      - "921"
       X-Request-Id:
-      - d1641193-e742-4189-bccf-9ab720703978
+      - 2c445bdb-6771-43b7-882c-7ee32bca3b03
     status: 200 OK
     code: 200
     duration: ""
@@ -134,11 +134,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_iKkqjUAXcWmo737E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_7FcKAmSPwE4XCKT3
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"185-44-253-61.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"185-44-252-215.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -151,13 +151,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "576"
+      - "579"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"cd9411534f174d16b4e1c358ebbefe24"
+      - W/"36e686435604c516239cf3ab711c14e8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -165,15 +165,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "799"
+      - "920"
       X-Request-Id:
-      - d895e1dd-a916-4f6e-b79d-fad7d6b2aa13
+      - faa13971-4676-48d8-915e-4cbe34f671ab
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_iKkqjUAXcWmo737E</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-silly-howling-pewter</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_7FcKAmSPwE4XCKT3</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-important-happy-iridium</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -181,11 +181,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_2reeTvnHbOod4ubw","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_qaemjbkBSrfzGPT2","state":"pending"},"virtual_machine_build":{"id":"vmbuild_qaemjbkBSrfzGPT2","state":"pending"},"hostname":"tf-silly-howling-pewter","annotations":[]}'
+    body: '{"task":{"id":"task_r2SFcLPrSioyY4Te","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_qFdCqlYTf7oR6Hoc","state":"pending"},"virtual_machine_build":{"id":"vmbuild_qFdCqlYTf7oR6Hoc","state":"pending"},"hostname":"tf-important-happy-iridium","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -196,13 +196,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "279"
+      - "282"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"b072881523008ec97d9176be3f32ec1a"
+      - W/"3502f614daf4623b082b85b7cb8626d8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -210,9 +210,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "798"
+      - "919"
       X-Request-Id:
-      - 8e663ca2-0437-4f36-94c1-2a3d96db2391
+      - 4199fbc8-37fd-486b-a924-6a86dadf6dd0
     status: 201 Created
     code: 201
     duration: ""
@@ -223,18 +223,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qaemjbkBSrfzGPT2
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qFdCqlYTf7oR6Hoc
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_qaemjbkBSrfzGPT2","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_qFdCqlYTf7oR6Hoc","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-silly-howling-pewter\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-important-happy-iridium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -247,9 +247,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:50 GMT
+      - Thu, 06 Feb 2025 17:37:47 GMT
       Etag:
-      - W/"5f5089dc96b0f1c9e3787201734c7f98"
+      - W/"3c8e76771d6227fc52ae3190f0d751db"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -257,9 +257,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "765"
+      - "914"
       X-Request-Id:
-      - 70a025ce-2d33-44e3-b73c-e195dc2bd831
+      - 3aad2e12-e4a1-4c10-8ab9-54ddeebd0df4
     status: 200 OK
     code: 200
     duration: ""
@@ -270,18 +270,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qaemjbkBSrfzGPT2
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qFdCqlYTf7oR6Hoc
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_qaemjbkBSrfzGPT2","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_qFdCqlYTf7oR6Hoc","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-silly-howling-pewter\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-important-happy-iridium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -294,9 +294,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:55 GMT
+      - Thu, 06 Feb 2025 17:37:52 GMT
       Etag:
-      - W/"5f5089dc96b0f1c9e3787201734c7f98"
+      - W/"3c8e76771d6227fc52ae3190f0d751db"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -304,9 +304,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "687"
+      - "908"
       X-Request-Id:
-      - cde2b16c-8540-4f9b-9fdf-cde7f67d99ae
+      - 8d04b52c-5973-4078-96b3-3c17b869af82
     status: 200 OK
     code: 200
     duration: ""
@@ -317,18 +317,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qaemjbkBSrfzGPT2
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qFdCqlYTf7oR6Hoc
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_qaemjbkBSrfzGPT2","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_qFdCqlYTf7oR6Hoc","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-silly-howling-pewter\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-important-happy-iridium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -341,9 +341,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:05 GMT
+      - Thu, 06 Feb 2025 17:38:02 GMT
       Etag:
-      - W/"4f9639cd640123e76a4dfdee73194358"
+      - W/"50beb70f29172af465c1b3af18ccd83f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -351,9 +351,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "998"
       X-Request-Id:
-      - 22ca0715-c71d-43fe-911b-6b513f7b8fc4
+      - ad995c6a-8998-485f-af18-dfee4f6a455d
     status: 200 OK
     code: 200
     duration: ""
@@ -364,18 +364,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qaemjbkBSrfzGPT2
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qFdCqlYTf7oR6Hoc
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_qaemjbkBSrfzGPT2","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_qFdCqlYTf7oR6Hoc","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-silly-howling-pewter\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-important-happy-iridium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -388,9 +388,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:15 GMT
+      - Thu, 06 Feb 2025 17:38:13 GMT
       Etag:
-      - W/"4f9639cd640123e76a4dfdee73194358"
+      - W/"50beb70f29172af465c1b3af18ccd83f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -398,9 +398,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "991"
+      - "995"
       X-Request-Id:
-      - 5d0e7dd3-80d0-4ca7-a9a5-475d689b411e
+      - 435106d3-d391-46ce-b24a-d55b97cf2ef9
     status: 200 OK
     code: 200
     duration: ""
@@ -411,18 +411,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qaemjbkBSrfzGPT2
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_qFdCqlYTf7oR6Hoc
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_qaemjbkBSrfzGPT2","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_qFdCqlYTf7oR6Hoc","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.61\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-silly-howling-pewter\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.215\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-important-happy-iridium\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -435,9 +435,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:25 GMT
+      - Thu, 06 Feb 2025 17:38:23 GMT
       Etag:
-      - W/"544b238308223349b6de5fcce86ceda8"
+      - W/"c6e2b89438dfa709c1f36ca6b0d9d6a5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -445,9 +445,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "984"
+      - "950"
       X-Request-Id:
-      - 00fb4d0b-c355-40c6-b6e5-20abd88b5968
+      - 8c3c713e-f0e7-4a36-b1b1-0864cbf61384
     status: 200 OK
     code: 200
     duration: ""
@@ -458,19 +458,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"starting","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -483,9 +483,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
+      - Thu, 06 Feb 2025 17:38:25 GMT
       Etag:
-      - W/"90a4bd6bcdf392475261a42fe851367d"
+      - W/"71c219281075590a5cbb8381c119b589"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -493,9 +493,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "976"
+      - "947"
       X-Request-Id:
-      - 4d424793-44e1-406e-bef8-193327c3825b
+      - 0621f9d7-1d0d-4447-989c-3f78355695d8
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -531,9 +531,1560 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:32 GMT
+      - Thu, 06 Feb 2025 17:38:25 GMT
       Etag:
-      - W/"63a345136c83fce510454ef1f7d8a0b3"
+      - W/"71c219281075590a5cbb8381c119b589"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - 7d1c9cf4-10c7-40ab-9732-935184c668f1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wq65zU86s16IPAuG","name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "377"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:25 GMT
+      Etag:
+      - W/"3771133438a0b95e7ec7d15c7cf23990"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - ba4e0790-1c6f-44b7-9fa3-997720e282a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wq65zU86s16IPAuG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wq65zU86s16IPAuG","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"},"name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:d5:5a:f6:cb:e5","state":"detached","ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:25 GMT
+      Etag:
+      - W/"286dd4add5a085ec2d9229ee94696ae9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "944"
+      X-Request-Id:
+      - bddeea50-f5c9-4503-8bb5-7e61f0ac8eda
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wq65zU86s16IPAuG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wq65zU86s16IPAuG","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"},"name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:d5:5a:f6:cb:e5","state":"detached","ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:25 GMT
+      Etag:
+      - W/"286dd4add5a085ec2d9229ee94696ae9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "943"
+      X-Request-Id:
+      - cecf1eb1-bd68-492e-819b-974ab8e5b5a9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vm-jwZDAdblU0XJ","resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"resource_type":"virtual_machines"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
+    method: POST
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:27 GMT
+      Etag:
+      - W/"928d7c940280e4a3299ec86fec5d2795"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - 8f7a7bce-4383-4eb6-97b5-1d922af540b4
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_KwweY4uJ5Vn7VNWk
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:27 GMT
+      Etag:
+      - W/"928d7c940280e4a3299ec86fec5d2795"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "934"
+      X-Request-Id:
+      - 7522238b-6fb9-4d30-84a9-5953d5f820e0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","resource_ids":[],"resource_type":"virtual_machines"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
+    method: POST
+  response:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"b2b56984394316c4aab28a4cc5553b2a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "933"
+      X-Request-Id:
+      - d3161012-792e-4017-a34b-fd295e7cd4ec
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_e5VQbKUat7qRTkPr
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"b2b56984394316c4aab28a4cc5553b2a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "915"
+      X-Request-Id:
+      - 7465fc74-22c9-44a0-82ae-588483a3ac45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_KwweY4uJ5Vn7VNWk
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"928d7c940280e4a3299ec86fec5d2795"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "914"
+      X-Request-Id:
+      - 514974dc-b191-4458-88f3-5200b7229e98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_e5VQbKUat7qRTkPr
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"b2b56984394316c4aab28a4cc5553b2a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "912"
+      X-Request-Id:
+      - c3b9bdf3-2157-45d2-9be4-76b88ee6c887
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_7FcKAmSPwE4XCKT3
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "731"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"2128f45b3ee609c38411b144a62b6fc4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "911"
+      X-Request-Id:
+      - 18407209-1a0f-4e22-86c6-52702a2181f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"71c219281075590a5cbb8381c119b589"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "910"
+      X-Request-Id:
+      - e97a2b4f-b651-4dec-a7ad-d671f83eea07
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wq65zU86s16IPAuG","name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "377"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"3771133438a0b95e7ec7d15c7cf23990"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "909"
+      X-Request-Id:
+      - 7c133c6d-23ae-4aa4-ab6b-b2aa70bcdf34
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wq65zU86s16IPAuG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wq65zU86s16IPAuG","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"},"name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:d5:5a:f6:cb:e5","state":"attached","ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"8ab755abe37d07f42cb9204120e8ae51"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "908"
+      X-Request-Id:
+      - 641dba1d-57d9-4f30-bd6d-49938ce734bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wq65zU86s16IPAuG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wq65zU86s16IPAuG","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"},"name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:d5:5a:f6:cb:e5","state":"attached","ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:31 GMT
+      Etag:
+      - W/"8ab755abe37d07f42cb9204120e8ae51"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "907"
+      X-Request-Id:
+      - d4a8e130-0aa9-4fe2-bfc6-250831965a9d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_KwweY4uJ5Vn7VNWk
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"928d7c940280e4a3299ec86fec5d2795"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "906"
+      X-Request-Id:
+      - 90d709b9-1a3f-495b-ac1e-481c943fe277
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_e5VQbKUat7qRTkPr
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"b2b56984394316c4aab28a4cc5553b2a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "905"
+      X-Request-Id:
+      - 956d4290-dd0a-4421-b992-650f03c20d3c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_7FcKAmSPwE4XCKT3
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "731"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"2128f45b3ee609c38411b144a62b6fc4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "903"
+      X-Request-Id:
+      - 3a677d73-9f9b-427c-95ec-9ab7c14694ed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_KwweY4uJ5Vn7VNWk
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"928d7c940280e4a3299ec86fec5d2795"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "904"
+      X-Request-Id:
+      - e383b8f3-fa12-4bc6-acd1-5bf7c4ca2798
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"71c219281075590a5cbb8381c119b589"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "902"
+      X-Request-Id:
+      - 8665b547-6dc8-4630-a96b-49d076498c6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wq65zU86s16IPAuG","name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "377"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"3771133438a0b95e7ec7d15c7cf23990"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "901"
+      X-Request-Id:
+      - 3b56ca38-631e-4aed-8e54-219ec0978ad1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wq65zU86s16IPAuG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wq65zU86s16IPAuG","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"},"name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:d5:5a:f6:cb:e5","state":"attached","ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"8ab755abe37d07f42cb9204120e8ae51"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "900"
+      X-Request-Id:
+      - 94464a2e-c51a-4ad6-80ae-df61de5fcbaf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wq65zU86s16IPAuG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wq65zU86s16IPAuG","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"},"name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:d5:5a:f6:cb:e5","state":"attached","ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"8ab755abe37d07f42cb9204120e8ae51"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "899"
+      X-Request-Id:
+      - cd6d8ce7-2324-4637-a88f-4b925fb2ab3e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_e5VQbKUat7qRTkPr
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"b2b56984394316c4aab28a4cc5553b2a"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "898"
+      X-Request-Id:
+      - afec4215-2511-4c44-8a68-0a97f51f3da6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk"},"properties":{"resource_ids":[],"resource_type":"virtual_machines"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
+    method: PATCH
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"58070b968baf57f10476ac2918dbcdb1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "897"
+      X-Request-Id:
+      - 7fbd9857-021a-4c30-8d3f-4184a4d8cb7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_KwweY4uJ5Vn7VNWk
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"58070b968baf57f10476ac2918dbcdb1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "896"
+      X-Request-Id:
+      - ad06670a-2395-4413-a12e-a9a52eeb2ee5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr"},"properties":{"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"resource_type":"virtual_machines"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
+    method: PATCH
+  response:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"2a81e6c3c39f5e32e1c7b637f8137c28"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "895"
+      X-Request-Id:
+      - 6987a757-4d6f-44ae-89ad-afc2d7197d48
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_e5VQbKUat7qRTkPr
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"2a81e6c3c39f5e32e1c7b637f8137c28"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "894"
+      X-Request-Id:
+      - 44aff5ff-4c32-4f24-bdb0-224cb4400c89
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_KwweY4uJ5Vn7VNWk
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"58070b968baf57f10476ac2918dbcdb1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "893"
+      X-Request-Id:
+      - c8f8265d-6c03-457d-967b-bcc64f997f44
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_e5VQbKUat7qRTkPr
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:32 GMT
+      Etag:
+      - W/"2a81e6c3c39f5e32e1c7b637f8137c28"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "892"
+      X-Request-Id:
+      - b56ba003-8bc3-4253-9841-6c69603926b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_KwweY4uJ5Vn7VNWk
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tMpxbWCxFzMQ5d0","address":"185.44.253.129"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfS3d3ZVk0dUo1Vm43Vk5Xay5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALkndtPvmVWOE+qQS6c0SbNu3jw4y5lLTIKt\n3A9EIfgF0JpOPLxGeiiHU+3q8TU8CJ0hYrjIPlRpXLTGI7TC14L/er1fcaAqxXNZ\nk1whNFaDiHtebDItZx+/MRf7mL7K/ZIUBYgG4SsD9zceTSBYp4k5wUrXEpJTh3XT\nn7EIHjDl/fpxLp6NKR/FhfbpCd3DsZU3zKlbH5ayKgQiqULpMpoiM0A9iAfQb00f\niS216ek9DM0txZtL/PdmFe9Q75XPsovZlNRd0+y3FAxEEuGP9HQQJwd8T2oRce32\nJhwy/OSwbCXbSs0Zb0ahFi6/Zs8qKW4Umaqa5LEn6aI/HwYzH0rE42Rj6mpb/tsg\nsdnA6hgI4+KodFfn9SE0D72ZkCDIVqAu28dyrNdONj28PtLFCcM9PRqISzHhdFkf\ne2h1AEXRqpbu7GDxS1IfWBPeF21g+wNt6ydbYwX0NleXHTR3C8OpTOZ48btg8he/\nicgb+NdpBuG92ItZg+7mS/NpixM9xjibsnSGXOhIcAJf8240Wy6Un+BmTZgZZQ+M\nZV2CkQqpQJhPdkvZlEthaFJWgm73U5k4pWuVD0In0BQwusokre/R0xtviKmmbqDV\nwYx53JnmENrFckJ+w7zI0JVApPjiNuV4pkhrzW7tjxSuRPzuSxFxeFGKbCckQIlq\nvzFaQ61ZAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQL\nOw2a6JkGzp38EoGKCi4/P8ZYRzATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFAs7DZromQbOnfwSgYoKLj8/xlhH\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9Ld3dlWTR1SjVWbjdWTldrLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAJvY30K19tI1r\nT1UZmMcK6lTBIwx13AqCkXJ7hwP/NIVk+naRGJvY0ohUStjocWOZ2p2DvVsU9wYn\nAtO9kq5E6eBhUKbuSTsW9NHU8gkcvRw7U9e9/r6VFDn9l0vAhvPVKWIjLFq35ZiB\n7YvnXDy6m99/6ogH3T3IEk/qj29e2DMByvF2cXxrb/rlOWyd8LyEKD7Hl3pAfBWA\nxWLV47iWDtqYBTAeYLDaZ5bD48cODxPP2lYzoeCYsF+5CLChy9DzTVe1dMkS88Nb\n5cvF/6P+VGOlAu07JbyU8mj5h92iK0V4Y4KBmIheKtI+Fftlcl2Ql+TQlNf2Xv4m\n3m+iTXuPNB2Vlu8MKfVT+/mIBvPDL0KQnL+yuJFqWCQSx2cLXBoGDOf9bUj0/9Ot\n/VnuQHk7NLmnhyp6jR1/npGA76ahRk4nCwwMo/zJuH8pLDJkORm4fRcbKwo+8Dws\nYIGcaxY3jOkoRC07c5ntNMeImUkxi2mt7wvn/WLBMbZNO57WP4Cj80GZXhVv2CPE\n0Y36ot845WR4HPSe8Ja/OtziELmNcOgbpBViF178Ig0bWl0S71/bqq9PgeygP9FF\nUKI1jV7ouqniDq9zS2DVdPoUtTlV9yaDYrniBrH0aoMUwfb7R708RW2CUVTuJXjM\nAutbW/SO7d2C4NDKbDrb9E9cH3vj7ss=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAuSd20++ZVY4T6pBLpzRJs27ePDjLmUtMgq3cD0Qh+AXQmk48\nvEZ6KIdT7erxNTwInSFiuMg+VGlctMYjtMLXgv96vV9xoCrFc1mTXCE0VoOIe15s\nMi1nH78xF/uYvsr9khQFiAbhKwP3Nx5NIFiniTnBStcSklOHddOfsQgeMOX9+nEu\nno0pH8WF9ukJ3cOxlTfMqVsflrIqBCKpQukymiIzQD2IB9BvTR+JLbXp6T0MzS3F\nm0v892YV71Dvlc+yi9mU1F3T7LcUDEQS4Y/0dBAnB3xPahFx7fYmHDL85LBsJdtK\nzRlvRqEWLr9mzyopbhSZqprksSfpoj8fBjMfSsTjZGPqalv+2yCx2cDqGAjj4qh0\nV+f1ITQPvZmQIMhWoC7bx3Ks1042Pbw+0sUJwz09GohLMeF0WR97aHUARdGqlu7s\nYPFLUh9YE94XbWD7A23rJ1tjBfQ2V5cdNHcLw6lM5njxu2DyF7+JyBv412kG4b3Y\ni1mD7uZL82mLEz3GOJuydIZc6EhwAl/zbjRbLpSf4GZNmBllD4xlXYKRCqlAmE92\nS9mUS2FoUlaCbvdTmTila5UPQifQFDC6yiSt79HTG2+IqaZuoNXBjHncmeYQ2sVy\nQn7DvMjQlUCk+OI25XimSGvNbu2PFK5E/O5LEXF4UYpsJyRAiWq/MVpDrVkCAwEA\nAQKCAgAlhLmveH25uHCQt2ydFRtaIL0nttqK1ZdLY6+T6Fp5x7PdkLz96coXLFT1\ngQYfo2qbbIh0qR74O+FtQDk8B79j7CES/qQnsIMSPLR/lrrkTQL6/Mcv48Nhy3xH\nP9RT1Q5M64GzbrFx5fvST3GRfGV2iR2B7NL2k7Z/ScKyPNLhVbmBZi3sMu6CYaQj\nxFUbeuwhMI1oQ+7CupeI/v0NcfOvB/8apV1LOBFVr248tQARIy3U5dGFBoDcIPOQ\n6vWhhdTIQe7Gmby32uFVGvY4ftMqMZu3CJmPBLnxXk+apzpXnOhNQ4KEzQKfbUTx\ndBeBIyoCBGqfB4QP4eaV2fSPbQyJ4dV9c/jnWcEPXdI81XnXnX6xUZUoEDFu82Xa\nq7JZq30Z4Vu4sQ8myuTFnE2Fg7hJvtY60xUbPDon98PA2eQhpVz7TlYaF15bG7TG\nLe+bbrAY0qUIZZ1YCvn/NPm335pXdDTlnalkfra/kPr7BPE6kvI23DN0aLBU5jsB\n7rJ3g7cDbjoZRPNT6tf84twlvnhboMcfYzMr5h/2BoyK6U4VT5u4nlfufgnAqlnf\n3S/N4Wjjm98rvbMaUa6zXcgOazM5q+LD715RwiOXV0VhhLQdjNq8fQvTDGutvcF7\nbgWylwXyVsb/fHxYkBNYVgA+2vAY+gMaraYOxRnWKBkToPSGAQKCAQEA4GiZbjWA\nivZ/nbDiPkKtvT+1IDUzJRXbD0Cl9bQLC+N7UOC7bSc0dEIzqp53RXbvNnp7/mht\neIIwj1C3VoIOROgZY6l10xEZ64hmXHxBETXCAPtTzfbxl88JgahvN8n0jCjjQX2s\nF8hX9fwjLilO42xgopCHOj3uPFrAb7LNkIMwO9vunJCaz16g1S4GeZthJOS/RqJc\nZOaKNuqs8j9+jH97mriPPdmoyMCAMUBQxvK/vNit9AgO3sAMM1M14Tii/E9wHdHC\nYCK9gI3p3ctr7EdHaeRZMOfomq/E+K2DP3QO5QcVsn5G3QgD0+FmESIPSoYj4l6C\nS7brkRijpf+ZPQKCAQEA0zgvU6gMnkmR0VClUXv7bSOVeBVRsH3TUDSascvxYfK7\naZfYk0AWUgT+U+EX7WsW0bXJijIRLyo2Z9gsibtfdpQ2YtRWMX7z2DVsrtWYS9jZ\nvSvCEyv4cQd+hxicC7S4AmCVrF5tgp+aoFQLVJdoXUK4WMTrhZUCFFqGrs+EK3CL\nDJvGs+NDo2b6AfX4zA7gEyXYImU8c36YVNAZApL2Qg4P3cCS2syMnlAHXlMtR2Fe\nopvciGAu4AVyd6HyReTb9uTUTLxu+gKbQiRaPeLe/3znaPcV3jrwX80NDVet1Xzz\nofAyCjL94MycFcBVkZ02ZBdojYOI3yg+Ms1/oZpOTQKCAQA2lnssKeuY4hls/Igs\naP/mV0byDL7iOIzPCwTT3fYJ8E4hAGnXRYAm/6udx2pwBVxvPiBHZJOsis7RLetL\nKdvauzLh4Wj97N0HRGjR+o/BZfhJUNmz8mwWZ5CCb7yOL5xDM/cECVQBfQSYm7rb\nEcVU4RoosUuTyVjYaaMCCNakXqUvCnLitvJRm004TjfZAQkCdnpo7jnXeZUJgtCL\nJRLdjm0818RQYVADdYA5etGrc4VcpMC76fHkEYdmPMmQfbx378LwHgRQamL6kIrh\nHwijszsV8SwZD3CvoC4j5+FTYCH3aF/IyZrnTXnQ4rV3WXeqwzKbcC31yQtIglvc\nl25pAoIBABkrvugXRLmwRsJM/AaD4eiVrwBKehuwQvhx7GV3ymJDzPW+dL7HimFn\n2u8gCfvvIR8IrOXdJZMbUrR5XIVlYPD+pKSObV8ko+aGJ1eGeMnBI+GZT119hfPi\nUr/CvQXgGXWfEPcjoaVJY+HrYhZInNVQWCur++1FXqQSTa6TaErM9KUiA0H4uVzF\nrtGBAI9Azo85mVIwAk45Leodin12CgbBKj7g7h9I9REAtIAXJXQ2NFLohBV0cOGd\nhJChKgAOT/BSQMKMSiVdHid5sY9ic/S6a9FkcKS1HWQtSXrnkf25EEeiGjSA8yRQ\n/eDRtODPfWXcLEeA/1SotRDU0HrvqpkCggEBAIQEBkwwB66XC3Pz8GQ6Mq5b4AMr\n3RFi9vFgdugHwBu2BVT2bFUztBl5b563wozLwKhNdvY50+t0/J5RaTm9JL+zZLyr\n5nO82CP0vNWxtMYMdOafjJ+yHKm/Ol6oWzYiDLw7L28Ai10xxAKU3d9y0xGh4Lb1\nfE4e+eOCPp5Qy1xmpyHyLvGjb6xeHcPG9QzcoTDxZnSdI3mC2j6zNR5Lj409eQW2\njannz5iHi2ycuhHPuQOOib3eAk6tPMwYGP8IHZnAcZ3dtfZpBpPYk838BcBQCOJS\nDR/PnBvRNFgJTArdM/dp0aWJ64k+1S6s94drDXxSn8eF1xEeblcXUpAPq5I=\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:33 GMT
+      Etag:
+      - W/"58070b968baf57f10476ac2918dbcdb1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "891"
+      X-Request-Id:
+      - d1c42b45-acc7-4991-89a2-849b9eacdb7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_7FcKAmSPwE4XCKT3
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "731"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:33 GMT
+      Etag:
+      - W/"2128f45b3ee609c38411b144a62b6fc4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "890"
+      X-Request-Id:
+      - 905b605c-dc8b-48aa-9e9c-ddf506a55490
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:33 GMT
+      Etag:
+      - W/"71c219281075590a5cbb8381c119b589"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "889"
+      X-Request-Id:
+      - a082ac48-ed96-4a1c-b2af-b7436f0e76e2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_wq65zU86s16IPAuG","name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "377"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:33 GMT
+      Etag:
+      - W/"3771133438a0b95e7ec7d15c7cf23990"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "888"
+      X-Request-Id:
+      - 8491c3b8-1a83-4fa3-901f-0bc7579b6a88
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_wq65zU86s16IPAuG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wq65zU86s16IPAuG","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"},"name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:d5:5a:f6:cb:e5","state":"attached","ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:33 GMT
+      Etag:
+      - W/"8ab755abe37d07f42cb9204120e8ae51"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "887"
+      X-Request-Id:
+      - 3d4172ac-b5b0-46c9-8b1f-71dfcd27b80e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_wq65zU86s16IPAuG
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_wq65zU86s16IPAuG","virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium"},"name":"Public
+      Network on tf-important-happy-iridium","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:d5:5a:f6:cb:e5","state":"attached","ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:33 GMT
+      Etag:
+      - W/"8ab755abe37d07f42cb9204120e8ae51"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -543,7 +2094,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "885"
       X-Request-Id:
-      - f29d3ae9-7a5d-442f-bbfb-b7ad338c9cf0
+      - e5a1fd22-2d49-4276-8e1f-64e2820dbd47
     status: 200 OK
     code: 200
     duration: ""
@@ -551,22 +2102,23 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_e5VQbKUat7qRTkPr
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_oIW2qRb0ux5zqjZJ"],"ip_address":{"id":"ip_QzJovXhGRu25pU7B","address":"185.44.254.64"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfZTVWUWJLVWF0N3FSVGtQci5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODMxWhgPMjA3NTAyMDYxNzM4MzFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPSmXrbct8WiCWIi4S7XRmDzeWsqP1BhuT+t\n1d57Iv7uQMxZmNxLhGRUbLg/V9MSSYm/d6RnStx//RKGD1us4DowuvsQKHTrfFYN\nPGmO6WVa5f57r1KmT2CkVntT0ideTux6QIEOmW2VY7WHq1yXqguxbfNq+KsIdmy5\nXjkp3uCGJx+RE4d1GqEIIMK1SWOnwOAymrQ95cuqL9VNTwJ85WqwpR3yy6gKj3cs\nEfSeZStle5qf7laSDRUiJ0D+FsZK/TDEpxQpXvSQayI0q168C//3Zo/89wzOpvUD\nz4GcjPO5rbuGzYxbUWpw048a4kuwtFdDR1HopXLIJnbs+1kf941mThUrCGaq1KF9\n04o/C5PeWq9rne3lR2HBQGj0NSUsGfAP0HaJT4Ev+YZ9doBOt9Jw1iq2vkQMySMw\nUMpfJ5tib2DKdbEd3lilaEDdtQDvrqEtTue6Nw3CgPgJyhIMYaIu5yjY5mLpEug2\nLLOlPqv3jwKTBMy7jfE3aWfMPUbP8g5xDRYQ/qvKcn3SBoMCjToFOyOo6feDw/5y\noLtw236ai1QsRxKds1IK82YeAflaLYMPW3j41EPXGjOzEZxTMaHk+Baau0Cr4njU\n59yDN19P6Y3dJ/GKt2CirAEXqSH4T4Mae/nqTDmRZL6twUnPZ8Ai3mkW96tGNp09\nhfNG17uhAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSW\n9NOfBct37ihUx/JKXPQllnTMcDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFJb0058Fy3fuKFTH8kpc9CWWdMxw\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9lNVZRYktVYXQ3cVJUa1ByLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAUVh3AJeSrRMX\nSeupNz1Rf9ikvGC3Bbp9ikSoqH43tNtiVEa9UNdpe5GC+P6HtXnQWu0VHLfDi4d+\n/iIK8HPSiAZhPxXJDMKbV9WJ1dNX6z7ys5VF0Gxju3ufYyDHLPZq7g4b+ICY/lxg\nUl7rfiuOBSTKZTt2aeun8KcIhLwQ6xSNtuvHxH7R0Zet+m+ORX4z8GpQk+uKM62J\n9q/8hCqPRKPjyEqKRs3TcKg/TTpRsnijUAZC7D3Pip4rjx1ubLsCnzHTCsalS/wz\nHLc5YjrWkajI3LIyU17E+s3exEypIUQMsyrF1Qj5Z2/+ozJcKGU7yw/ztBy6SURU\naqRZBZKo3QlZYczlR8axRDhzAu0mnmHRJohikq5FVrG1Ujn1CWjVmqu7U7YQ3dNh\n0NIrotzsFOBk1LzmHPtfqpZ9M0g3fkJ8N/mY9zJuT4b/M1M3rpAgXBTr2vTwDTFf\ndBYfPTeCa7iUNh9Sul57h1zIKf4g0HT2sIIsxkQjCc6sfIOfAlhq3xHjVSt5CP2V\nvm6NzsxXeMaIPE5+tXlIjKB+FNg7Seks7635iWaPg+th5X3z6B56lWtTOTwNBk7T\nMEibg+Zz0HXUSGQ8h8sT0CR6VwtTQbV4+YgQ5xzm09puW9tYFNtZzZKLvT1QH4tO\nAe6MFZ1gjLlvoD6gokLAbFs0e6fOvio=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEA9KZetty3xaIJYiLhLtdGYPN5ayo/UGG5P63V3nsi/u5AzFmY\n3EuEZFRsuD9X0xJJib93pGdK3H/9EoYPW6zgOjC6+xAodOt8Vg08aY7pZVrl/nuv\nUqZPYKRWe1PSJ15O7HpAgQ6ZbZVjtYerXJeqC7Ft82r4qwh2bLleOSne4IYnH5ET\nh3UaoQggwrVJY6fA4DKatD3ly6ov1U1PAnzlarClHfLLqAqPdywR9J5lK2V7mp/u\nVpINFSInQP4Wxkr9MMSnFCle9JBrIjSrXrwL//dmj/z3DM6m9QPPgZyM87mtu4bN\njFtRanDTjxriS7C0V0NHUeilcsgmduz7WR/3jWZOFSsIZqrUoX3Tij8Lk95ar2ud\n7eVHYcFAaPQ1JSwZ8A/QdolPgS/5hn12gE630nDWKra+RAzJIzBQyl8nm2JvYMp1\nsR3eWKVoQN21AO+uoS1O57o3DcKA+AnKEgxhoi7nKNjmYukS6DYss6U+q/ePApME\nzLuN8TdpZ8w9Rs/yDnENFhD+q8pyfdIGgwKNOgU7I6jp94PD/nKgu3DbfpqLVCxH\nEp2zUgrzZh4B+Votgw9bePjUQ9caM7MRnFMxoeT4Fpq7QKvieNTn3IM3X0/pjd0n\n8Yq3YKKsARepIfhPgxp7+epMOZFkvq3BSc9nwCLeaRb3q0Y2nT2F80bXu6ECAwEA\nAQKCAf9XugW2GE2+FHE+lhdVNdyXkfyyLZrUEUOxh5IcP4oozdxUoON6Y4+XCs4A\n9fZzdj95NQW8O7+UnNwdf+qX6BWWzVbpx3JNyt1/84d9T/VpEp5o9WBA06ApiKp8\nxQYvO/TTBeHYO/TDQhlijOu0mtc9ZIFOlD5OlOOkMt6O4ZZfaJnvADrpO10Vpx93\n6KZJTsGsTeMW8nWi2sjNgCvsCJ8e7cwePBOFWkk+WKkP3U/jYW5v35lO9ZGHqo4q\nz4gFy8GZxZAKEjCLU2dfpldWImXDu1qUuQSDK7tIkl2ik2QCEP92xY+z4TROA6sZ\nqtKhczKclA8Y09eCkeCObKoW2Z22xT/CnnoUpb1rNDNBhQcpU5Tw73sG1hZKXnA3\nmT/T7CqOR7BvKA6zAOBDo6/ZA4RobgcwL9qaZ3XZ/jGm6+gvyewPpNFz6pqItzDd\n+6JGBn92FWsTtyiVJtVGb/UWwP5++frnvwLmJj428RNe7ciAO3HofJ/yy3e0+C6E\nu2dBuuvoPbGRYWa6ck4rCdU+vSn3+P6pXuhtENZJ9wfhI6uqd5WbbxEOqGmnHwiE\nm43CSqoNyQgdqcLnl0GYkHLKKtugCWuZlypdZugLLn5GQOY/EJIRMAod6P2fMxzV\nku+0X8Wj03nX6tq9qerz8u9bWz+KfVDwBxvIMbMWgTpnosIBAoIBAQD+CAJV8x9+\n58ZL6TSZnT15OkAJzcFS3JmpJ+6DdtxMSO8W+iOhuQ64V0W35a7tTljp7hEbyQg8\nOb477g99Gn+9p0SNUqkpfC6LfUfCOC9YY+omlB7IM+xGSxTzNpUT14ijUAQvz/jc\nsG+s5gKYg8i+NXo5E94UsrWfUWeWvQ6ZByBtKHhCqL/FBlHj2xtTIX2nxRLuS5Oq\n2FNlhbxtmsjROi/qLtmPTwC0qlg0xnIcOsal4JaIrDRnlpeEQRLdSZD7Meds+XqK\nGT/iJo1lTXZXIUmJoVezsc5PsytJZeIRoe0k8Ul83fCgMiGH+1KSCxYYGItt0xst\nuAKkBjK/LQnTAoIBAQD2i7+YMlAJRUqXUOIW5I0DHECH9gasm1uOECO+6DjfuGb+\nvt4C1h383+aohNb51LipIJoTfQCPUAiQUK2EzVdr+KREJkhiiTCekoDDcUlbrP3a\n7LsxL7U9Y6BVgVED+E3or2qp08UfDxbsKCFDM7BrpD1i/XcH6+sNIwGau6GPfbAD\nQoBjWeZ5TO+7dlUwXV5EEfyccF1/ifmMBEZs9VZ5Cp/lvJmK9/VXTTcjSTXQX6Gx\njSHL0qVa1w+c8cZyjRhj0QAFmBh+PaRAhnzr751agQ3Yd8B1kSFXrynAB3Vt/y4t\nsopYN4w6vb08ykSRXV9zFjlZdwJEBlpBSy/sbKg7AoIBAQCmRnXI7n9SIMGCFJ5S\nYkLHo+IgyKXe5/hIaZPMRzPBVwfwYUCLbcb90FoZGeUa/WpjjGl0Z2zVhvJG5fcL\naxnr+J19Z3rEZb1Nnm4m6YHL+HJeWBuh7aKdDC4lWDfSKgUM6KYk6Zs6UN54LIHM\ndI4kOnrK+38kyyjopG8KkqsIbUrDSHcXIr+LZiyZ2WQUUNqfwvY2Ng/tBvXngNcq\nYuNJWC3eulW7YPnUR5++w5oTckFueAfwY89VcpOwhKulXq7gTPTvNokH9akEDToF\n8eMg+u/Yf1wZiavCLUOLIn4MDpJb2PfCHL+RC984079jSpBmq0IwW7rxfP11gX0b\n943zAoIBAFT7arlNbmUjq0hpKuV1Nl4CGQREe5x3mKFpUsj1RtVmvKnGpMQZhhCq\nJNmloGxRNK2nfTSGe/DqR2lnRchm92FSPVz4TS8Z1tZx7Uxw+jZNdNtHimaz6ScV\n9ihDAOf7aO9xt7R+OI4yJ1aTppOBd6hC3p4GfEcQvN60WFM7pb7ONiOJgrO8Q0NA\nj8nwSgD3zgxsnsRVvwS9THVE6/mWv43NabxIvCw4uCq1hPH2xEPlEtkeqq2VGEYt\np0YT2LGXjParDfTfrmGlYb6UHO8+kuClZ15cOMzNj86npB5687FMqmA6EJHD4+RD\njr0rg2MP6lzDJlV+PhuwjN/AyO4Xrg0CggEADd9MHJ/5mnrzFGF5ctCuDOBrwlJp\nqpWneB1JGIm9WQgMSQ14huLEX+EOJlkOu0+FrK080WIZ5DK2T6XW4wCV1P/Iq+eH\nrSnigt7rPr4a+k3MZ2yx26bMvCoB7DcyL/pqx5BPFilYPMz5BeOBfM/rn2unq8Tp\ncCYQuxJMmG3A6pYpqniOSeXDg9ZzoSHJ/rq/kwfujNkw3o3hVCcVi44eCN5WsTEx\nqmhKnZnW4en+hS78gNugMzIDKT5hn9qdeITLR41Qod2qGHv5Gm0XJRMbu6JTITwh\nrD/iKpiCEbWA71g14u27tir4p6H9gyP0deSCXvMzc0eOpTwFfRXA9XbY2Q==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_oIW2qRb0ux5zqjZJ","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -579,9 +2131,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:33 GMT
+      - Thu, 06 Feb 2025 17:38:33 GMT
       Etag:
-      - W/"63a345136c83fce510454ef1f7d8a0b3"
+      - W/"2a81e6c3c39f5e32e1c7b637f8137c28"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -589,1454 +2141,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "883"
+      - "884"
       X-Request-Id:
-      - 7241158a-51f2-4e20-8a4f-4a99defc401c
+      - 4b2f0041-e6a5-4621-b450-8f63b8e3eea0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3gboNKBwmhCPkqka","name":"Public
-      Network on tf-silly-howling-pewter","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "372"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:33 GMT
-      Etag:
-      - W/"f732b078ffeabf7fda42e49aba15b176"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "881"
-      X-Request-Id:
-      - f9e255ad-a170-4dd8-acb7-a06b31f0fce1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3gboNKBwmhCPkqka
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_3gboNKBwmhCPkqka","virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter"},"name":"Public
-      Network on tf-silly-howling-pewter","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:17:94:9c:81:3c","state":"attached","ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "496"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:33 GMT
-      Etag:
-      - W/"2d099e02838504ffb56a78144a370b93"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "879"
-      X-Request-Id:
-      - 7106d66e-cf17-44e7-beab-e9419ae1e194
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vm-hbTT7e49oNq4","resource_ids":["vm_Xw73PHIkW6UdG4A5"],"resource_type":"virtual_machines"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
-    method: POST
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
-      Etag:
-      - W/"004a830b8e12ae5c6bb0f8e3d08d98c9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "877"
-      X-Request-Id:
-      - 1edc9f12-da0c-494b-92ae-49e9e8e2c938
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Iuu7RcdwlTChGA6Y
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
-      Etag:
-      - W/"004a830b8e12ae5c6bb0f8e3d08d98c9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "867"
-      X-Request-Id:
-      - a63cbc10-d547-4fe4-a6f4-abd607be019d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vm-hbTT7e49oNq4-alt","resource_ids":[],"resource_type":"virtual_machines"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
-    method: POST
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
-      Etag:
-      - W/"bda71196a644e26cf68f6a4915096ba7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "864"
-      X-Request-Id:
-      - d7ba6cb4-5753-466d-bdfd-273c3a570b7b
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_OeVQof5VFMN2Ra93
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:36 GMT
-      Etag:
-      - W/"bda71196a644e26cf68f6a4915096ba7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "835"
-      X-Request-Id:
-      - fd5e6b9c-347b-42ef-bd3f-0700d7c7fc42
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Iuu7RcdwlTChGA6Y
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"004a830b8e12ae5c6bb0f8e3d08d98c9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "830"
-      X-Request-Id:
-      - de27c024-9544-4738-bffe-7d2626a2b93b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_OeVQof5VFMN2Ra93
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"bda71196a644e26cf68f6a4915096ba7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "828"
-      X-Request-Id:
-      - dea45f6d-3ffa-45c4-8e5f-43b0cc3cd4bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_iKkqjUAXcWmo737E
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "723"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"73f1c713e72044a25ba3cf05c20ab19f"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "826"
-      X-Request-Id:
-      - 2fa8c981-948c-46d7-be55-d58f2a0bb554
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"63a345136c83fce510454ef1f7d8a0b3"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "825"
-      X-Request-Id:
-      - 780d6aed-74fd-4241-bd3e-d3fbfb08b4b0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3gboNKBwmhCPkqka","name":"Public
-      Network on tf-silly-howling-pewter","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "372"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"f732b078ffeabf7fda42e49aba15b176"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "821"
-      X-Request-Id:
-      - 24ecf797-ae4a-40ec-a60c-536200067fbc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3gboNKBwmhCPkqka
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_3gboNKBwmhCPkqka","virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter"},"name":"Public
-      Network on tf-silly-howling-pewter","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:17:94:9c:81:3c","state":"attached","ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "496"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"2d099e02838504ffb56a78144a370b93"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "819"
-      X-Request-Id:
-      - 630c639c-208c-410c-b6a9-e61874b82bc3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Iuu7RcdwlTChGA6Y
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"004a830b8e12ae5c6bb0f8e3d08d98c9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "818"
-      X-Request-Id:
-      - ab0fb5b4-82ab-4343-87db-c18cd7580fd9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_OeVQof5VFMN2Ra93
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"bda71196a644e26cf68f6a4915096ba7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "816"
-      X-Request-Id:
-      - eef83e74-ce8c-4821-b7b5-5757e7925663
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_iKkqjUAXcWmo737E
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "723"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"73f1c713e72044a25ba3cf05c20ab19f"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "814"
-      X-Request-Id:
-      - d65a542a-2c13-4fe7-ab11-2b42f0a1ead2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Iuu7RcdwlTChGA6Y
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"004a830b8e12ae5c6bb0f8e3d08d98c9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "815"
-      X-Request-Id:
-      - 4738c18c-4b31-456e-b8e7-0832e65633fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"63a345136c83fce510454ef1f7d8a0b3"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "813"
-      X-Request-Id:
-      - dac0a3a0-8bda-4abb-9fa1-f432530221e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3gboNKBwmhCPkqka","name":"Public
-      Network on tf-silly-howling-pewter","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "372"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"f732b078ffeabf7fda42e49aba15b176"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "812"
-      X-Request-Id:
-      - 35a70717-47d7-4052-b41e-0a3a1047647d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3gboNKBwmhCPkqka
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_3gboNKBwmhCPkqka","virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter"},"name":"Public
-      Network on tf-silly-howling-pewter","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:17:94:9c:81:3c","state":"attached","ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "496"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"2d099e02838504ffb56a78144a370b93"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "811"
-      X-Request-Id:
-      - 1ac6f87e-4bb5-429a-9c4c-60b1893cf0e7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_OeVQof5VFMN2Ra93
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"bda71196a644e26cf68f6a4915096ba7"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "810"
-      X-Request-Id:
-      - d9f9f149-648c-4a86-a451-2c986f3a529e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y"},"properties":{"resource_ids":[],"resource_type":"virtual_machines"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
-    method: PATCH
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"c1be6d6f093ca20e0fd120a1b75c7301"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "809"
-      X-Request-Id:
-      - 0dcd6c9c-4188-454b-9d57-21c9f84a29f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Iuu7RcdwlTChGA6Y
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:37 GMT
-      Etag:
-      - W/"c1be6d6f093ca20e0fd120a1b75c7301"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "808"
-      X-Request-Id:
-      - 99c436bf-37fa-4366-989f-e009d7ca08b3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93"},"properties":{"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"resource_type":"virtual_machines"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
-    method: PATCH
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"251ea4bbe59ae6ab122d0cce5ee99dac"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "807"
-      X-Request-Id:
-      - a6825890-f6d0-4f57-80c2-d19453705d17
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_OeVQof5VFMN2Ra93
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"251ea4bbe59ae6ab122d0cce5ee99dac"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "806"
-      X-Request-Id:
-      - 0858db70-ce6a-497c-99e9-1da7581fd1b1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Iuu7RcdwlTChGA6Y
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"c1be6d6f093ca20e0fd120a1b75c7301"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "805"
-      X-Request-Id:
-      - 2040719f-7889-48ce-aa50-80adc40351d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_OeVQof5VFMN2Ra93
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"251ea4bbe59ae6ab122d0cce5ee99dac"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "804"
-      X-Request-Id:
-      - 67f2b9fa-7442-46a8-bf62-405d85e422ad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_iKkqjUAXcWmo737E
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "723"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"73f1c713e72044a25ba3cf05c20ab19f"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "801"
-      X-Request-Id:
-      - 7684f0c7-8016-48e4-84ee-7fd6566f0f86
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Iuu7RcdwlTChGA6Y
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_7mPmnWU44w2KUPW5","address":"185.44.252.219"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSXV1N1JjZHdsVENoR0E2WS5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM1WhgPMjA3NDEyMTIxNTQ4MzVaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPPgPAHssqsh8aMSHZqyYRBvd9yQKzy8dW9S\noO/jCBZhKu+6g5bFdJ68YyY6HXS/EkHcl2hmgI11/g9bx1jmolhS3xKxADp3VaG0\n1zqM7nKdNZEo5PGLiZJnRNJuPAWAWUVqphlu0xYzR85mQ6IFDMzagYV1KkOw+cxj\n+s5WZWKeFURVbumzZYPPGoffsFfbf3UfoQrlctPaWkmAiSAdBx3VM3fG2KaKwfTW\nwuQ5K8BKHKt5cd+gPmFTuyvRKEq0x7dt9Tw7QswUa8WsoieJC4DwxzgIfd2n8Mfj\nyuw4MTLUhRnsyDkWHzia5fgAGVl1vzWgs6Kps93I3aWPBE24fl1YAu6E0HW5w5Kw\noNtiTzEGfHu6lQBD0qrxX23Q9UcAF2Q/Nk++6A+r8uUurnksYEHmTZcgQrpvjbzr\nZh+YRpGb2eSgaPCSUVVlulaDytcp/bRyg//7QHL7h2OLJKVmY4bPBAPy8qjW25te\nFKbiMJ5pfoDh+pfSXRZPRxxg6thYkkbzP8X4LglgQxSQCVdFRAGwJo3M4ysQfSWs\nm8jNG2/LEY1oNXNhk8ZFKE/T36UXAHgzNFe5seFA/zLn9F+sggHkAdwZNINYsETH\nMpt4q7ztbyWGJCPEn9Zom2hVYAAtN8+LQR8fX6WV0xkttNS+TpkRKtu8b/WLIDCF\njE3l/EQRAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\n5nXCLrVK1iubWgeLCA5p19dCozATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3mdcIutUrWK5taB4sIDmnX10Kj\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9JdXU3UmNkd2xUQ2hHQTZZLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAYTsjHJD6K8Hn\nxM9HI8hZqpTaQxly/C3um0la0mD69ENEkjTDmCNzeUzca3gbef2LdNa7kmPOOteK\nLRT3lsJpTWhPWwIikfZg5p70QZACz+OntlPdQCWG8VoVYfTWOSj2ps98IoK+HRt2\nHwlvQuKfecajaYNEgwllhrnW2liebaXabAC9PT7tSf3RTv8hXTSIt60n8n8JcaSS\n/g4G2UjIQgnA+c+ERbEvhWn/3oIn698o0CrADbebZXwY9810OZ/veZ1L3Fz/A6Ft\nSeEHmYfJHNTaEy01Nlb+ZunDwUdAjjDwmpz72DJf0rLDAW5u5YQ6suGYNG9or98O\nmY8sWLlgb70aB5xLVfmFOstwn7c0x4jnJAKiqS01mphOhPRGlfy6r5CDo2QPNauF\nxpUGmYRtXgGG7CDywdxdsSJ/+TdyU0xq6cdAF82cD6FTg1RQngzmSor/P4kjJVpi\na5nfsmFl1oBX57cXQA1Fox3uZ2Nc7VchoPgtI4M5rcHf5EwRZluqzUfFL88Gh0IJ\nZa4TA1kmCfKMs+i6ZTsLQuJg6hOQWdqbCgel/vI3FZKT4rpH+rNG4+b4aGn4pzfS\nPrcSNLBhk0j+GqFyuVGPAenY2UnyUev3ta6F1zUl4HbE98QUqbudaI3fBEFO4fJo\na/cfLG7mdNTjb5a7rHX54kLmtZ+vNmI=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA8+A8AeyyqyHxoxIdmrJhEG933JArPLx1b1Kg7+MIFmEq77qD\nlsV0nrxjJjoddL8SQdyXaGaAjXX+D1vHWOaiWFLfErEAOndVobTXOozucp01kSjk\n8YuJkmdE0m48BYBZRWqmGW7TFjNHzmZDogUMzNqBhXUqQ7D5zGP6zlZlYp4VRFVu\n6bNlg88ah9+wV9t/dR+hCuVy09paSYCJIB0HHdUzd8bYporB9NbC5DkrwEocq3lx\n36A+YVO7K9EoSrTHt231PDtCzBRrxayiJ4kLgPDHOAh93afwx+PK7DgxMtSFGezI\nORYfOJrl+AAZWXW/NaCzoqmz3cjdpY8ETbh+XVgC7oTQdbnDkrCg22JPMQZ8e7qV\nAEPSqvFfbdD1RwAXZD82T77oD6vy5S6ueSxgQeZNlyBCum+NvOtmH5hGkZvZ5KBo\n8JJRVWW6VoPK1yn9tHKD//tAcvuHY4skpWZjhs8EA/LyqNbbm14UpuIwnml+gOH6\nl9JdFk9HHGDq2FiSRvM/xfguCWBDFJAJV0VEAbAmjczjKxB9JaybyM0bb8sRjWg1\nc2GTxkUoT9PfpRcAeDM0V7mx4UD/Muf0X6yCAeQB3Bk0g1iwRMcym3irvO1vJYYk\nI8Sf1mibaFVgAC03z4tBHx9fpZXTGS201L5OmREq27xv9YsgMIWMTeX8RBECAwEA\nAQKCAgAAjkI/aYqpWSpzygFx7iDKfiEydMxPFx7YDMLRHnNQ7xJp+W19/8qEPL79\nF09530rrW3/80j74vjbAp4o3aaR1DxCdukmF2JUZXpAe/LM5D6Kk8gg+L1M2QjCl\n9MUDk4dLNohVBoD0oVPzOchtq2qcDONpVRsDjHkFPjUUGJ5NMI8Gg4Cn3QDI4W/u\nCf8c3s3WNnw8yh5jh9vXebOA9I/6QWzHQ8IP9GunYys5Lz1/nVZIuGjKBFN1ZVDH\n3hzOuXAQZZppc2PI6JhWRaPDnfb+FDkKp6T3HFWFdGoXSl7SVCmkJXtPUKhBjhjN\nYogBlthuBtph7yu5wFDA+n0dWuOZfGEAfobv3J+eqH0qjjZXdwNsQoSv04LkiRnd\nDwHSlQ3ojYPIWW+R3dglr7v6IlFnSqeeH5osI7IAJR5TbXpiJeYXi5ApyphndARV\nynAnXdWbvIgu7o6WslVtTflAXsoz1xDg3c4WGy9BB+zF9DCSyTzCaFBxt91esl9T\nwvDfCIlzL68WgTAiju6QKgFGNj98rPIyUHjLDEBxjURHrycgKk7f9VbQ2GKlDV2A\nza+Gll/XJMRxCNua9FtXm3ScyoxzRouW+ec8PQwa9Svm8Y1KEvbhEGouZdpj8p7E\nkPx/C87iccyEMDjrI1R3mf/q7ScOJCZxZBxcxeK4q4WCHVTpAQKCAQEA+/um1tOQ\nyKYt16ODPnh6VeyIAR2aEKX6P1S6HwGalXIrK0tsUALLvzkfsFYYQWl3x3QZGxL9\ngWYozJl8/vdj0cPNV6NweRAZH4/Pfp54YOXwkvTYqHpxkFvsXWTD2D6wdIudcMC0\n3STg/mnN0kBQ8De6UtKTp858Kvu/3llZWhaJSw9kJjTiHdn1hWy7fNx8fbSr6bhM\n0aY234RMqf271tSP8ob6fJYAaTU01+cSu/bvjQDFgV5BNIgM8gASNJg9uOVRgsTc\nwEeK6rZiLFE9xiPNso/8V6rSSRmDPELSwfk8vG0bL8B+UISVjHyv5vZDTB8pl5U/\nT08iHoC6AUEBgwKCAQEA98N/WBsVsgDpO5ONxt9EXeXE99fzkxXAtMlJD0xgoKlT\nNaDV6nZ2EmqTaTUs+8G+l5OWNvcJunxsfNlpysatTj8LTde/8OtwH6v/+vuP8tmk\nxo3Je5htjT5fEDmTxSl4wBiEMbRkFRik7JMORL/FzFdibtbRWdWjufe0DOmKS16A\nSNyhWOByAHz07LeqUOumvYVvmUTVmNqyufORrkyWEU/2PFq6Q5Rzjm0aFtXRYk3J\n5KB7a80W+Ic1vG9O6BIRUaDKUFv6rq1J9UwGzj1sbs2Udyh5pwjJP2xuqZP6nIGR\nouUuGScbao4PZp1p3RdCj3kNxCJW84pjs0+hT4vT2wKCAQAlayVHWXtykFrWXs2q\nhTGFeO5pW//44OzcYrSQzigqcR2//B9FcmTXLKBsCxzm+cZzs+XWg2dpw8XjPBe3\ntPz5tV3U2cxl7eINMcnaP6YYnYywBfP2cNhUW5Ip/ECo6AZECEeE6tjwzf0rSoLp\n6esbAOuGSQbsMFl3+JJxbks6eYZBwzNYCRpa3Hb9LTxaOlOyRxYQSvH9X/VeE8Ne\nqvMt37rQhQLFZXECLoh+Vy4NA4pnIeoyX9DHAD0L4r7RWJoxzrvf82PkmbsjR5ok\ngpvtxHtTPNZ4HkHD4Sn/1Nx/OYevY3RaDvey9T1P82QbpA4yS55diCgymsmyReNZ\nNFIJAoIBAHCYWIvaqy5cuaGIedrR5gjh/XRAoIHMVeoSu3AHXrZEnPr3H5/Qu/G8\nm0cpkkrLDmll+dL6y2IDX24Rg8FSLrorbmCu1pyO8kKCcO9HWXCctgRBtTnE2Kxi\nluMRt3TXVve9bH4GI6FutKyKW+akXChz4djLKRKxQxmlVx6zF1UPGi+CjJSOU2Cj\naM8W3ICvxvPD6yZ1ILi5UpWs+hyC04QEmbtt484IbcdhD4UnIGOTRFfxEoW4C2Ng\nVuxOjUZrx5EYCDkiw7aUK9Mc/M7HHTrxlDHepAJjvMlk5pmMFU0AmQW1LxDhM9Vl\nv9v7V3vRMT9wXPAwRuGgl5SKcJ1sxxcCggEBALsKeVHgOIKpTDkPSPaT0TUfHQmp\nIh7RlmsiOjOOwh7K5CCp9YYg1Pv3jqwML7YYOBMUjmtPkdtT9V4b723vI2x1o7OR\nIOgrMoSLWoZ0B7wPW9QYdHHurs0iyTvK98dylW9eF80YtPB5xZewRSvKwe/KMjUd\nrBJDv4Sh/iFqNSig+2Yk2XOnRZJdA/AdelsI2kCOcB+GjaCoBa52B84jrvQXucsI\nG1GDHAdehtcSS+fAitzFAIgcWr/qToVzBPJQM7DdKIi6Q2TGi1887RhTbIi3e8uO\nN6uoJa+IE1tY4J2XMG4f/shG0uSKbIxBKo81BBo19s3ir4UlPZ+tHOiY6FA=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"c1be6d6f093ca20e0fd120a1b75c7301"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "801"
-      X-Request-Id:
-      - 58395ae4-b31d-48d8-837a-e9fa8d607657
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"63a345136c83fce510454ef1f7d8a0b3"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "799"
-      X-Request-Id:
-      - cae75d02-ea94-4667-b0d4-3b8d1b3b05a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_3gboNKBwmhCPkqka","name":"Public
-      Network on tf-silly-howling-pewter","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "372"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"f732b078ffeabf7fda42e49aba15b176"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "798"
-      X-Request-Id:
-      - e4f3b0cf-91dd-42d8-8c7c-43bdc6f56505
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_3gboNKBwmhCPkqka
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_3gboNKBwmhCPkqka","virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter"},"name":"Public
-      Network on tf-silly-howling-pewter","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:17:94:9c:81:3c","state":"attached","ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "496"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"2d099e02838504ffb56a78144a370b93"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "797"
-      X-Request-Id:
-      - 9a856381-2dea-4ebc-87c8-9c9dee25e862
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_OeVQof5VFMN2Ra93
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_Xw73PHIkW6UdG4A5"],"ip_address":{"id":"ip_8tA3BEBUDKsioZXp","address":"185.44.253.94"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfT2VWUW9mNVZGTU4yUmE5My5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODM2WhgPMjA3NDEyMTIxNTQ4MzZaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJXeiGw3QbpCq16J9Xq0pTaQ+0rGgzz7HXcE\nBFVxHs7tpEeK4sa5T4gFMcnVJh7SZ+f1ICyykvHKHcmGY24WQboF+tuldfuz+GYg\nxQ2U/oZBTaf38xy8c4lZ6U/UZpujeB8yg/ncfScEFofmaqobNB/0iS0CfVwfaFFJ\nxs6soCjrC2aAX0P7dWApgiyBHstiTVjo9Gy4kXaDAPQym/ki5yGLUHUm10fZPvLW\nGooGE67Geqy45yqsbbXS7hCsb/r5ykL2wRGTRKhOJ2ReO1mF9L96klfyvu84L8Yt\nA1bboI/pvh4jklj6DC3gDWawIBWnSEb7uef5xvE6l36RBUzFSC6W+ZKEZMYb60FW\nRBq1ie9Zpx0Ks2kKFjV+lXsDebi4UpwFWhiS6wgKdAVh6hVzkqPKzCl4iMsP+utU\nIejFa0GkEOA+AGjaybPfZq9HyM+4UbVcc3lgIebQHNvaPHZPfpN9V2tqX+32u8ms\nkpxRl00A1dxDFV7aPO7nwKp7+mcEqwjR4jVsU09P7Ye4aUIqx9cnJG0eSzzc/5os\nuwt29cy6sXi6m84N7jw4N6nlYwR+32pKl7PtCoAkIB6ojGfbqoilpdcJEZg558Gi\nJltvQranbXvqncJ4+18K9ECvRrFFmfx86zkEIWJONUxLFNwj4+d8j/mcbf9gNETF\n/e8+KmpdAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQA\n7v4MvGLXe41yOfnG9c4qdw2PBDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFADu/gy8Ytd7jXI5+cb1zip3DY8E\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9PZVZRb2Y1VkZNTjJSYTkzLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAhkvq7fdNheog\ngq9P1DRtgKB9fNnxaRXxyPCTb12/584kKwNzpGzh6vHfRnhLQauezOR9PFXDC4Z6\n3IfkRFCcfkeo8VU77k3F5yOwJaf7BY2cVoQnnOCjiJ4pTq7WWkgCL3p9GBZqe704\nturyXFRq2JAUgohYVbDe4maOSUr3NnxN2CQ4eqMIN07UQ/03bI7n93GEia4Jry4q\noswJNaO34e6JG35x31D4g/8gwa2k1edx6tzPHXTBt+38OFtLFu2dZ3Y5gFfrgTsZ\nkSpwLF/lMJ5mSI8/qMLarL2+h4F2SdUfZD94cT2/GkTnMBbaP0pBOeMLtyxHn2ir\n0tGYKJif9vnCmUFYYllZHRzGvrydxXg0IAU6eZ1sZXrmq6JuFjTWaLcXOSy9kUQp\nT0swbgumDwZnBbWLLUat/K3hSk3SkA7qOa93rHiAb/G4QFH9ODNa2b3ZQgt4a7bq\nEPk2qJP26tJ9zZYbHtLyCMiO90wyQRzZy4p9RQZDEWq89Yj6RndZkDheOyAsGp3v\nRGDRVvEjWEbYggs2n73XyZD7xIxohn0dAoTAcEZFMe9bzIUW5PyFg1GEGxjtNBpL\n5rx+3LsnthXkBmPBLbweWkWABd8siMk0tI6Z49ovKe4UiaYLOMI37apCnZPwkUF2\nT2geqnhlcl++4W3F/Jyis7DkSU+/gg0=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAld6IbDdBukKrXon1erSlNpD7SsaDPPsddwQEVXEezu2kR4ri\nxrlPiAUxydUmHtJn5/UgLLKS8codyYZjbhZBugX626V1+7P4ZiDFDZT+hkFNp/fz\nHLxziVnpT9Rmm6N4HzKD+dx9JwQWh+Zqqhs0H/SJLQJ9XB9oUUnGzqygKOsLZoBf\nQ/t1YCmCLIEey2JNWOj0bLiRdoMA9DKb+SLnIYtQdSbXR9k+8tYaigYTrsZ6rLjn\nKqxttdLuEKxv+vnKQvbBEZNEqE4nZF47WYX0v3qSV/K+7zgvxi0DVtugj+m+HiOS\nWPoMLeANZrAgFadIRvu55/nG8TqXfpEFTMVILpb5koRkxhvrQVZEGrWJ71mnHQqz\naQoWNX6VewN5uLhSnAVaGJLrCAp0BWHqFXOSo8rMKXiIyw/661Qh6MVrQaQQ4D4A\naNrJs99mr0fIz7hRtVxzeWAh5tAc29o8dk9+k31Xa2pf7fa7yaySnFGXTQDV3EMV\nXto87ufAqnv6ZwSrCNHiNWxTT0/th7hpQirH1yckbR5LPNz/miy7C3b1zLqxeLqb\nzg3uPDg3qeVjBH7fakqXs+0KgCQgHqiMZ9uqiKWl1wkRmDnnwaImW29Ctqdte+qd\nwnj7Xwr0QK9GsUWZ/HzrOQQhYk41TEsU3CPj53yP+Zxt/2A0RMX97z4qal0CAwEA\nAQKCAgANwz10mppu7WJpWx1E4xlCP+F5G25qh4ZMK1KZOhB3NjwzfwiWRpGMJICk\nT+5L6aHgcOfp0uL1pfbto762bwAi13ETAfMqEHvg0mTmJhGS6KT7UM9tiyIdBzm1\nZVmgNKHPqPGVB294HsL8QJJOWWiEVWN806a0HVo/ZMQHWgjsg7Esp4tCu0aAdIS0\nwOLAEKCZEpjSRxzB7QPbE66zxpsXvysTUbl2qqJCO0Z9TajkZZZXDYqE+7Ko04bz\nLF1YMd97c3IwF/23wFLpFPzkRWNAFj8hfnQ+6Zem3klZN5qwvJQDQTGrpBgW5RAL\nUbnl4yfFr6YsgbPdlouE9Eev+3SbrAiIhJYV+JpxX5NY2liLQsv2Os6er2/xdUVO\nKMSgtry8Si6kf+dXhOODTSs//NsfzEtenafA8Bz3Fnt2r04ZTSmHqmqxP83F98H8\ncbrMRSjReUZgadpXMoeSmsU1j0FRZojPgEUR1yQfFk+m/mhA9N5IRWkw6qphUZtQ\nLKKfNg1lwsm1r7IbQ1VCuC98Xi1etlID+xpYM7XAgjmAs6wE5DCGzud4Odmiu+lq\neswcsqrXEH54PYL/XvkniIz6JiVBKY+n5Jegt9YuylCHWkdof4CwJ0A1mOLwMSg8\nOYnpDicPH09hAwUMij+cX3lqj9kWAgqrxLIH04pL1jEcM/AVzQKCAQEAxNUM/itG\ndKCBs6Db+dYYEQp82ltgwhcoS8IgBduDBGxtVXSKSnAI0r30UPtMxIr2UNOK+6dU\n0iEyOXSSIVBFRsG2lhO1eaMVFOB/BVACD/XWJDFtxOiNSB0mZyZz8Y7e6EGborVI\n4ol0nCRddcm2ogpUJxsDlbkOY6FI/r4a/6Z0GQ5BAOYTjnZspP7qax/TZFeDxh7i\ny5+Am5+yM1aYgwaz7LYWRXHPOZCIS+AdTywdLqzZeHSAmaepnbIU8BSL146KmyNN\nb1b2BQDvzRxxDxcG4bxiNB5wA8VdA/2u3YJqA9ED04Ea9jX0UDrvGZKIwny7E5sq\nY65ZtqbyX+Q+EwKCAQEAwuuDXTGMhudphqyyxa6GwujWEHZBRylPIq+XlpMoePPZ\nhJjjzRo435aGUzIVoMokSr+RKJmMtOaPgzy496R7K2DZ40Mioma0VanlhUXGBFyq\n2mZpzRoGwqcOfhxj0Bwrv4N/goGJGE9jqgquukJrkryCopZA9SvtDQHTvrVKweIe\nt6GOlW7zaRSA48P8kHdFuFy3GoJygo2luenISqqfVIR8X9QzkMTTpA64RQ0DSLtL\nmyZ5BNFXha8fp8qgX9XveHVMrJCyvtDFsbwK+EhEphyX8huZ37AgAxh8Dy8X7XCT\nWcKGpRpn9OxNp259qwIS1gHP86uMZQCQVjVLzNYDzwKCAQAY5R10lEKgA6ED+Cd6\nbPK0TRBHieEuC0HEezQTqZTjnVcixM+s5IipJu9cwrwN68mFpYvhkmNvBFXW4ICP\nCBkK/vs59how3UiQUGigYmMwY5aHE11f103vPgiaaUmm1rwowguOQ8GJLXt7ODo9\n6JpZ2laUb50/dZ11SnPyDFdb2FC8zom4NGFq1l2dbMR3choJiewXxdZHjM/2Xvdp\n+NznTZS6LrmYZPGhxT8H4buzRNAYFDKZQpr1VDhmwpxVVTPuuo+bWZa0q1oIffrW\nhW9jSjVLnckJ8IOYZoECPTa9u33vJ6OFP8IKO/6/mwScxmTXvHDo5Ooym12rdWgY\nasTTAoIBAESPqqlBIHjjNQ8V99vow6YTWBh6QAPT1+4PbXadVIMW4s/tJ1OhgZfD\nzoO8/jaMY6+XKmvpdsC6yIgU98rDpD9h1cJGfww4q/3lwMHcBQbLwZ0IoPZvzSjy\nsfpR6hntjsXSbytsfNh8NEY/c644ZrY6cIjX6QlT5hHJLr3J7v27l6pnvUt6t0ui\n1qNG8LOwAGoU0qMUd0rMoBqAzN7WnSyRXV4nueuWEAuI0fAX36vZlYKBSdgT+oEf\nVDck4rxS9+Sa/dlFHFpZ/O/DgOhMIzl6nUefxcQUo23zUs/UdMoj6vCLp+izHRXd\neIMILlPUauOzx32iPcPZKuvn2z21makCggEAU/Ffimn1XXg08bOrDZ4v0p83zQ+9\nQB10aoFjdgKAO4kXDUL9A8M5Z2tVQqYef2Ce5tc0aiehNMQtdhasUAJdx6PxkEsS\nK3VyfBsdmMw4kNbsBB8Cc9/j6xyi6KHRUKeJm4lFgqy0FH7h5PQ2t1dCdS2SawRk\n46UHHwXb2DI137I7OGLxxOrFc6mN/ZJQ+pKFIiJvaThGjDTtbjLBX9StYlVcIrqP\nq8iEIOy2UITohPYGlVg/RmIj75wPaedOwWGN6JvIciEMIqDgu5T5e+P/lbHcUhqZ\ndwX/DGSe4fu4riA355Si/U9gyVC4W+oDPOJqEN7qCi2wxREAYSZlhhKhlA==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_Xw73PHIkW6UdG4A5","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
-      Etag:
-      - W/"251ea4bbe59ae6ab122d0cce5ee99dac"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "796"
-      X-Request-Id:
-      - ae84aaa6-194c-4217-81dd-ea7df280121a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93"}}'
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr"}}'
     form: {}
     headers:
       Content-Type:
@@ -2046,7 +2158,7 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: DELETE
   response:
-    body: '{"load_balancer":{"id":"lb_OeVQof5VFMN2Ra93","name":"tf-acc-test-vm-hbTT7e49oNq4-alt","api_reference":null}}'
+    body: '{"load_balancer":{"id":"lb_e5VQbKUat7qRTkPr","name":"tf-acc-test-vm-jwZDAdblU0XJ-alt","api_reference":null}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2061,9 +2173,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
+      - Thu, 06 Feb 2025 17:38:33 GMT
       Etag:
-      - W/"0294b44fabc6f0a4b0e333bf218981e1"
+      - W/"5d91d383912cddf18d62ad06ea5d2dee"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2071,9 +2183,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "794"
+      - "883"
       X-Request-Id:
-      - 5ab63f4b-4e06-48b8-93a9-cd7b2da075e7
+      - cc8887a6-5556-41e8-b8be-bb03ba004d3f
     status: 200 OK
     code: 200
     duration: ""
@@ -2084,19 +2196,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2109,9 +2221,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:39 GMT
+      - Thu, 06 Feb 2025 17:38:33 GMT
       Etag:
-      - W/"63a345136c83fce510454ef1f7d8a0b3"
+      - W/"71c219281075590a5cbb8381c119b589"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2119,9 +2231,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "793"
+      - "881"
       X-Request-Id:
-      - 2e240d25-f7b8-4dae-b6c8-50c3515b296e
+      - d0b6f0e9-0342-419f-87b1-56b5bfb968fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2132,11 +2244,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
     method: POST
   response:
-    body: '{"task":{"id":"task_MSa403N1kRN3rMPM","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_Rd4hQWGN8Vm0VKtI","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2151,9 +2263,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:39 GMT
+      - Thu, 06 Feb 2025 17:38:34 GMT
       Etag:
-      - W/"ad36b3f03e6fcb4f03d31c361b8c8797"
+      - W/"847deacaa28282cbb2f8810718a1f9ed"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2161,14 +2273,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "791"
+      - "880"
       X-Request-Id:
-      - 30cdf4f9-0eee-419c-9676-9f85cbdb2842
+      - 1c59896c-dc07-41ed-be07-5f47a9427e60
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y"}}'
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk"}}'
     form: {}
     headers:
       Content-Type:
@@ -2178,7 +2290,7 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: DELETE
   response:
-    body: '{"load_balancer":{"id":"lb_Iuu7RcdwlTChGA6Y","name":"tf-acc-test-vm-hbTT7e49oNq4","api_reference":null}}'
+    body: '{"load_balancer":{"id":"lb_KwweY4uJ5Vn7VNWk","name":"tf-acc-test-vm-jwZDAdblU0XJ","api_reference":null}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2193,9 +2305,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:39 GMT
+      - Thu, 06 Feb 2025 17:38:34 GMT
       Etag:
-      - W/"40734c30315d624294fc27a421ddf4c0"
+      - W/"55d091b46c6a7a9939c09ea8badf78ef"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2203,9 +2315,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "793"
+      - "882"
       X-Request-Id:
-      - ce7c7868-81db-4a92-936a-800bcbbec6c2
+      - 776519f2-19e5-4784-a65e-51caab759148
     status: 200 OK
     code: 200
     duration: ""
@@ -2216,11 +2328,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_MSa403N1kRN3rMPM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_Rd4hQWGN8Vm0VKtI
     method: GET
   response:
-    body: '{"task":{"id":"task_MSa403N1kRN3rMPM","name":"Stop virtual machine","status":"pending","created_at":1734018519,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_Rd4hQWGN8Vm0VKtI","name":"Stop virtual machine","status":"running","created_at":1738863513,"started_at":1738863514,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2231,13 +2343,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "162"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:40 GMT
+      - Thu, 06 Feb 2025 17:38:35 GMT
       Etag:
-      - W/"5e2df4d16a75ed2f972875e3bb52e156"
+      - W/"15facc0359d5768c0cbfcda9356b8c8f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2245,9 +2357,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "790"
+      - "879"
       X-Request-Id:
-      - 3f63c2f5-6450-40fc-b81a-60fa8e41f5e4
+      - 21eac948-08ce-4d85-89fd-f2037c870cff
     status: 200 OK
     code: 200
     duration: ""
@@ -2258,95 +2370,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_MSa403N1kRN3rMPM
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_Rd4hQWGN8Vm0VKtI
     method: GET
   response:
-    body: '{"task":{"id":"task_MSa403N1kRN3rMPM","name":"Stop virtual machine","status":"pending","created_at":1734018519,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:45 GMT
-      Etag:
-      - W/"5e2df4d16a75ed2f972875e3bb52e156"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "780"
-      X-Request-Id:
-      - 5ddd226b-4ac5-457f-870f-f97a7dd7bc93
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_MSa403N1kRN3rMPM
-    method: GET
-  response:
-    body: '{"task":{"id":"task_MSa403N1kRN3rMPM","name":"Stop virtual machine","status":"pending","created_at":1734018519,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:55 GMT
-      Etag:
-      - W/"5e2df4d16a75ed2f972875e3bb52e156"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "773"
-      X-Request-Id:
-      - 0872fe8d-7b18-418b-aa57-71d6946a4a6e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_MSa403N1kRN3rMPM
-    method: GET
-  response:
-    body: '{"task":{"id":"task_MSa403N1kRN3rMPM","name":"Stop virtual machine","status":"completed","created_at":1734018519,"started_at":1734018536,"finished_at":1734018538,"progress":100}}'
+    body: '{"task":{"id":"task_Rd4hQWGN8Vm0VKtI","name":"Stop virtual machine","status":"completed","created_at":1738863513,"started_at":1738863514,"finished_at":1738863516,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2361,9 +2389,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:05 GMT
+      - Thu, 06 Feb 2025 17:38:40 GMT
       Etag:
-      - W/"4a54db7f1c1746b06c8690758797ad82"
+      - W/"691f8807edd52235315ce12c3b9bd3bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2371,9 +2399,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "952"
+      - "877"
       X-Request-Id:
-      - 67fd48d7-a864-4b49-88cf-bc4886314f5b
+      - cc6243cc-9140-4cec-8139-75ad848fb05a
     status: 200 OK
     code: 200
     duration: ""
@@ -2384,19 +2412,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2409,9 +2437,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:06 GMT
+      - Thu, 06 Feb 2025 17:38:41 GMT
       Etag:
-      - W/"32464b325fba4ca39fb59f026fa4f93b"
+      - W/"b703b4a7e25f72ee6401089482510427"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2419,9 +2447,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "951"
+      - "876"
       X-Request-Id:
-      - 228a32a5-9787-4da2-b775-abc777ebcec6
+      - d69c776d-b8c4-4864-8010-ff1a19e17606
     status: 200 OK
     code: 200
     duration: ""
@@ -2432,19 +2460,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_oIW2qRb0ux5zqjZJ
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_N0ALRY15MNBMhrwN","keep_until":1734191346,"object_id":"vm_Xw73PHIkW6UdG4A5","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_Xw73PHIkW6UdG4A5","name":"tf-silly-howling-pewter","hostname":"tf-silly-howling-pewter","fqdn":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018475,"initial_root_password":"eh8sCHip4nsbDxu5","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_U0sxYmXutwA6M6wi","keep_until":1739036321,"object_id":"vm_oIW2qRb0ux5zqjZJ","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_oIW2qRb0ux5zqjZJ","name":"tf-important-happy-iridium","hostname":"tf-important-happy-iridium","fqdn":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"2YRWwmgnU9EPEJWz","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_iKkqjUAXcWmo737E","address":"185.44.253.61","reverse_dns":"tf-silly-howling-pewter.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.61/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_7FcKAmSPwE4XCKT3","address":"185.44.252.215","reverse_dns":"tf-important-happy-iridium.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.215/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_Xw73PHIkW6UdG4A5","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_oIW2qRb0ux5zqjZJ","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2457,9 +2485,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:06 GMT
+      - Thu, 06 Feb 2025 17:38:41 GMT
       Etag:
-      - W/"97cd642e348c8a2f62056c6dc4e3122a"
+      - W/"180d91b67f11fa7853e44c284aa5e8bd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2467,9 +2495,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "950"
+      - "875"
       X-Request-Id:
-      - 899909e1-bac7-4fa6-8a06-e392c8a678cf
+      - 54bb3a80-bab9-467b-95c5-165c27dd368a
     status: 200 OK
     code: 200
     duration: ""
@@ -2480,8 +2508,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_iKkqjUAXcWmo737E
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_7FcKAmSPwE4XCKT3
     method: POST
   response:
     body: '{}'
@@ -2499,7 +2527,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:06 GMT
+      - Thu, 06 Feb 2025 17:38:41 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2509,9 +2537,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "949"
+      - "874"
       X-Request-Id:
-      - 2f96ba67-fa45-4f90-a154-1030fe2961ca
+      - 1c4b8f86-7fb3-4def-a3f9-61c08d17cde6
     status: 200 OK
     code: 200
     duration: ""
@@ -2522,11 +2550,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_oIW2qRb0ux5zqjZJ
     method: DELETE
   response:
-    body: '{"task":{"id":"task_2mCzae3YpBA9lRYY","name":"Purge items from trash","status":"pending","created_at":1734018546,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_KUzncTKedJrt1yGz","name":"Purge items from trash","status":"pending","created_at":1738863522,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2541,9 +2569,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:07 GMT
+      - Thu, 06 Feb 2025 17:38:42 GMT
       Etag:
-      - W/"0a3942fb6cde2a489c23113da10891d2"
+      - W/"836c66ec711297a8494ece2c553116eb"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2551,9 +2579,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "948"
+      - "873"
       X-Request-Id:
-      - b5179b5b-b638-494f-bea5-0b05de226085
+      - f53cdeaa-3fcc-4563-8aef-c9bbe9fbd266
     status: 200 OK
     code: 200
     duration: ""
@@ -2564,11 +2592,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_oIW2qRb0ux5zqjZJ
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_N0ALRY15MNBMhrwN","keep_until":1734191346,"object_id":"vm_Xw73PHIkW6UdG4A5","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_U0sxYmXutwA6M6wi","keep_until":1739036321,"object_id":"vm_oIW2qRb0ux5zqjZJ","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2583,9 +2611,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:08 GMT
+      - Thu, 06 Feb 2025 17:38:43 GMT
       Etag:
-      - W/"92bd72eabda8c01698a1960c586f5950"
+      - W/"1046a42ee3a9d57b4513003ed395011e"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2593,9 +2621,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "947"
+      - "872"
       X-Request-Id:
-      - a83031e0-1aef-4b4a-a31b-0fc4fa7ea310
+      - 6c9ad472-7a91-4aae-8640-3446f13c3dc8
     status: 200 OK
     code: 200
     duration: ""
@@ -2606,8 +2634,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_Xw73PHIkW6UdG4A5
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_oIW2qRb0ux5zqjZJ
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2626,7 +2654,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:13 GMT
+      - Thu, 06 Feb 2025 17:38:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2636,14 +2664,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "939"
+      - "864"
       X-Request-Id:
-      - 704fe06d-4b8a-4131-ac23-00d3e78c87d0
+      - 90d368c9-c7c2-492a-b0bf-6cf30ab9ac3a
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"ip_address":{"id":"ip_iKkqjUAXcWmo737E"}}'
+    body: '{"ip_address":{"id":"ip_7FcKAmSPwE4XCKT3"}}'
     form: {}
     headers:
       Content-Type:
@@ -2668,7 +2696,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:13 GMT
+      - Thu, 06 Feb 2025 17:38:48 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2678,9 +2706,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "938"
+      - "863"
       X-Request-Id:
-      - 39d564a8-f3d1-4e59-bc2c-1adb36052ffa
+      - a162806e-95d5-47d9-94ad-5c93a457518e
     status: 200 OK
     code: 200
     duration: ""
@@ -2690,7 +2718,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_OeVQof5VFMN2Ra93
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_KwweY4uJ5Vn7VNWk
     method: GET
   response:
     body: '{"error":{"code":"load_balancer_not_found","description":"No load balancer
@@ -2709,7 +2737,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:13 GMT
+      - Thu, 06 Feb 2025 17:38:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2719,9 +2747,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "937"
+      - "862"
       X-Request-Id:
-      - 85f07763-65cd-4882-8bc9-414e8da94124
+      - 2fabaed7-e351-4da9-aad6-813c88b46a11
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2731,7 +2759,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_Iuu7RcdwlTChGA6Y
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_e5VQbKUat7qRTkPr
     method: GET
   response:
     body: '{"error":{"code":"load_balancer_not_found","description":"No load balancer
@@ -2750,7 +2778,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:13 GMT
+      - Thu, 06 Feb 2025 17:38:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2760,9 +2788,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "936"
+      - "861"
       X-Request-Id:
-      - 83a49d24-8b01-4213-96b8-5712c11afa9d
+      - 6cf6eca3-09c2-4a54-b88f-fcdd92c02144
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/v6provider/testdata/LoadBalancer_vm_group.cassette.rand_id
+++ b/internal/v6provider/testdata/LoadBalancer_vm_group.cassette.rand_id
@@ -1,1 +1,1 @@
-THkAuhPqh10k
+Sq8XLSemkbH7

--- a/internal/v6provider/testdata/LoadBalancer_vm_group.cassette.yaml
+++ b/internal/v6provider/testdata/LoadBalancer_vm_group.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "826"
+      - "930"
       X-Request-Id:
-      - 65b8a7d2-a80a-49de-b2d5-8245bd334a8b
+      - 0d67ce67-0765-40cf-b339-5476a107291d
     status: 200 OK
     code: 200
     duration: ""
@@ -51,11 +51,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machine_groups
     method: POST
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -70,9 +70,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"e09b20c9e270112f56f98e763064e9ec"
+      - W/"a32de4efcc94db89294f3b06d89faee9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -80,9 +80,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "827"
+      - "931"
       X-Request-Id:
-      - 76ad808c-0cb3-42bd-bc10-2ee8c992e0cd
+      - 902108c1-14a5-40d5-ada9-2d1472e79939
     status: 200 OK
     code: 200
     duration: ""
@@ -93,11 +93,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_3n0uvhy9xt2Gnc6l
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_zGHYlMlbBR2o6Oxx
     method: GET
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -112,9 +112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"e09b20c9e270112f56f98e763064e9ec"
+      - W/"a32de4efcc94db89294f3b06d89faee9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -122,9 +122,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "812"
+      - "926"
       X-Request-Id:
-      - fbc2b17d-9e20-4d97-b352-398437e77a73
+      - dea5b2b2-27b8-4c9c-bbf2-98df3fb0e3d5
     status: 200 OK
     code: 200
     duration: ""
@@ -139,7 +139,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"185-44-255-149.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"185-44-254-151.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -156,9 +156,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"995b38e1d14fd7d189ae8ab760052736"
+      - W/"30e93abadeb9274d381abf469ccafec2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -166,9 +166,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "818"
+      - "927"
       X-Request-Id:
-      - da8e7e27-af34-464f-a8c9-32b0989617c6
+      - dc80a6df-f098-4172-bbbc-938486fb6a0a
     status: 200 OK
     code: 200
     duration: ""
@@ -178,10 +178,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_Yu4vIT6oQW6R4CUD
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_Czi6EgcXgguwdkN9
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"185-44-255-149.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"185-44-254-151.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -198,1971 +198,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"cbdcc5f43e348d1e4e6b78350a975651"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "810"
-      X-Request-Id:
-      - 8ca891f5-7897-4c3c-8286-fd52f4021992
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Yu4vIT6oQW6R4CUD
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"185-44-255-149.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "579"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
-      Etag:
-      - W/"cbdcc5f43e348d1e4e6b78350a975651"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "809"
-      X-Request-Id:
-      - d3d24cb6-365a-4510-84db-bbe14004f1f1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_Yu4vIT6oQW6R4CUD</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-long-victorious-sunflower</Hostname></Hostname><Group>vmgrp_3n0uvhy9xt2Gnc6l</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
-    method: POST
-  response:
-    body: '{"task":{"id":"task_sLLD6BATrApLAC4B","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_BTc6WblqYbXN11k1","state":"pending"},"virtual_machine_build":{"id":"vmbuild_BTc6WblqYbXN11k1","state":"pending"},"hostname":"tf-long-victorious-sunflower","annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "284"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
-      Etag:
-      - W/"53bca318dac053a525c662e72f1a68c2"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "807"
-      X-Request-Id:
-      - d5e78e1d-b389-46b4-9b63-aea98c6ff2b1
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vm-group-THkAuhPqh10k","resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"resource_type":"virtual_machine_groups"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
-    method: POST
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:50 GMT
-      Etag:
-      - W/"86c9e81cdabfd7d59d3b944601d303ec"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "811"
-      X-Request-Id:
-      - 247bc80e-bffe-493f-9a5b-214093660aae
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_K5EyBtF1SfJwe4dC
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:50 GMT
-      Etag:
-      - W/"86c9e81cdabfd7d59d3b944601d303ec"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "784"
-      X-Request-Id:
-      - b30debcd-24d5-45de-a43b-11d3c816966c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_BTc6WblqYbXN11k1
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_BTc6WblqYbXN11k1","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.149\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-long-victorious-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_3n0uvhy9xt2Gnc6l\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:50 GMT
-      Etag:
-      - W/"59408aa902da69bd2c60a77ee3d1c6b4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "780"
-      X-Request-Id:
-      - bf34d890-9846-4aae-ad6a-f685e35c32f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","resource_ids":[],"resource_type":"virtual_machines"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
-    method: POST
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:55 GMT
-      Etag:
-      - W/"e739a0e922a108fd790cefb083efaa3c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "783"
-      X-Request-Id:
-      - e5c33a12-2737-46ac-ac75-eae0f80dbc4d
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_pXTQBv1RSeVFvhko
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:55 GMT
-      Etag:
-      - W/"e739a0e922a108fd790cefb083efaa3c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "698"
-      X-Request-Id:
-      - 9cc445c3-c553-4f55-9eda-a792a772ee34
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_BTc6WblqYbXN11k1
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_BTc6WblqYbXN11k1","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.149\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-long-victorious-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_3n0uvhy9xt2Gnc6l\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:47:55 GMT
-      Etag:
-      - W/"73be343373cfff3cf45065ea6721e512"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "695"
-      X-Request-Id:
-      - 8d8dc8f4-bae0-4014-a63a-6ff39df9b117
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_BTc6WblqYbXN11k1
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_BTc6WblqYbXN11k1","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.149\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-long-victorious-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_3n0uvhy9xt2Gnc6l\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:05 GMT
-      Etag:
-      - W/"73be343373cfff3cf45065ea6721e512"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "999"
-      X-Request-Id:
-      - f771b349-295d-44ed-ac17-2fb46889b1ff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_BTc6WblqYbXN11k1
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_BTc6WblqYbXN11k1","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.149\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-long-victorious-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_3n0uvhy9xt2Gnc6l\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:15 GMT
-      Etag:
-      - W/"73be343373cfff3cf45065ea6721e512"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "994"
-      X-Request-Id:
-      - 466c0bf8-d283-42d8-82ad-ccea223601a6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_BTc6WblqYbXN11k1
-    method: GET
-  response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_BTc6WblqYbXN11k1","spec_xml":"\u003c?xml
-      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
-      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
-      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
-      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.149\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-long-victorious-sunflower\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_3n0uvhy9xt2Gnc6l\u003c/Group\u003e\n  \u003cAuthorizedKeys
-      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1734018468},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:25 GMT
-      Etag:
-      - W/"f8f2fe1a568edb37484246c1d5606fb4"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - 20e07e9c-81ce-435f-a61c-f1f21c415e92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018471,"initial_root_password":"m9NDlEm6SLMw5ayX","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
-      Etag:
-      - W/"321e75c1fd70010117834bd9142a6c4a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "982"
-      X-Request-Id:
-      - 516c841d-80d9-4148-a332-842505f60abd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018471,"initial_root_password":"m9NDlEm6SLMw5ayX","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
-      Etag:
-      - W/"321e75c1fd70010117834bd9142a6c4a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "981"
-      X-Request-Id:
-      - 9b0ee89b-33ae-458b-addc-c5d80e2397f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_EjbN2JEXh3TaHeqo","name":"Public
-      Network on tf-long-victorious-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "378"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
-      Etag:
-      - W/"da6bab1e2b4326216845cbe815f4c28e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - ef604bcf-df23-4f5e-8340-3a29d164c8c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_EjbN2JEXh3TaHeqo
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_EjbN2JEXh3TaHeqo","virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower"},"name":"Public
-      Network on tf-long-victorious-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:46:5c:df:98:ab","state":"attached","ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "507"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
-      Etag:
-      - W/"573ee442d36e46d9cda3189c4d13aea3"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "979"
-      X-Request-Id:
-      - 15010bec-6afb-4ba9-bf50-a7ba4f34ad92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_K5EyBtF1SfJwe4dC
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_gNT9C9bX5uYEPleo","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
-      Etag:
-      - W/"8c20f5b1fc7d1d5b50bc9febeea79aa6"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "978"
-      X-Request-Id:
-      - 94f9efa1-2cda-4b18-bb35-bc72d4a62c10
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_pXTQBv1RSeVFvhko
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
-      Etag:
-      - W/"e739a0e922a108fd790cefb083efaa3c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "977"
-      X-Request-Id:
-      - 7f4a9244-d769-448b-bcff-dfb9a21c0bad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_3n0uvhy9xt2Gnc6l
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "134"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
-      Etag:
-      - W/"e09b20c9e270112f56f98e763064e9ec"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "972"
-      X-Request-Id:
-      - 150fefaf-20f1-43cf-b85f-a6f631d7690d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_Yu4vIT6oQW6R4CUD
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "735"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:27 GMT
-      Etag:
-      - W/"43d91a8564e4e30c82c02bc7f245bf83"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "972"
-      X-Request-Id:
-      - 0feb1aaf-5937-47d1-b278-4b43a97bfb2b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_K5EyBtF1SfJwe4dC
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_gNT9C9bX5uYEPleo","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"8c20f5b1fc7d1d5b50bc9febeea79aa6"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "970"
-      X-Request-Id:
-      - 2b58d10f-041a-4d35-88c9-bb4bf5a7b99c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_pXTQBv1RSeVFvhko
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"e739a0e922a108fd790cefb083efaa3c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "967"
-      X-Request-Id:
-      - 88c189eb-b326-4b7a-93e8-46ae4a466b14
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018471,"initial_root_password":"m9NDlEm6SLMw5ayX","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"321e75c1fd70010117834bd9142a6c4a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - b41b061b-6591-44f5-bfe3-92ee82d24343
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_EjbN2JEXh3TaHeqo","name":"Public
-      Network on tf-long-victorious-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "378"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"da6bab1e2b4326216845cbe815f4c28e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "965"
-      X-Request-Id:
-      - 906dcadb-405a-4afd-a00c-2bdc4ed828db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_EjbN2JEXh3TaHeqo
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_EjbN2JEXh3TaHeqo","virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower"},"name":"Public
-      Network on tf-long-victorious-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:46:5c:df:98:ab","state":"attached","ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "507"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"573ee442d36e46d9cda3189c4d13aea3"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "964"
-      X-Request-Id:
-      - 7a9f71c9-0811-45c0-bdb0-46dc354f2c2a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_3n0uvhy9xt2Gnc6l
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "134"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"e09b20c9e270112f56f98e763064e9ec"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "960"
-      X-Request-Id:
-      - cee3f657-865c-4487-bee0-fe34d3c7ff7f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_Yu4vIT6oQW6R4CUD
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "735"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"43d91a8564e4e30c82c02bc7f245bf83"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "960"
-      X-Request-Id:
-      - e4e4ebd5-bb02-492f-b0dd-367044df8c92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_K5EyBtF1SfJwe4dC
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_gNT9C9bX5uYEPleo","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"8c20f5b1fc7d1d5b50bc9febeea79aa6"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "958"
-      X-Request-Id:
-      - 1e693870-49f7-47bc-aaeb-40dd37e505e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_pXTQBv1RSeVFvhko
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"e739a0e922a108fd790cefb083efaa3c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "955"
-      X-Request-Id:
-      - 813c4d6c-42d9-4fbe-8598-1fd9fa3d659f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018471,"initial_root_password":"m9NDlEm6SLMw5ayX","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"321e75c1fd70010117834bd9142a6c4a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "956"
-      X-Request-Id:
-      - e20fa3cd-eaa0-4d29-a83c-e7c2241020cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_EjbN2JEXh3TaHeqo","name":"Public
-      Network on tf-long-victorious-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "378"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"da6bab1e2b4326216845cbe815f4c28e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "949"
-      X-Request-Id:
-      - 8c9ad475-e8f7-4a80-bb2a-8e29d16e39e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_EjbN2JEXh3TaHeqo
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_EjbN2JEXh3TaHeqo","virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower"},"name":"Public
-      Network on tf-long-victorious-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:46:5c:df:98:ab","state":"attached","ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "507"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"573ee442d36e46d9cda3189c4d13aea3"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "947"
-      X-Request-Id:
-      - f975c55a-2f67-4dd1-89b1-b7586c0b2862
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC"},"properties":{"resource_ids":[],"resource_type":"virtual_machines"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
-    method: PATCH
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"700c6cfe5fb892787e645ab02360cc69"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "943"
-      X-Request-Id:
-      - 56a70496-6f0b-41d8-b0fa-57aab443381c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_K5EyBtF1SfJwe4dC
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"700c6cfe5fb892787e645ab02360cc69"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "940"
-      X-Request-Id:
-      - 6997daec-14fa-45dd-b301-a6159c59b927
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko"},"properties":{"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"resource_type":"virtual_machine_groups"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
-    method: PATCH
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_gNT9C9bX5uYEPleo","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"6371a796ab73a7f4be339706e3a77cbf"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "937"
-      X-Request-Id:
-      - b3cee72b-8f32-4a94-80c7-f4d64a77101d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_pXTQBv1RSeVFvhko
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_gNT9C9bX5uYEPleo","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"6371a796ab73a7f4be339706e3a77cbf"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "934"
-      X-Request-Id:
-      - 30fe237f-18a0-453b-b8f8-88e7e05a8935
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_K5EyBtF1SfJwe4dC
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"700c6cfe5fb892787e645ab02360cc69"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "933"
-      X-Request-Id:
-      - bbf7732c-2ae8-4a3b-82b5-fb8e7792f1f8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_pXTQBv1RSeVFvhko
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_gNT9C9bX5uYEPleo","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"6371a796ab73a7f4be339706e3a77cbf"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "932"
-      X-Request-Id:
-      - ab7050a1-4dfe-418f-8f57-d1519009e3f4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_3n0uvhy9xt2Gnc6l
-    method: GET
-  response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "134"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"e09b20c9e270112f56f98e763064e9ec"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "929"
-      X-Request-Id:
-      - aee87a84-3734-4a18-a53e-2ed4aa05fd8a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_K5EyBtF1SfJwe4dC
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_pIB0cQZbb5oE3mzs","address":"185.44.252.15"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfSzVFeUJ0RjFTZkp3ZTRkQy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzQ5WhgPMjA3NDEyMTIxNTQ3NDlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAKsrHudtqV7wRuod/fR4kNP+s0KXl2iIDSu+\n1DqQovtepV3lli3gfj7QpmUXyw75P0S9EcVHeKKXmEZ8I9MZu/l0RK3rVXdRULq/\nFTexSNVPlmmwGoSpyAuCV29Mhq7y7Tb6g8eDI3+46yzsolRkj5kS/Aa6zIxyad/H\nviXD0Zx2W2KgAF2G0zHH8xsiTq9LOIfOZPY3++IC7RVKQeTzOO12z9WWU2Q18399\nRvmly+Tdt0jiA5l+r4Gp7JP4TukX9C3R1rzU0juloGjO3GN4dkyCHSmMTWl1zuMf\neww0o7fgsURvQqb7Z540vN0pbMiA7gBovqOP8rmV41cYSN0DSeCSUCs0tqGP78QH\ngxVXU/Ou3+6pdQHiDAYLGTwPnuqSVP7Mh6XDtN6fwJHg+0Iotwb5d5XtJJCwUYSb\nBwcPcxVaWN+H7PSCLTrImBNqq2pjVZFzSl1PD4DGkWLcs2jvJi0rCPJfnpxszT9A\niDK+a3ps8nWBPeMzpciFrZjG2G7HWQfIjhZQE+wutck62bJIpqU89wf1wXzsVarz\nt3/WbmQ+03XcXimdXn+Yz6rOInmPNv4NZWB3Zo6MPpNHX5zHc0lnNvq3t0fLmLRq\n+212iHUUKKkdUQmFqD6VUlD2w+8Wz7KZ6SODy9yncT2Rl0Rgessc7XUG89z8s/xB\nKLY8sGU5AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ3\nZ5RKw8+2hNvnFM4+zNrLxI5ZUjATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFDdnlErDz7aE2+cUzj7M2svEjllS\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9LNUV5QnRGMVNmSndlNGRDLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAQ4zkI79F/Ic6\nLx6hMzEoa5hkNY6Jxod3LeDdl+DaNLc9dpdoG9uXNKYvLWMWuVN8jE/V1TfhdsRX\nICbxl/UUNfrkaYL4gD2IeqIneTmJXAEeoXvTAt6+2zIDf4HMnJ2pgPJ76SJStPTk\nfCX8z7p5scbuuAtOG3sInlh/Wj2QYmNLGkqFp2f6FYfmxG7ER8ky9s3DzIM9PEkn\nOYbRqiWH+GNYAwJK85zjYrqqjW/42cdJ4odroWBPyDxkoon2i46F/3L5+A204vda\nPyTi0YifEKTNEYzGUpYKXvkWRoyvG2aX+MMe8zvCzyk2AXX7rP3oCvdoS9pxeHQg\nY3A1CJIGrFmL62ids7Ay9fi6lT93OXKsvo7DMcaE1S/5ns0iuA+GDhHlydUzbTJN\nDbKn7TkUr3mk5vNkX1NaIrd2EqjOW1ptcp9qWb9iEeWB9duAvEPtulTRqecLhMRD\nAxE2gcYNlI0Z0oMeywyIv/fAGxfsXKdnUzbIzyZCtaARU1tyrs5gOpdOhUoXMurb\ncnVlv2X8LTQddkmLQhXj/ALjZPoedQ+6mcbetchWsNRaZGnSN2mENUITm73UKGlW\nZJaEiMqIcq+k7t12ls0wUrDHvcUoV7pMBZENS5wsvq0L5Izpgco7SlOr5uqysTpb\nondynF6etDq4q7LVmGXBY3QX9aeCv3k=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAqyse522pXvBG6h399HiQ0/6zQpeXaIgNK77UOpCi+16lXeWW\nLeB+PtCmZRfLDvk/RL0RxUd4opeYRnwj0xm7+XREretVd1FQur8VN7FI1U+WabAa\nhKnIC4JXb0yGrvLtNvqDx4Mjf7jrLOyiVGSPmRL8BrrMjHJp38e+JcPRnHZbYqAA\nXYbTMcfzGyJOr0s4h85k9jf74gLtFUpB5PM47XbP1ZZTZDXzf31G+aXL5N23SOID\nmX6vgansk/hO6Rf0LdHWvNTSO6WgaM7cY3h2TIIdKYxNaXXO4x97DDSjt+CxRG9C\npvtnnjS83SlsyIDuAGi+o4/yuZXjVxhI3QNJ4JJQKzS2oY/vxAeDFVdT867f7ql1\nAeIMBgsZPA+e6pJU/syHpcO03p/AkeD7Qii3Bvl3le0kkLBRhJsHBw9zFVpY34fs\n9IItOsiYE2qramNVkXNKXU8PgMaRYtyzaO8mLSsI8l+enGzNP0CIMr5remzydYE9\n4zOlyIWtmMbYbsdZB8iOFlAT7C61yTrZskimpTz3B/XBfOxVqvO3f9ZuZD7Tddxe\nKZ1ef5jPqs4ieY82/g1lYHdmjow+k0dfnMdzSWc2+re3R8uYtGr7bXaIdRQoqR1R\nCYWoPpVSUPbD7xbPspnpI4PL3KdxPZGXRGB6yxztdQbz3Pyz/EEotjywZTkCAwEA\nAQKCAgBUzKQe24FRe5BmZD1wZFq77C87CocEToLX7U6PRSC5kAY1IozoZZOl4xDM\nfKEo5eqmT1UCe4oUYy4ZnV7SMqmhyCxOTYyl9C8elZQZZ0dCBo/qBEje+I4WxZgz\nl6ISAl/rIOkwapOnryEzvHgff0J0/6bEXr7/xZ8WMorNgtnRvgFANyx3KVhwDTMv\neiupRIbZITN7l/i9291A8uz6VFUbsAT/N95QgzoDKzmCbNU6qW0oOnC2FsE0Z87A\n7/+IE0nxeUf9fSI6Uq/JvNIKpZ9WABAaiVvAp5C7jNkVDu8dJcAsu0I2H88R3ebD\nWsZ9/wHqSfpIZgRGVS+v8mQGup5aSAVCyPZOaBP0Rl/aHBOW6xmkvup06oNnuVZL\ndRsvyhlsNb33TFYOsjZOazd+J1Uonjd4RUU6RV73Uohn/GNphNGKew9VzKJT404w\njzlbmPkKDmdpznksISqb5bl56WBQqOkS+zaPTEOCNoz5mx/74eA+DuhDLssKnu4k\nGiAZQQDPRO6YtgwZbO4kSjYYLrffkEaCR2S0ozc0iTor7GXJUYQTU1ntpJrDkw7I\nNLbiopgHu9/rx7b/uFF+0gyFbvG3bLO/Z76hiBWQ2lH6fKMsGZpHcW/ahzHZz6qy\nz740025ncwT710SEpbW3FGcY8DUdB+JCWOmflavAqVZcCLjaEQKCAQEA2rl/hQY9\nMOcvOdAlxFFV2Lo3X0fF4OeUmr3kWNZAtnQ2TUTu6FhgEEXbyQTgz7hugWxdfrF7\nzxn06OWhuejBO3jwL1gyra0UjLH1fzoZynK1QKrbRqHRsBNo+4/OcTURaEhiTRRb\nAWzbBmfiJ6Jqr6lbveJEjy+v059YBEAmWb/AiEaYknXFBCCimXqNyWwzFuBrYmbP\nLfmLXBIirOgL7qIDfGTEU2jOWYI7xdbvmTu+no9cdcHwnK574WStGw+MoQR5YJZH\ngItnyYVZACIH44SF/Gl/5b/CI6Kh5bfRp9nulKk6OxJRpTxTEs+XmG3glbMhJRAz\nv/4Ix89Vy3jsDwKCAQEAyFbYfD2gp43UZhfbI0FKvgQIp8IpY5J+5mwFNp7+Z3WA\ncAqxeiXwokzRRJsw4cB/BabwbDLPKJxqsGXgzVRJpd40seqBFM6dFzP0n9RC3Aby\nuIZmxMEdbGngpVSuPogJbVTj7oK6wh4T2Z/C+rAHDTQo0FVj3JUuub7AXSIUof/3\nYZnbgBRNIYC8V41cB8JUD0T8J5AS023Rj+XJ2yM0hbQS2TsVQVCd/ojr7gfMfvb4\nwWAod9QOQCqTMQgnsL+nd2uGxN4hAkyXGDa+Z3gdK4tvI59Qa711lpUj5f0pP1/G\nuLu1t1wgO351R9KDgLGR9aaNEZN8VN/pJvpGzvlyNwKCAQBO9qEe+T2mJhBaota/\npU2EzNWoxFSf+Xsg0mVZ3R/HvvTLuJM3tpAXz+ClFenDlCXw+5pVXuX/wrM0UZKt\nd2YrfmHX9dN1+AJvOOAUanldKURecFBxk4IMOzWvfB9fp3T9XQSAJ1UjkpUQHvj6\nrhwuBspkJwfxWZn0oJY6Ep7F0ABGMpZqabIS52VMW35MtY9MNwENqWgqhOjW+IUk\nPzHvmPYBNq/aHQBCOE40AoDFpVgQDlmm+blQF34JxTrphheTGfZn9FkkAzAZBNc4\nwRBwBywIEF5oJ26DRveD43UBUCBd8ypeoSJwsPKc2+0yzphB80WIB+1m5uNsn2Gt\n753pAoIBABH7CW8NMPAY4KlRFs/xOj4Xqpcz6/cN3OndZBJk7rxmZWKo8wjdgt1u\nO5IGw7pfRodBVm6/mKwybbjrS+Ph3sJOUThurasqaBr/BMObj2ykCwDYvzyFgJiM\nYCc2lHT0TLRNXC+59/0YKfvsRNmvFtLujYM1RsMzeIAfSLCTMHrhuFhAMN0r9Ug+\nf6jz/QCNRnIgZOlAGxBy2M4rd5R9cmdVpCNvFBdKnwOLUnGIrafvjp/8e2VV2PmV\nWKSb8MQCT4t+URg2P4wvR5hawXgT5bpUx2LRF6yz0mvzcsdfk2YmuHU4E7UjRZlR\nXkFV+YuBZHJBwoODUzNi7VAcQmKtLL0CggEADM1PLsPW2HqMmuJPJKFrO201dbqQ\n+2zNiOvSyxCPWj8TtFk+5KoEaj/RPWR3bBW1GI2CBoseApUSwwO3Br2P4iRpNQ9e\nxTb1yXfwf1deUeOtS7J500CROBOMzE2eosMczQ8vAZMGNAtffGBioABXN42HPZ+E\nieJZyIDD/dKqiK1Knrms+XeeYEt4iAvOkhqcrBTnWVF5mDxu4vUpCDSmCnaVKKJp\nw5gbvO09koJ7QiQw1dH7BZM1Qa+uS6HZUsEwgKPY13D1BnfomY5j6Zdn0Q6d3eJ5\nM7uX+lQjTQX6Ewnuk6rz8hln/30IbAU02bww//v7661h3riho2y/Q2dUBw==\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"700c6cfe5fb892787e645ab02360cc69"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "929"
-      X-Request-Id:
-      - 1e8ff035-f95f-4d0d-b965-7ae9bce243d3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_Yu4vIT6oQW6R4CUD
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "735"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"43d91a8564e4e30c82c02bc7f245bf83"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "929"
-      X-Request-Id:
-      - 9cd74404-54ee-4102-95ef-c0e36e4a52d4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_pXTQBv1RSeVFvhko
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}],"resource_ids":["vmgrp_3n0uvhy9xt2Gnc6l"],"ip_address":{"id":"ip_Ig8xZHIihzsCgf8B","address":"185.44.254.209"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfcFhUUUJ2MVJTZVZGdmhrby5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0NzU0WhgPMjA3NDEyMTIxNTQ3NTRaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAL8kftzbrNcXfBy6RFUeWNejuXkA7T3reOI+\ni06zBD3dF6oAXO89cZugX5FDWebFLFtSQQ/kf+xOMYrCVoGWtN99Gv/60ivvgimm\n+Yli8x3tBzbcHhpeAew4mAVZrb0TQ3isH9wkAeQJUEQfHMUu5O8zKMCcSNY5BzGN\niwo/9R74NywyTa/hmv0y5UI53StnIlWns3l6UmaBMhr3vvgw+0vcQ2jGK79dxC4b\n5rOPgGOv+M0XH7yJc+3auJevxkHQ1N/hH+EXuIwx2mzFjwD6yKflmPcsVemG2kpW\nGp+JSU2u7LA/OhVjjnFqWTvzQFdQmjV+URdKD5HgI3PvUBiBE3QOe20pbME9cWRt\ngM4rVx4lUY+4auQa3QjktNX4C6aIzIkSpYeodavrOdBa+otSSJpTaP0BPO4lesLw\nImOf2Waqw9OhgtTqD+29HlJImwaoeOiAINifS0kXYey9QQGCzuna45y5VQtazsrR\ntjoVLOgUSptrXEZtkzhV/Zz7oSpTTIwAUcm4oo1RCeBsdIlvjcTSTOXCvuMMwk8z\n+1fza3l6dzcYtQqRNFJC3eaGg1XkBTYL1WcRi+BOMIaG58/P6S3diVRGLhzIRXJL\nER2GKWcZY44sqAp3aE8yqabQhriZ22f7yLMKF7nmPt4ZA1mVbTKhA8g+GiQILP3w\nZKG5jtVvAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQ+\nZY4PS9LrfYCX8wOPWQjNtJ/5TDATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFD5ljg9L0ut9gJfzA49ZCM20n/lM\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9wWFRRQnYxUlNlVkZ2aGtvLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEANCpfCJPX3nsY\nvsWS1SZQgdgWmEOOIXDoee3UGlpVNlWGFvpsNLNWSoju9NIqKGqu9P0J4/owBAuw\nxwxcFh0KbPPpa5tOqGzQ+27j8ijSeqeXSVA/LoF/KgF7BecYaDWTBp/hfLjCEGyS\nXuddB2O2hcwNQP4MjRNjzQltlxpV/TEso8h5P7sF08G5S38JtX110UlX8fnLGNHm\n+m9DxFo0sMeqzbali1KJoT3ksyyi4AOuO28irKz1d/Ryu1dZbHxy+6+iNvt/QX50\nQXlsHDmfh3A4o3NTjR+MrY3nOKCzlTe3Gi2A7NVu5OaODUf/8JqX7jNKAHyVcxOX\n6WHeGSfVx+k1928l77Byg9PrsG4njJ6PUZvqLgaCtKvtI2anrM2oPAhkuj5SJ6ZZ\nGOUpeWvsz21rdCx9lb9pTAz7EqICuZAvu9X/xWFf85sbeGnqyIXUI96a0LdLYWNg\nsxd/twvSEteF4VoOalh63nzrT0SlrODlxyImOsEQXt1Agi9nmv5qfBOQ+4+5K46Y\nidQfMXLD60eveFAtBQ55UNtcmQgAyFt0LHJu0H4VkXkjOyabjNzkeBcJ566McIj3\nc5CVc1OPtpXRr3jojLLil8fQ9fpFCveKCBmk8GQO4O6MJJVd+vhaejABIuXp9mS0\nUD01YU6HBzNpbovdtLvO8NRo5kzW+SM=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAvyR+3Nus1xd8HLpEVR5Y16O5eQDtPet44j6LTrMEPd0XqgBc\n7z1xm6BfkUNZ5sUsW1JBD+R/7E4xisJWgZa0330a//rSK++CKab5iWLzHe0HNtwe\nGl4B7DiYBVmtvRNDeKwf3CQB5AlQRB8cxS7k7zMowJxI1jkHMY2LCj/1Hvg3LDJN\nr+Ga/TLlQjndK2ciVaezeXpSZoEyGve++DD7S9xDaMYrv13ELhvms4+AY6/4zRcf\nvIlz7dq4l6/GQdDU3+Ef4Re4jDHabMWPAPrIp+WY9yxV6YbaSlYan4lJTa7ssD86\nFWOOcWpZO/NAV1CaNX5RF0oPkeAjc+9QGIETdA57bSlswT1xZG2AzitXHiVRj7hq\n5BrdCOS01fgLpojMiRKlh6h1q+s50Fr6i1JImlNo/QE87iV6wvAiY5/ZZqrD06GC\n1OoP7b0eUkibBqh46IAg2J9LSRdh7L1BAYLO6drjnLlVC1rOytG2OhUs6BRKm2tc\nRm2TOFX9nPuhKlNMjABRybiijVEJ4Gx0iW+NxNJM5cK+4wzCTzP7V/NreXp3Nxi1\nCpE0UkLd5oaDVeQFNgvVZxGL4E4whobnz8/pLd2JVEYuHMhFcksRHYYpZxljjiyo\nCndoTzKpptCGuJnbZ/vIswoXueY+3hkDWZVtMqEDyD4aJAgs/fBkobmO1W8CAwEA\nAQKCAgARmXhTjlKKzNnGV2GaqMcAtqLe67aXIKBVIfHNFu9JYZsf3GqyMz52WDzp\nxiwindMTZtkgxScA3hjyWtSA7XHNW4U/PpwCzvR1hgSsoWobPkuPbJMaVb+S6DRv\nLFkH83HJ9vyeq3Nqc2/AO1EjLXSHkHaseCITairUZYurhO9lS5uLkTzVTfjptA78\nmxFXQWbIQOm7Qge7nSJnmJotMMK4CG7t2G6yGch01RLX7lr2/X6eJlvrYzNDxQOB\ndqjS6eSVPJ2lKdGkmaPap2d0bU2eeqXWqcQQqDRfQIWxB4CythbgX4ynPYR3GEC2\neWkE4SIMfOCrO/bVCrCY/db/z/AMyISphY/uThJaKIvcjSyQ21+aT8G6UbcAv0EU\nMrBPpiVZRmFepvzAOScdsj8SLsjoFvbzoRMiZA6E7Gg6bpAnpgUAnXulgXFp9aUG\nr+Lu992/F4BX6SvX94IQFi2lM351rsWPd5o4Ex3nE0QVEH2d54BINVkLztq1axdL\nGBgaC44GylTSgUgm8D/1dUpHACJu3EuN/HfolZ/BUSRxOdQ+uRa/x1pLHkHMUWXO\ng1IGeO0H/GuMJKsce9+RGhm2mueT/VYVYyPnM3+1HR8vc7+kRAsCdzoqey3nzOZw\nr/2RtY0bcuEE0SzYOQZouvhY6QGuGdOtMJbgQbq1E/Mn4F+SGQKCAQEA4AtxvzUR\nuQbMEprT0p7TuP/e0W4cyzu1v/2rew1AjcZUjB8qELtrA48MgfRzdPo3jp+1DasT\nxVvvc7wzIngK5MtMjrLRrQONzjdPpjFOYqCf9oV54zseXdkKiJAB7kmlqQYGUncI\nYg/E3fk8oE2WIQ6uJHFai+204VtWyeF4xEvjJi39Cm/5bjVRUEolT557ZH2ukiTX\n5z1AUJ5z/8gP7PXzulkZryZYK9G8or/Cjrp8cljHzOXRbc56rX2WEaufai2uoLm9\ngz7XBZ51N0oWwaO4UTXYiPw0Bf7dcLcWfr+FSqy5lBB/yCcxXJGC2QLqpTtQp1o2\n73NsYZ0c9ZnmjQKCAQEA2mexjzwBHMoRRHvJZumru2RUF4EqjNHv5ypw2eFok8r2\nqzVVpO68s7Yu94W247j5YQggywXDgDmYsISARQt0ip7UqQ2DfwyZGqC+AqkfFq57\nws3dhJGnJz3d96QAI9CMFFBnnZChRPDDoun84XZ5UIQv5fQ/gNAxzE7cZqSip3Mp\nRKsnI1D1Pvq5glyjEHlZPH7INTr7xDoyVKF5aeyrS6936dFO1CED1tc47j+EyKnf\nFUkRPOcPKPQ52dU3jaSmqgZxe9MMPj3qW0/RNSGUUbpFOVwloL3qGSf0Y1JE6NvI\ncjea9ewhKebly1iogdhaPylkE6SVWjb7WWZyKU166wKCAQAVgoPFK78r2G83Sg4U\nJpOFK2ulB8FT8cOdTylrgvYzplrvqP5M5PF9Qfqdb262SF+VHdgwG8CmLhFrNyJh\nqMzC8pHDEX/38GNo7P6Eoi84YNt6u43cNwzPTcspGUpWKlPxSlbJDAyN/Z2VAhzD\n9y72tYYakZdz37qB+Fb4wuDpV6/TNo8YtW9pGU1ZPAUhA8Is/7QG6+qelM7b7pqM\ncBS3V1WzCmLg4fmNG3HU3jw7n8Pa5pMoJNhahnxYs7n4sFV5yDD/1VVQiHP0YiY2\nzLIqnSFRCq5jWHNWMAXqkGlkeda+OJ8IjBz4hmrCzGWXmCQXAP7ZUlv72UUKih8B\npWjxAoIBAQCnBGcHVuau4mPEEDmbJpR6UCXyd4dXeu/PwmfcZoC3jJ2HndipsRvC\n/k36YVnT2U9zgWi6eOThOKpoSltg8XqkywNrZ/coADVQ5J2JoVUx3iqsdQuyZkQC\nQVBuIQ8uVDvbCQXDu6dn9gpVmkQVEqmBBiUu39J0KkH6sE/heoMcNHfZmFzsp+tz\nxv54D2lvnqy8E2P9OObxT2PPzk/vzdnMnhnAR5zVoY2zDJDvuMlNPoJnX6H8BeJU\n+jcHOwMpoUEGgrjj7SfOrUB7pZUh4VTwDtcDH1FzE+hiZmiAT5h8zh4CIj2xVGqk\nBXuzPlBWQ2H4LSnnz5ObErKx0iL5LNQTAoIBACI5I8ySZqeQiHP7Qth+OoENccsx\nM0fmc0THc68/GkWygTuKDSKHhE0HbLevmTKZ+MYlRQkN0d0IJ+XURtLDO5YEMmMk\nfcnFx5I9lxVMTM3GcH7IAw76AocQMSj+uR4nPMTmohLxRXTGYxfuzEs4LBM1IRQU\nzlKomVmvTJUj5qOVB0Niej/g/Yem5x51BihbdBR1hDk5Ud3wyh3NYphnpfF2wDiv\n6iOiAEW8dQ9KwAZeZ9tQRJp78uTnwyNSPeA1TAmUKTfq8NNaUEU1bTcOL3bJo4j6\nlX8d4iqQR7eC550OKsBu741UB8xWOsu2t6p6AS10E+O8lGSrWEhND0pJ5QE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_gNT9C9bX5uYEPleo","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"6371a796ab73a7f4be339706e3a77cbf"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "925"
-      X-Request-Id:
-      - 9234b330-7533-46b9-a9f7-8a90586e0a80
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018471,"initial_root_password":"m9NDlEm6SLMw5ayX","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"321e75c1fd70010117834bd9142a6c4a"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "924"
-      X-Request-Id:
-      - 8791d363-84a9-4df7-ae30-976b9b4857f5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_EjbN2JEXh3TaHeqo","name":"Public
-      Network on tf-long-victorious-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "378"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"da6bab1e2b4326216845cbe815f4c28e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "923"
-      X-Request-Id:
-      - 4b6bb463-ebb5-42e3-8632-5e98d304c2c7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_EjbN2JEXh3TaHeqo
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_EjbN2JEXh3TaHeqo","virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower"},"name":"Public
-      Network on tf-long-victorious-sunflower","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:46:5c:df:98:ab","state":"attached","ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "507"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"573ee442d36e46d9cda3189c4d13aea3"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "921"
-      X-Request-Id:
-      - a1087214-7135-4e4e-b46b-9af1bd1a0605
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018471,"initial_root_password":"m9NDlEm6SLMw5ayX","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
-      Etag:
-      - W/"321e75c1fd70010117834bd9142a6c4a"
+      - W/"bf94d2053abc5a96ec9c4328dbd51c36"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2172,7 +210,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "918"
       X-Request-Id:
-      - 4ecd707d-9b45-4129-b788-1d37422807b2
+      - fb4f1195-9e54-4785-bec3-d016254fabfd
     status: 200 OK
     code: 200
     duration: ""
@@ -2183,11 +221,2086 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_Czi6EgcXgguwdkN9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"185-44-254-151.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "579"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:45 GMT
+      Etag:
+      - W/"bf94d2053abc5a96ec9c4328dbd51c36"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "917"
+      X-Request-Id:
+      - 6c824f75-367c-4310-a35e-c7a57be2fb65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_Czi6EgcXgguwdkN9</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-ambitious-handsome-lily</Hostname></Hostname><Group>vmgrp_zGHYlMlbBR2o6Oxx</Group><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_thA2mWMHfFiuakHy","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_zN3F8ESuuDsKkEVp","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_Qwj3HO5CvN5Ks1l0","state":"pending"},"virtual_machine_build":{"id":"vmbuild_Qwj3HO5CvN5Ks1l0","state":"pending"},"hostname":"tf-ambitious-handsome-lily","annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "282"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:46 GMT
+      Etag:
+      - W/"faa3b1989768e1782543c9f4546be6db"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "916"
+      X-Request-Id:
+      - 9c979380-bc83-4724-a89e-573c6d721347
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vm-group-Sq8XLSemkbH7","resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"resource_type":"virtual_machine_groups"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
+    method: POST
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:47 GMT
+      Etag:
+      - W/"0690e08e4f9c09b09b9c6ae3936c06b9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "925"
+      X-Request-Id:
+      - 9a51fba9-8220-49af-aef4-6157c26deaa0
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_sd0aQzMCc15JWJj2
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:47 GMT
+      Etag:
+      - W/"0690e08e4f9c09b09b9c6ae3936c06b9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "913"
+      X-Request-Id:
+      - 94bdfd71-6efc-454e-92bc-3e6b6829d78c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Qwj3HO5CvN5Ks1l0
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_Qwj3HO5CvN5Ks1l0","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.151\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-ambitious-handsome-lily\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_zGHYlMlbBR2o6Oxx\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863465},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:48 GMT
+      Etag:
+      - W/"2a26a259c6ad7238f2258cc0192350b9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "911"
+      X-Request-Id:
+      - 1e653679-4afb-47e6-bf7c-a44d93576df4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","resource_ids":[],"resource_type":"virtual_machines"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
+    method: POST
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:51 GMT
+      Etag:
+      - W/"363f3b2b9c49e074403ad912edb4bfa1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "912"
+      X-Request-Id:
+      - 27e365e5-aff3-4409-a286-9037e6bdb35a
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_AUvsO3rFBbCw97jX
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:51 GMT
+      Etag:
+      - W/"363f3b2b9c49e074403ad912edb4bfa1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "910"
+      X-Request-Id:
+      - 76a7b83f-5a34-43f6-934a-c229ad746f91
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Qwj3HO5CvN5Ks1l0
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_Qwj3HO5CvN5Ks1l0","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.151\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-ambitious-handsome-lily\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_zGHYlMlbBR2o6Oxx\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863465},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:37:53 GMT
+      Etag:
+      - W/"133172ac9ab6231ad9a34aebfcdd390d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "907"
+      X-Request-Id:
+      - 6c70bb15-d95e-4246-87d3-3f89b5d4a66c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Qwj3HO5CvN5Ks1l0
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_Qwj3HO5CvN5Ks1l0","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.151\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-ambitious-handsome-lily\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_zGHYlMlbBR2o6Oxx\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863465},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:03 GMT
+      Etag:
+      - W/"133172ac9ab6231ad9a34aebfcdd390d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - f2ea00e5-0ea6-483a-95c4-4e0cd6c226d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_Qwj3HO5CvN5Ks1l0
+    method: GET
+  response:
+    body: '{"virtual_machine_build":{"id":"vmbuild_Qwj3HO5CvN5Ks1l0","spec_xml":"\u003c?xml
+      version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
+      by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
+      by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
+      by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.254.151\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-ambitious-handsome-lily\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cGroup\u003evmgrp_zGHYlMlbBR2o6Oxx\u003c/Group\u003e\n  \u003cAuthorizedKeys
+      continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738863465},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:13 GMT
+      Etag:
+      - W/"1186dc55d7a1951e9f3ee09978347ab6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "994"
+      X-Request-Id:
+      - 8127b84c-9cad-4166-8eca-2e39ea9bd838
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863471,"initial_root_password":"3ktC19FRxHwEcyqc","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"18af62dc66f122fa9bba865d8ba32d3f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "993"
+      X-Request-Id:
+      - 5f3b64cc-16bf-4d5c-a444-61d3a67998c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863471,"initial_root_password":"3ktC19FRxHwEcyqc","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"18af62dc66f122fa9bba865d8ba32d3f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "992"
+      X-Request-Id:
+      - e27ca44c-6ff7-4239-8427-1bcc08c2937b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_PggKHGqf3JNGRimJ","name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "377"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"21b1b41cf931703b22b05198ab1b8625"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "991"
+      X-Request-Id:
+      - ddfa5168-de28-4a1f-8b24-979b35453d35
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_PggKHGqf3JNGRimJ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PggKHGqf3JNGRimJ","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"},"name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:fc:f7:f1:c3:cb","state":"attached","ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"4927a903ffe923c9d074a9f87e5896c6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "990"
+      X-Request-Id:
+      - 91513443-4489-4f07-807e-77635671bc6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_PggKHGqf3JNGRimJ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PggKHGqf3JNGRimJ","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"},"name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:fc:f7:f1:c3:cb","state":"attached","ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"4927a903ffe923c9d074a9f87e5896c6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 545e5c16-75b3-4672-bed9-16d636b328b2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_sd0aQzMCc15JWJj2
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_zDJfps7VKaB2ZqO1","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"68d6865432fe45f2218344784d8b2395"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "988"
+      X-Request-Id:
+      - 4015c9a5-c755-4ce0-80da-2e5e78c10a7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_AUvsO3rFBbCw97jX
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"363f3b2b9c49e074403ad912edb4bfa1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "987"
+      X-Request-Id:
+      - dc80329a-e48e-4bba-87f7-347169702324
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_zGHYlMlbBR2o6Oxx
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "134"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"a32de4efcc94db89294f3b06d89faee9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - 8835438c-3d55-48d5-9717-de1c88217b18
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_Czi6EgcXgguwdkN9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "731"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"87c166ce2ead7cef12f6e12e1f4db214"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "986"
+      X-Request-Id:
+      - dc1b6fb1-9feb-4ba9-a53b-0a4f28713cd0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_sd0aQzMCc15JWJj2
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_zDJfps7VKaB2ZqO1","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"68d6865432fe45f2218344784d8b2395"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "984"
+      X-Request-Id:
+      - 71b36d3d-32f8-42e5-a150-b69d46986973
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863471,"initial_root_password":"3ktC19FRxHwEcyqc","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"18af62dc66f122fa9bba865d8ba32d3f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 60b93199-9191-48d5-a21b-f7bc3f0e8573
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_AUvsO3rFBbCw97jX
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"363f3b2b9c49e074403ad912edb4bfa1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - 3e5daf0e-6435-4c2e-b35a-b2916f88d4f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_PggKHGqf3JNGRimJ","name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "377"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"21b1b41cf931703b22b05198ab1b8625"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - d92f9d93-35bc-48be-98f0-6c26ed84b25e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_PggKHGqf3JNGRimJ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PggKHGqf3JNGRimJ","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"},"name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:fc:f7:f1:c3:cb","state":"attached","ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"4927a903ffe923c9d074a9f87e5896c6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "980"
+      X-Request-Id:
+      - 45894dcb-7ee8-40e7-bdfc-dc81e164fd60
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_PggKHGqf3JNGRimJ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PggKHGqf3JNGRimJ","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"},"name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:fc:f7:f1:c3:cb","state":"attached","ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:15 GMT
+      Etag:
+      - W/"4927a903ffe923c9d074a9f87e5896c6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "979"
+      X-Request-Id:
+      - 49ddd1d1-ccd4-45da-8d6e-8ed1b9e7a137
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_zGHYlMlbBR2o6Oxx
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "134"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"a32de4efcc94db89294f3b06d89faee9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "978"
+      X-Request-Id:
+      - 03b3eaed-81c7-45a3-ae67-80e1ac1ed992
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_sd0aQzMCc15JWJj2
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_zDJfps7VKaB2ZqO1","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"68d6865432fe45f2218344784d8b2395"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "977"
+      X-Request-Id:
+      - ef86cfe7-705a-4e59-aeaf-82b5d373d274
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_Czi6EgcXgguwdkN9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "731"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"87c166ce2ead7cef12f6e12e1f4db214"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "976"
+      X-Request-Id:
+      - 8f684fcc-17ec-47ba-adc0-dcd342a500d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_AUvsO3rFBbCw97jX
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"363f3b2b9c49e074403ad912edb4bfa1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "975"
+      X-Request-Id:
+      - 4cd4fe67-935e-45bc-b470-07fedf2913f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863471,"initial_root_password":"3ktC19FRxHwEcyqc","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"18af62dc66f122fa9bba865d8ba32d3f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - c198f00c-137e-41b5-9b46-af4493100d45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_PggKHGqf3JNGRimJ","name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "377"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"21b1b41cf931703b22b05198ab1b8625"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "973"
+      X-Request-Id:
+      - 8a4e08fe-1855-4125-821c-7a318a16e133
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_PggKHGqf3JNGRimJ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PggKHGqf3JNGRimJ","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"},"name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:fc:f7:f1:c3:cb","state":"attached","ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"4927a903ffe923c9d074a9f87e5896c6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "972"
+      X-Request-Id:
+      - 92957aa1-da6b-4fa8-8ee5-6dc617e030cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_PggKHGqf3JNGRimJ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PggKHGqf3JNGRimJ","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"},"name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:fc:f7:f1:c3:cb","state":"attached","ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"4927a903ffe923c9d074a9f87e5896c6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "971"
+      X-Request-Id:
+      - f0c62e1e-dd2a-4a12-8f1b-ccf20b0bc1d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2"},"properties":{"resource_ids":[],"resource_type":"virtual_machines"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
+    method: PATCH
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"267ca9878712683b7c36b3b9ee35ff9f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "970"
+      X-Request-Id:
+      - cb3f14f4-0d68-4f80-af5a-6e3f6b944e7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_sd0aQzMCc15JWJj2
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"267ca9878712683b7c36b3b9ee35ff9f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "969"
+      X-Request-Id:
+      - 1fe347f4-cd22-4e70-9efa-7fbbeec00450
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX"},"properties":{"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"resource_type":"virtual_machine_groups"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer
+    method: PATCH
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_zDJfps7VKaB2ZqO1","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"25197cfda196ee88dc7d457cb8dfc5cb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "968"
+      X-Request-Id:
+      - 95cdd626-2d8e-4c16-9129-1f4582301a0c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_AUvsO3rFBbCw97jX
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_zDJfps7VKaB2ZqO1","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"25197cfda196ee88dc7d457cb8dfc5cb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "967"
+      X-Request-Id:
+      - 4e8cbea9-ff87-401a-a71d-d4faf8f85b48
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_sd0aQzMCc15JWJj2
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"267ca9878712683b7c36b3b9ee35ff9f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "966"
+      X-Request-Id:
+      - 7a802987-e6dc-4666-8183-67d796ea46a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_AUvsO3rFBbCw97jX
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_zDJfps7VKaB2ZqO1","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"25197cfda196ee88dc7d457cb8dfc5cb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - daedbd03-a7de-47e1-b9bd-ffd6d858b4d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/vmgrp_zGHYlMlbBR2o6Oxx
+    method: GET
+  response:
+    body: '{"virtual_machine_group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "134"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"a32de4efcc94db89294f3b06d89faee9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - 66502d8b-a2fe-4e57-8ced-66eb979a8dc5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_Czi6EgcXgguwdkN9
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "731"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"87c166ce2ead7cef12f6e12e1f4db214"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - b4d7f0d9-699e-480e-adb5-a1d7de090f79
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_sd0aQzMCc15JWJj2
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null,"resource_type":"virtual_machines","resources":[],"resource_ids":[],"ip_address":{"id":"ip_w4HQ0xgzC3wR4bkm","address":"185.44.252.105"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfc2QwYVF6TUNjMTVKV0pqMi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzQ3WhgPMjA3NTAyMDYxNzM3NDdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBALuMXlj8nnsNw4BUkuWjZsKYA1HvmQuJEFla\nvZ9eIEKvlN45aFlFJSpgv2KjI0UiA09Y7sdTRxRfravhjln2tiJPgdkfymVN7FZj\n+4jSX/GajIzkdu48aDcaEUHyXJt7ioTgXPX+HJ66+A3wrZkzmfjKbPcfOCAAZBBy\nDLWhlgm++iqqDqR0CgKeQ2FXZR8MwXZg9dte7hl4hoGnU4NXDepbT0oXyjpxAYsO\niwBijk8F8JyMWG6/k6bjHs5z/yXrwm3IDrXA3O8yDp1bMYUgPyyafxrJhGOWp6XK\n+RYhp3TfEokKlPoWp++4PWJmRfLB+7sojrcZbvn+JuXFr/AJBktdgb9SdK1A9OZC\nc2N4MGKfvRotymzGiMfeZn7gRp3oiQCSZ+OAPUaYae7l7nPJUHITnvRzDAaziFVO\njfBl5rDKpx5ZDvSvft5qZxw9VE1AE2VHVBlVq6mOEeJkTNoNpHPFTTD+JcPWYVoL\nfQF8+LJG+aw4EaytIAoKXd/7+tZ2yAVQpC9heF6U3Hv5YmYHdD19tAa/femytApm\n8kyxkumpBcvHpwmUERkII/C1p0+B/skbgufq+5icN6lAewd63lgRfzi/Y8hfHMku\n1g+LEjvSyFRKYsjeaSGhPuQ9VC0CF+FMViW+43/oTaPywLjlypZmkcSZ+AmJOHqr\nRcd3FTyPAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTd\nxM/v/3AooRfuBONrrVGdigJ1YTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFN3Ez+//cCihF+4E42utUZ2KAnVh\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9zZDBhUXpNQ2MxNUpXSmoyLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAfFbPVAFPfsiu\nlvJ+ZFaENfdPcwxv6HRW44aqELyEJXTl/yWHaw48d1HII783JI9e795MC8tUcI9m\neC1DBBEaIXFdXtGUvsMOby5nyAp2Fajg1WTSdB3oJw3540ZbMfFH2kU17i/n3H7h\nL9W/NDw2LatjhU32eZcxkPIsNF4MehK726LcahuTuNU+3fPgZg1OmM6ASxwGYkb/\n9jYJnsJp6sTE9Cjet7VS4CZSVMfI13WwkUfFmdxE1s89l5sI9j2rydErNB3OlsWN\n4Pm2sCc1tpwuvDobwbWeWv1VtyFR0vsozavFMjHciEwWeLowbmWryKIpg/MRRrQm\n79vJrRudRgfwsa4xH4h8YuwJgq/2tW14LbuOzfaOFkEeEwVAobCzLIJlIhMT6d9U\nedV76Iqcx74sJ/WJ42Jhu57TG5k7ZVaiV79sfGhK4BtOEFZfcpIQv37sYTBbNlQQ\nAwehjggeDehZxSVUPdRlYez3NSAixtsEcoSYm6vIoH2nw+OUFFcogJzDQlOSvygx\ncbHXz7XiXjMp1FjLg2AfqaItuzoxmziO7LyRKf4C/uwHbMquYSlX26Rvl0ADxlCL\nnLJmJLbTlzNd4KxRf248pcSiXR+2eb5Z6eBxCclu3XJpoBIsgUdYT3wMJth+ICek\nMKBojp+tmQFS2YDNzoY9CshDmI2BSA0=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAu4xeWPyeew3DgFSS5aNmwpgDUe+ZC4kQWVq9n14gQq+U3jlo\nWUUlKmC/YqMjRSIDT1jux1NHFF+tq+GOWfa2Ik+B2R/KZU3sVmP7iNJf8ZqMjOR2\n7jxoNxoRQfJcm3uKhOBc9f4cnrr4DfCtmTOZ+Mps9x84IABkEHIMtaGWCb76KqoO\npHQKAp5DYVdlHwzBdmD1217uGXiGgadTg1cN6ltPShfKOnEBiw6LAGKOTwXwnIxY\nbr+TpuMeznP/JevCbcgOtcDc7zIOnVsxhSA/LJp/GsmEY5anpcr5FiGndN8SiQqU\n+han77g9YmZF8sH7uyiOtxlu+f4m5cWv8AkGS12Bv1J0rUD05kJzY3gwYp+9Gi3K\nbMaIx95mfuBGneiJAJJn44A9Rphp7uXuc8lQchOe9HMMBrOIVU6N8GXmsMqnHlkO\n9K9+3mpnHD1UTUATZUdUGVWrqY4R4mRM2g2kc8VNMP4lw9ZhWgt9AXz4skb5rDgR\nrK0gCgpd3/v61nbIBVCkL2F4XpTce/liZgd0PX20Br996bK0CmbyTLGS6akFy8en\nCZQRGQgj8LWnT4H+yRuC5+r7mJw3qUB7B3reWBF/OL9jyF8cyS7WD4sSO9LIVEpi\nyN5pIaE+5D1ULQIX4UxWJb7jf+hNo/LAuOXKlmaRxJn4CYk4eqtFx3cVPI8CAwEA\nAQKCAgAm82ko3BZiAiLHRUlY7g3Kfl26J6PGdInztNfLAHZ8wxCM8qlMWQL2AS/e\nYXlSw1Sipxq4RQBvJ8ve9bJl1spO5+pU2LhlP8DE1HEKIn8Qo4NrQ4u7wMn4H67T\n3m0DUa4cGKjV4he5k6Uu5/x14/Snagsla9NxOgOOMtGW619I2OQF9lmiKANoNcxS\nrB7xSunnFw4YqGeU3KY6yTCcB3l5Ycte3QAAETY71iJiSxW5LceiC7fWEG2u7F6a\njBbCnms795+uecao2uGUJrtrJZ5ZOiEJxC59rG1XDoea5BRuPmIQGiWEpy3rqHz/\nMbR3TXhlj2/McTjOLM2RTPRUStuGclFAiDcyrfc2AA2ZyYAFNy2LkrHTbVvHqGr5\ngB0bVvoR04YUPJ29wowgjmLkrqWDUmCrnAZcPwPudvkwDMDc0AvFBBY0RFZbwX00\nBuVn3JH2obS3KqYJaFvcGsUDsHm77CDWrtNGezHCeTrEekPUYB6h86/jWJQjpL76\n95LaNQL6WQWfK6pD4m3/aCqUO1tP6rDQymL+PQC90FXhcBhO15qFCaJ2MWB8oL0l\nPXtHsxoUwj+2TPJ2sAD9EfPfOrAqfcaJMWoYtmtXdsoUmwTh7tm0rDvsq8kE4UMx\nnGnaNUkd18MjHZySiJAIeYQhVzDce5nMjUGUvbEsLtEt//B+4QKCAQEA6HqgCsJB\n0kz9cKA1aOVLF417skozYUl7h/yXQEZG16eSBTtTNAWmS3eGBiPhj94qDcchGq4l\ngQttPkpgNIRXyhJwjqAxmmI93pZ8vaod7lsy7kqPh/kCZHhonOYdX51WmWZG8KqW\nwL1BN5VsCP5DePwb+VwPK6tFRNgTHXFqylm3IkgyAT9USaQ3YBPJS097q+D3dD88\n3Fhx1crF5yOliWDVFUKLDea6hE7sfBblMHg3yCpOkneacVjYr0hVMD+6aBdE7pzi\nchm62rFCkrAtvU4ecFH1K4gFHAWxJQa42hkI5W72A3IZNP3/yHqrGYtBGuwPwrAt\nrQcZgIxPwUOPsQKCAQEAzoYBhDopR8Mp0PLMuYzB0ZlweQeMOU6gbQJndqYzvgqD\nTf+sNwofLRGl+QYKs0hzxeUav04hy/XfYDmAGBawocah8bgWycECk/WvPUg3hSUO\nL4VRdztx3wAt4CHLwT3uxiJ7151rmDQsyJimmwmPvSz6Vi9q08oxHBEZnZhW99lH\nxHgV8/Q10m9cUCSbFL1Ew1jaYeATjLRuXBVElgB3rcp0k/hZgymF0fKCIn7OrCXz\ntKbGXEgdMUCiqD1DZ+pfVQM8BYdhTHaPXr3MhFhoQYiDfmH8kx4wNRk/I7+DtUcH\ne0EJPH4htYBCk8bkwIapE+6Hgwkm5nHumwp6fdrgPwKCAQAheOZqJiYL/YHQIYEP\nJVR2g6x3sy9KpqXeooO0gWnZywq/LheAuf+DhiYJ5EipyjcL3MvrZ3+G4PpNqa/I\nX/Wz5ovGPVJnBBYcYlZ7iG7ezsq6fInF7hhmFuAZFxjLl3/MfmlgZW9nONiXBDCV\n6uYUGVh9wr98biB/FQ1Lg/T4RYqUqQhqHZApOjeu4apt6XfI+48lcaV1pFZfjd6I\ntR00dni3oukai0n3mtV52GIPZH/DljPR6t6Vy1EHi8aYN9TC//aw1G3WN9YrfrIz\nJKKxSvoe+e3u4pq5uigTSLB81nXtctiBDoCKnLejSeYwu1gYZDywr2UkMI1/cLRb\nAztBAoIBAQC+TQL2ubUyGCbfD+wPiiFKpw3ZqFfQsp/m8tEtpoaFNiC57b7d1KjX\nmayLY8LWYwuzLaJQ54kC7SQRAcsD51yJJYQyPQRakkxy1G/Ok039lSCWL03bBV6v\nMvYS0nFzNkNgNYRSMQ9k56bgjLDwqYXWtqxSYE0arPRFvYgSDL8OkRutcU4hRkWW\nC+FPQ/vWx3SmYKiSiazZ+aS7mylg4ztkW+rCMpUg5FEYHVNGv/xm6m2/Z/HeNOEZ\nckqvpgwHpBKGPn2/RnkkwRbpIRFkXiZrRISOH3Jiie237/SbVyzhDHtbWplNMZiU\nK4StsRc2RJ9l62TZHMTIkfFg0e3/LIF3AoIBAQDWdo9OP+1oqsiQkr5empiHIia+\nh6spSaprhWVK9WkoaKdpTh5tzgKRE/9bIMVrFdq5ONRzw+yTjZrNLxLbMI+F8cZn\n9nPFXEGEjV9SZTBT5bva93tqvNvbfslh5mOAkjQuciFZr/7R+dl6Vbci3brHgFou\nkTPW5X9kRh083tfaXFIwQR/opw+ThldrXMqQdbLxDsd3sKV9FNBZBxe5hO04fgOM\nyZfP48I/lGDz/7XJJJ0zTy9lFOlDRBKankJfWMMNgceDB5lpfUdtTFjTFVEIygyf\nx3BPSkHnNS56yHCXKkrwp+G0ko3RLwpJYm1upGfwJkJ394tRdcwOZrkmAVfM\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"267ca9878712683b7c36b3b9ee35ff9f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 9b2cd612-a4ae-401a-b98f-af6ee604eed1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_AUvsO3rFBbCw97jX
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null,"resource_type":"virtual_machine_groups","resources":[{"type":"VirtualMachineGroup","value":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}],"resource_ids":["vmgrp_zGHYlMlbBR2o6Oxx"],"ip_address":{"id":"ip_aJaRtTmKc7q8VipG","address":"185.44.254.124"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfQVV2c08zckZCYkN3OTdqWC5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczNzUxWhgPMjA3NTAyMDYxNzM3NTFaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAJOhi0KOc1syUH40Xz31USjGt/53LEYdnXhM\no1ooboircw8e7onNXvk/npBWIai9bqCQ2jRgdYWMsHQfFXvf74gC5HrPvNAQuFZa\nTy5M4gzOveGb7IiI4i32Qmn/QPAXxQZmJYHzaw3Rn6P6D59hz7nQg+62GPc4Ce5f\nC/GO/eCnLN8LFMCBO1mkFJPFGQ6Qvd4+jfI85HklN1IujndfvZpytaeKHVdq47DY\nnd4vi+2FgkepADBNCGtEzqVxY6frGdBrz5oQ6v0EtbkDHrtBJ5utgtF8Fv0Pdxb3\nSocKXiz8mefKm1IyN6C4HgDGjN47yw1gLqHHmeclInmM9pgW7qDIWmen4iySPfqR\nx7mT8XXArILJzST4sRfQZdGTn3cybB28DhYK8012lS3u40IqtePTk48/mRH3QneG\n0NpIsOU3eXvPdQ/+VFgAQ+c4/8UHR07iNKq66UPTj8adO9WXYwouMt0vnNqz+heg\nT/E4zDR/Z79IOjwQg14ZOCaHNlK7HTCYMZ56ehjNidyZpxe16S17P1xguVMmEfyj\nc+kauKBigwuIyAaann75RXNqxtrhxUb9+sYkjixUYKQG33kiKnqEdj9qELM1S4Vi\nm2B7wn77vMAW5oMd6OZLUwBqHI1N2/eDDm4isSC/K5S/9s/nQdij32urVLJYlIq2\niwLDuzQ7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF\nkKfzrrih8vMpeuWHMNJk3KTX3DATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFEWQp/OuuKHy8yl65Ycw0mTcpNfc\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl9BVXZzTzNyRkJiQ3c5N2pYLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAVUGjgSfkmpgz\nldNYWUGkiWMhFmfYMk4ty8AfZ0zcKBKaue2Z1lGGUTjJuUObX8jIMLStJtmHg1r1\n8fLAfi/PDAORNQHoAs82PZJZKqthPOZUn1JXT71Gh33zYCMBRZb81Lv4M7qUPxMY\n2wZOTpN6RD7YwG8WmFVWrcOAd/V2xfDzF3/kNxHP71goNZV255ejSsCJpjDYVlf+\nHfPzNNqHqf80TIoJ3YNuSww/30KZf3FV1GIwKQxmuGuB4obgBfntZfiMBQJfOwdQ\nnbTurYHUryXmHEp7gJwBBoAToGwbK3ssQOOMynSqtwV/fP2qgloYaP5wU9PySnLq\ntOPYjxkMPH+SC1jS8A96IwzHMPQQezlY5d5iP65c9kZCfJRE0kwAzfzuJA7q/uEZ\nW2kzIKiDfHxOGtJ7Hq7dgSfbPEtGWbSDrT86MBqXZk8IekNrFnbDc0JXoujyL+Bi\nbao59t+Hl+J/0wGAqKyyjKm0dBIDmTV3/t17MlXV4TLDc2CWmOvyJSYhRlBiRcLt\njIeTotHZzHqjhQ3K5pyxOEfWrmXIVKU2nADDTPzIvZK2OBWWLkWDdBy/eyl+AGIG\n+x8yGfjoo3zhqYISz8MTwsmbX8kVlwRe3YzxW4BOy52LUhg3HEelZzQT9yhnuxYo\nqoh8HevaPd7qvAVLGT/B+g3pc2NgRIE=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJJwIBAAKCAgEAk6GLQo5zWzJQfjRfPfVRKMa3/ncsRh2deEyjWihuiKtzDx7u\nic1e+T+ekFYhqL1uoJDaNGB1hYywdB8Ve9/viALkes+80BC4VlpPLkziDM694Zvs\niIjiLfZCaf9A8BfFBmYlgfNrDdGfo/oPn2HPudCD7rYY9zgJ7l8L8Y794Kcs3wsU\nwIE7WaQUk8UZDpC93j6N8jzkeSU3Ui6Od1+9mnK1p4odV2rjsNid3i+L7YWCR6kA\nME0Ia0TOpXFjp+sZ0GvPmhDq/QS1uQMeu0Enm62C0XwW/Q93FvdKhwpeLPyZ58qb\nUjI3oLgeAMaM3jvLDWAuoceZ5yUieYz2mBbuoMhaZ6fiLJI9+pHHuZPxdcCsgsnN\nJPixF9Bl0ZOfdzJsHbwOFgrzTXaVLe7jQiq149OTjz+ZEfdCd4bQ2kiw5Td5e891\nD/5UWABD5zj/xQdHTuI0qrrpQ9OPxp071ZdjCi4y3S+c2rP6F6BP8TjMNH9nv0g6\nPBCDXhk4Joc2UrsdMJgxnnp6GM2J3JmnF7XpLXs/XGC5UyYR/KNz6Rq4oGKDC4jI\nBpqefvlFc2rG2uHFRv36xiSOLFRgpAbfeSIqeoR2P2oQszVLhWKbYHvCfvu8wBbm\ngx3o5ktTAGocjU3b94MObiKxIL8rlL/2z+dB2KPfa6tUsliUiraLAsO7NDsCAwEA\nAQKCAgAQeVHcwvWiGGq9XThq5bbr7xo1ZfSwUaSypGauwbKX7f3gaD9jwYxBZwqE\nKRWyH+APldUWTCnrwF0pEBY/JP2J4WdqlvIxtklDsD8ut6Xv75q7vsELJASNRBzO\nzuI0Xd/+t05PLSu7NohIbY0/Eqnx87qNMY/L99plLwEFBcOpxS3vfmvkkWc0jmfn\nbMfqMAJSobYIRn2TpoYBAIX6/IQ1ZGswlMEdHKXneZH1lbuubRwHxWw/zOYixjet\nuYn5K8sieVgIuq47lBd3255wdImoHcQVKUeNb04xkgskfOaGbEemWHMISJHxjX93\nmbBlf37zRqeIJl8JA+6laV1TxRdVTqDa0ijzL8h+auwDoiLKhnRWKp6B4yOzjeTT\nEkdzZJNZsm5MeB1m29+byrssIukcCZ8lMudcy4LrR6p1ebxuf2dR5BKIX1s95M90\nWdVN/dNkPefZPhkkPIUvDhAZVbZGEjR7thkEz2Is8BsCcG9Rxo3t/74S8/espb5S\nb6Ap9dXWEznssLi40Cf3oKLeoMS/cHfA+EWqfqNBgD7nFJ4o8D0IBwb3Ap6YpBaU\ngQwFg/4HkPM5U5geXttCIMpber8rA3+Wr8JJnDjtJihI+yOc5QdjBCFzfp9k1gCF\nuZi1gB4GIDfYzUZjRsuOJ9TvriPqqFW1fPCrFfABE8N2Rsgw8QKCAQEAzdcHImlY\nKRE2H4wEfxXs1VLceu/zJTmZe2RSdiXFt7lktK9Sc283EfhqE4da2QTzcr6m+y8s\n+1rnNoQVZqRlsyRWdvoDgnWYHOikFrTpfs78SH8lv9LZpeahHdNgE7To6G+71yLL\nMY7DX7DXsAAEz8Pnbau5OOYvkjrZCBbkqkFw4GMf/Awo55h+aezVBC1quOwS/gox\nzjvkdXjyyrPz1Htx1z/sC7rHrDx6eM+g2fb9VgKqjLhfuiOJJ5hFueYS61PS9kgC\n70dOM5MIkPSlRW4ZlFPr8cvbURZLcjw3NBc6rNr55+1Z9Ktcbi06q6hnKemWRsfw\n+6eiIFvCLAF+6wKCAQEAt5tAoYftoT9EOXxxJfjUJKEvR5yiA1hccYuYCQsKia7/\nL+sOrPAb7QeFEBiHXFX6uFayKK5yDF924RpTxhypk2coUatAySbweUWxe+4KiO3e\nR2WJ6CFgkc7ZttDuJkI+xuUkET6YdawGd24XNtvHlacsMu5U2AAb013LZqgHjX2L\n+lcThigzCvIC7IF3fTrRLfjCWHguFIwYF5ARVgNk9fMx0aG/66ZlIA6d4s65KeNF\neUSIRIwzosOJqZSWlGRids1jn+W94+aodUdrEVp3PLNQBdsDIFIPWFqfaZfxHcUa\nPvGdNHOJX6Eq55ttjrFgYo7cHsjV1OK4sh+RijPr8QKCAQBmtT2VGRVpYHIuKZJw\ny0LiarcjDKm5UFVaMYPH+i7+7p3mXnj4qmzDJb3gQrC9CvBit+jf+vkp7oDiPePj\n1HH+gko2kafAp+afviFqRxkfMi7GCdOPNKlvU3XfSQJust1oZaBHx8+1ybOJAteM\ntWWxOeI3YfFJB+qCv6Rdmfa9UWv+OtfRz0t1zCx/tDHSJMtUvE75vaJ+cnobd59G\nL6ahxnrWWcnxTGCne4Hs2EU9nTVpfmkVUEZLvcGJJTzddoTIMYpZYzM7q8vEhkBG\n/BufWkGfNoTLoNmtSz+YH523+0NGzvjVliRFpl+3hg/5aU0Yp7pZVRjUqR+Hn+Fy\nTcjDAoIBAAYyc0gAcoDSxda64IbLkz15Q0NDgiRiwxwB/iuv97cV9P8FDAXCRO8H\nJfKZIVh4fnHiWzkMSkUoo7aNUO6K4R5ciPvYr+MaMVumgosQScK9ZJc8Uh9HoR7K\nwIZvHtqjucK00TbTygmOuNknGhl76Yyfi9pcOPjhaA8GR2s7mKWp6yOT9NC+Ypqn\n+HlLFWFgrtbCYqzhwYxn/hgtgKhKjQnQH4pXz0aA40DlvWZ+W7mSNjIVohPON5/y\nwZ67qSlxCfHAlPA8rOAYVO9Abdi0GPovgy/vaHeazXHJ/T9vJXA/ytb9CLVQgP59\nThlrIZODYSFyePOBC9aXoGxCrILhpcECggEAEkkqiUCtVWPOMsaQREpeghv0uVN/\nuYey7vJOjIJ+La1Lbauk5yadNn0Fc9bNZZ44D7a+Oho0Dz29um/zjx0/K1WuqAYK\n1Q40QKBcQUuBIt9IanxF7B+H4k+AoOYlqndTJjairDJv2ibm7mD5MTZzoDXcSq0F\nEzpD3OwCYirrdYk6B8ju9+hU3Dsiu12/DuJiXeyH324N/judEZWIJM+YCcrzMzgL\nEGympBotbj/blgc9Y2MMXy3BaHEqGkv5xdzBK5gMVm57t0xHy4nQyRnU2pEHDCHX\nkslNmREN5BBuVolZUiurksuj86ldEOyVkljyfZLtcacdBBnL4lfJkcQoKg==\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_zDJfps7VKaB2ZqO1","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"25197cfda196ee88dc7d457cb8dfc5cb"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - 148b35b0-e477-4ead-8a9e-e92517b2bd90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863471,"initial_root_password":"3ktC19FRxHwEcyqc","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"18af62dc66f122fa9bba865d8ba32d3f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - d25d834c-2857-4b68-bd42-5b3d2cb42837
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_PggKHGqf3JNGRimJ","name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "377"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:16 GMT
+      Etag:
+      - W/"21b1b41cf931703b22b05198ab1b8625"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - d72851ee-9ce6-459f-ab17-592746c76a58
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_PggKHGqf3JNGRimJ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PggKHGqf3JNGRimJ","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"},"name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:fc:f7:f1:c3:cb","state":"attached","ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:17 GMT
+      Etag:
+      - W/"4927a903ffe923c9d074a9f87e5896c6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - edd2515f-6ec5-4969-a444-40c02903dd31
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_PggKHGqf3JNGRimJ
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_PggKHGqf3JNGRimJ","virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily"},"name":"Public
+      Network on tf-ambitious-handsome-lily","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:fc:f7:f1:c3:cb","state":"attached","ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "503"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:17 GMT
+      Etag:
+      - W/"4927a903ffe923c9d074a9f87e5896c6"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - 1faa4e6b-1af9-463b-bc8f-757308ac895a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863471,"initial_root_password":"3ktC19FRxHwEcyqc","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:17 GMT
+      Etag:
+      - W/"18af62dc66f122fa9bba865d8ba32d3f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "955"
+      X-Request-Id:
+      - 5d9d5c57-7e02-4d8a-bcef-23d122711b4e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
+    method: POST
+  response:
+    body: '{"task":{"id":"task_7QEsBbe7Ilm6bI45","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2202,9 +2315,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
+      - Thu, 06 Feb 2025 17:38:17 GMT
       Etag:
-      - W/"8643ab05830682ce27bfd1a46de51c5c"
+      - W/"e0ec8fdecf87d1da8a922cc315e3bdcc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2212,14 +2325,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "916"
+      - "954"
       X-Request-Id:
-      - 83ae5ba5-baac-4ba4-bb4c-8b3fce6dc73e
+      - ed21cfc6-9273-45f0-b008-e14abc2785d7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko"}}'
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX"}}'
     form: {}
     headers:
       Content-Type:
@@ -2229,7 +2342,7 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: DELETE
   response:
-    body: '{"load_balancer":{"id":"lb_pXTQBv1RSeVFvhko","name":"tf-acc-test-vm-group-THkAuhPqh10k-alt","api_reference":null}}'
+    body: '{"load_balancer":{"id":"lb_AUvsO3rFBbCw97jX","name":"tf-acc-test-vm-group-Sq8XLSemkbH7-alt","api_reference":null}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2244,9 +2357,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
+      - Thu, 06 Feb 2025 17:38:17 GMT
       Etag:
-      - W/"9a802ad4967ca5ad223f5eaca891b95d"
+      - W/"e17b9d19a3d79735538b54db7a214f7a"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2254,14 +2367,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "917"
+      - "956"
       X-Request-Id:
-      - c63d5424-4591-4f22-b7a0-3d630665fb2f
+      - b6d5132e-b136-4adb-89f6-b50b9ef720cc
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC"}}'
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2"}}'
     form: {}
     headers:
       Content-Type:
@@ -2271,7 +2384,7 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: DELETE
   response:
-    body: '{"load_balancer":{"id":"lb_K5EyBtF1SfJwe4dC","name":"tf-acc-test-vm-group-THkAuhPqh10k","api_reference":null}}'
+    body: '{"load_balancer":{"id":"lb_sd0aQzMCc15JWJj2","name":"tf-acc-test-vm-group-Sq8XLSemkbH7","api_reference":null}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2286,9 +2399,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:29 GMT
+      - Thu, 06 Feb 2025 17:38:17 GMT
       Etag:
-      - W/"ce3c0d069fe6f98aea9b052f8ad1d1fe"
+      - W/"5bdf443848138b6475dbecdb67a91fec"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2296,9 +2409,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "909"
+      - "953"
       X-Request-Id:
-      - ec15443f-9ed3-4609-9b16-b509a5735c77
+      - 39d67ced-9242-4b67-b971-09e20e333375
     status: 200 OK
     code: 200
     duration: ""
@@ -2309,11 +2422,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_thA2mWMHfFiuakHy
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_7QEsBbe7Ilm6bI45
     method: GET
   response:
-    body: '{"task":{"id":"task_thA2mWMHfFiuakHy","name":"Stop virtual machine","status":"pending","created_at":1734018509,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_7QEsBbe7Ilm6bI45","name":"Stop virtual machine","status":"pending","created_at":1738863497,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2328,9 +2441,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:18 GMT
       Etag:
-      - W/"42018a14c9c952fe1d8f692bcb38b8e3"
+      - W/"7ea2fc7bdcf7e89186efa94742bef532"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2338,9 +2451,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "902"
+      - "952"
       X-Request-Id:
-      - 87329b53-4139-4efc-8d9c-56bf87d21c9e
+      - 4bbbbfb8-e93e-4ec7-805e-894ff1e423ac
     status: 200 OK
     code: 200
     duration: ""
@@ -2351,11 +2464,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_thA2mWMHfFiuakHy
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_7QEsBbe7Ilm6bI45
     method: GET
   response:
-    body: '{"task":{"id":"task_thA2mWMHfFiuakHy","name":"Stop virtual machine","status":"pending","created_at":1734018509,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_7QEsBbe7Ilm6bI45","name":"Stop virtual machine","status":"pending","created_at":1738863497,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2370,9 +2483,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:35 GMT
+      - Thu, 06 Feb 2025 17:38:23 GMT
       Etag:
-      - W/"42018a14c9c952fe1d8f692bcb38b8e3"
+      - W/"7ea2fc7bdcf7e89186efa94742bef532"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2380,9 +2493,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "868"
+      - "949"
       X-Request-Id:
-      - 5661295a-942a-40d9-b55b-3073f4738429
+      - 3d16d6a2-f16b-4c09-abc4-b4be9ff41e1f
     status: 200 OK
     code: 200
     duration: ""
@@ -2393,11 +2506,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_thA2mWMHfFiuakHy
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_7QEsBbe7Ilm6bI45
     method: GET
   response:
-    body: '{"task":{"id":"task_thA2mWMHfFiuakHy","name":"Stop virtual machine","status":"pending","created_at":1734018509,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_7QEsBbe7Ilm6bI45","name":"Stop virtual machine","status":"running","created_at":1738863497,"started_at":1738863513,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2408,13 +2521,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "162"
+      - "168"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:45 GMT
+      - Thu, 06 Feb 2025 17:38:33 GMT
       Etag:
-      - W/"42018a14c9c952fe1d8f692bcb38b8e3"
+      - W/"b34978c0a15b147d9937b2da9885177f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2422,9 +2535,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "779"
+      - "886"
       X-Request-Id:
-      - 79a048e6-984c-40e2-aeb3-8347942e25fd
+      - d5b402ad-f6fa-49ac-a598-83b9d205b9b9
     status: 200 OK
     code: 200
     duration: ""
@@ -2435,11 +2548,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_thA2mWMHfFiuakHy
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_7QEsBbe7Ilm6bI45
     method: GET
   response:
-    body: '{"task":{"id":"task_thA2mWMHfFiuakHy","name":"Stop virtual machine","status":"completed","created_at":1734018509,"started_at":1734018531,"finished_at":1734018533,"progress":100}}'
+    body: '{"task":{"id":"task_7QEsBbe7Ilm6bI45","name":"Stop virtual machine","status":"completed","created_at":1738863497,"started_at":1738863513,"finished_at":1738863515,"progress":100}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2454,9 +2567,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:55 GMT
+      - Thu, 06 Feb 2025 17:38:43 GMT
       Etag:
-      - W/"8c50a40f51d6d7bda9838b5bff02afc2"
+      - W/"4561040f655908e2ec47a0312b5f6324"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2464,9 +2577,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "772"
+      - "871"
       X-Request-Id:
-      - 0287944b-ea2f-4927-a0f6-7b79be75883f
+      - 8c3ac0c5-15db-4f91-aa0b-ed7d05b13493
     status: 200 OK
     code: 200
     duration: ""
@@ -2477,19 +2590,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018471,"initial_root_password":"m9NDlEm6SLMw5ayX","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863471,"initial_root_password":"3ktC19FRxHwEcyqc","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2502,9 +2615,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:56 GMT
+      - Thu, 06 Feb 2025 17:38:44 GMT
       Etag:
-      - W/"c93b79df76efd28c25fc47a41ca250ae"
+      - W/"35de94447729ac08fbff942c70663ae5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2512,9 +2625,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "771"
+      - "870"
       X-Request-Id:
-      - 12156d50-5a52-4147-a038-3b3c75142764
+      - 5d072828-cec0-4d7a-84ee-b16e4007115e
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,19 +2638,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_gNT9C9bX5uYEPleo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_zDJfps7VKaB2ZqO1
     method: DELETE
   response:
-    body: '{"trash_object":{"id":"trsh_iLfgZ5ZcMmn7FyyA","keep_until":1734191336,"object_id":"vm_gNT9C9bX5uYEPleo","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_gNT9C9bX5uYEPleo","name":"tf-long-victorious-sunflower","hostname":"tf-long-victorious-sunflower","fqdn":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018471,"initial_root_password":"m9NDlEm6SLMw5ayX","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"trash_object":{"id":"trsh_PkHhRfvbq4LvQcoU","keep_until":1739036324,"object_id":"vm_zDJfps7VKaB2ZqO1","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_zDJfps7VKaB2ZqO1","name":"tf-ambitious-handsome-lily","hostname":"tf-ambitious-handsome-lily","fqdn":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863471,"initial_root_password":"3ktC19FRxHwEcyqc","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Yu4vIT6oQW6R4CUD","address":"185.44.255.149","reverse_dns":"tf-long-victorious-sunflower.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.149/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465},"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_Czi6EgcXgguwdkN9","address":"185.44.254.151","reverse_dns":"tf-ambitious-handsome-lily.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.254.151/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_gNT9C9bX5uYEPleo","allocation_type":"VirtualMachine"}]}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_zDJfps7VKaB2ZqO1","allocation_type":"VirtualMachine"}]}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2550,9 +2663,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:56 GMT
+      - Thu, 06 Feb 2025 17:38:44 GMT
       Etag:
-      - W/"7f3a23f72e52972599c9455b7715ef00"
+      - W/"b31165dcb2c5df83abebb72a19d66237"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2560,9 +2673,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "770"
+      - "869"
       X-Request-Id:
-      - 2a915cea-4633-4f8d-a55a-d83ce1c0d353
+      - 918b12d5-3c45-4828-a04e-82f3f308ae75
     status: 200 OK
     code: 200
     duration: ""
@@ -2573,8 +2686,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Yu4vIT6oQW6R4CUD
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_Czi6EgcXgguwdkN9
     method: POST
   response:
     body: '{}'
@@ -2592,7 +2705,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:57 GMT
+      - Thu, 06 Feb 2025 17:38:45 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2602,9 +2715,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "769"
+      - "868"
       X-Request-Id:
-      - 78cf92a8-7f0d-4b57-9fd0-d20d43ea736a
+      - 5e27fde1-1507-41ee-b98c-a6fcfd7eb4a9
     status: 200 OK
     code: 200
     duration: ""
@@ -2615,11 +2728,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_gNT9C9bX5uYEPleo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zDJfps7VKaB2ZqO1
     method: DELETE
   response:
-    body: '{"task":{"id":"task_FrarhOYwmVJwiF8P","name":"Purge items from trash","status":"pending","created_at":1734018537,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_KPBTdtpfgyQtZ1gS","name":"Purge items from trash","status":"pending","created_at":1738863525,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2634,9 +2747,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:57 GMT
+      - Thu, 06 Feb 2025 17:38:45 GMT
       Etag:
-      - W/"b0fcdc863bd3aeba55640219df068cdd"
+      - W/"d3b0abe8e9f60c71fdd171c85e080c68"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2644,9 +2757,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "768"
+      - "867"
       X-Request-Id:
-      - d3730275-6b5b-4295-bcc3-d9c265ee5d33
+      - b1f3234c-2c89-4b35-a2ef-c66bef84e52c
     status: 200 OK
     code: 200
     duration: ""
@@ -2657,11 +2770,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_gNT9C9bX5uYEPleo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zDJfps7VKaB2ZqO1
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_iLfgZ5ZcMmn7FyyA","keep_until":1734191336,"object_id":"vm_gNT9C9bX5uYEPleo","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_PkHhRfvbq4LvQcoU","keep_until":1739036324,"object_id":"vm_zDJfps7VKaB2ZqO1","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2676,9 +2789,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:58 GMT
+      - Thu, 06 Feb 2025 17:38:46 GMT
       Etag:
-      - W/"5ce8336568e2906b1d2e5e9fa3b3f4b2"
+      - W/"77f52dbb0af7e87409c4fe31532ab1d3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2686,9 +2799,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "767"
+      - "866"
       X-Request-Id:
-      - b44caff2-1e76-4a05-9144-55af2e6e8f86
+      - 4fd88447-4fe3-4ee2-a692-0b4ab85da800
     status: 200 OK
     code: 200
     duration: ""
@@ -2699,8 +2812,134 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_gNT9C9bX5uYEPleo
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_PkHhRfvbq4LvQcoU","keep_until":1739036324,"object_id":"vm_zDJfps7VKaB2ZqO1","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:51 GMT
+      Etag:
+      - W/"77f52dbb0af7e87409c4fe31532ab1d3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "860"
+      X-Request-Id:
+      - 6c867880-2aa2-4f36-953f-4971e30ba130
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_PkHhRfvbq4LvQcoU","keep_until":1739036324,"object_id":"vm_zDJfps7VKaB2ZqO1","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:01 GMT
+      Etag:
+      - W/"77f52dbb0af7e87409c4fe31532ab1d3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "974"
+      X-Request-Id:
+      - 5ba6db12-bf07-479d-a792-cac40444b6d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zDJfps7VKaB2ZqO1
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_PkHhRfvbq4LvQcoU","keep_until":1739036324,"object_id":"vm_zDJfps7VKaB2ZqO1","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:11 GMT
+      Etag:
+      - W/"77f52dbb0af7e87409c4fe31532ab1d3"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "959"
+      X-Request-Id:
+      - a9b6f580-8552-49d6-8db7-044e62321c95
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_zDJfps7VKaB2ZqO1
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -2719,7 +2958,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:21 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2729,9 +2968,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "959"
+      - "956"
       X-Request-Id:
-      - 41d59dfa-a8ee-4d7e-a501-b8308c27c50c
+      - 716a7920-8e52-4692-991c-824856af3340
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2742,11 +2981,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_3n0uvhy9xt2Gnc6l
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_groups/_?virtual_machine_group%5Bid%5D=vmgrp_zGHYlMlbBR2o6Oxx
     method: DELETE
   response:
-    body: '{"virtual_machine_group":{"id":"vmgrp_3n0uvhy9xt2Gnc6l","name":"web","segregate":true,"auto_segregate":false,"created_at":1734018468}}'
+    body: '{"virtual_machine_group":{"id":"vmgrp_zGHYlMlbBR2o6Oxx","name":"web","segregate":true,"auto_segregate":false,"created_at":1738863465}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2761,9 +3000,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:21 GMT
       Etag:
-      - W/"e09b20c9e270112f56f98e763064e9ec"
+      - W/"a32de4efcc94db89294f3b06d89faee9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2771,14 +3010,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "958"
+      - "955"
       X-Request-Id:
-      - eaaa569b-9963-4482-974f-5d952c4f020b
+      - 5f2c271f-7d8a-4ac2-9485-6e5db61055b7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ip_address":{"id":"ip_Yu4vIT6oQW6R4CUD"}}'
+    body: '{"ip_address":{"id":"ip_Czi6EgcXgguwdkN9"}}'
     form: {}
     headers:
       Content-Type:
@@ -2803,7 +3042,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:21 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -2813,9 +3052,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "957"
+      - "955"
       X-Request-Id:
-      - 8c4afa17-a0d1-4d40-ad0d-e2d8e2328ada
+      - 34114eaf-0337-45af-ae4f-00035f34d4fd
     status: 200 OK
     code: 200
     duration: ""
@@ -2825,7 +3064,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_pXTQBv1RSeVFvhko
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_AUvsO3rFBbCw97jX
     method: GET
   response:
     body: '{"error":{"code":"load_balancer_not_found","description":"No load balancer
@@ -2844,7 +3083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:21 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2854,9 +3093,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "956"
+      - "953"
       X-Request-Id:
-      - 8886acb0-e626-41fe-8c16-0cc2b0cc3bdc
+      - 8818dc06-e409-48e8-91de-402a28ccf1b4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2866,7 +3105,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_K5EyBtF1SfJwe4dC
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_sd0aQzMCc15JWJj2
     method: GET
   response:
     body: '{"error":{"code":"load_balancer_not_found","description":"No load balancer
@@ -2885,7 +3124,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:21 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2895,9 +3134,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "955"
+      - "952"
       X-Request-Id:
-      - 365fa936-3ef7-4129-b318-f428494d1e05
+      - 7746abdb-e774-4d0a-926d-c8a753b81408
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/v6provider/testdata/LoadBalancer_vms_update.cassette.rand_id
+++ b/internal/v6provider/testdata/LoadBalancer_vms_update.cassette.rand_id
@@ -1,1 +1,1 @@
-oa8iPZZyidim
+e86wUNCgQvF4

--- a/internal/v6provider/testdata/LoadBalancer_vms_update.cassette.yaml
+++ b/internal/v6provider/testdata/LoadBalancer_vms_update.cassette.yaml
@@ -25,7 +25,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -35,9 +35,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "819"
+      - "933"
       X-Request-Id:
-      - 78d934d2-092b-47dc-9d6b-4a8cf324c394
+      - 948d9ca8-29bd-45e3-8dce-ba799687bcc1
     status: 200 OK
     code: 200
     duration: ""
@@ -52,7 +52,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"185-44-253-140.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"185-44-253-145.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -69,9 +69,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"83b7487f9f52c40c49fa2464751f0ebc"
+      - W/"0ad1a07b920c51f43d28acc0e5808398"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -79,9 +79,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "814"
+      - "928"
       X-Request-Id:
-      - 8c916d0d-b871-4f81-a8de-9b6b407305b3
+      - 834127b0-d938-4845-b705-2118c09df7b8
     status: 200 OK
     code: 200
     duration: ""
@@ -91,10 +91,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_vqlsEGzCvZxt09fO
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_2SfId867ZYhs8OSr
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"185-44-253-140.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"185-44-253-145.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -111,9 +111,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"8387124f24b176dc214a109c26e10b3a"
+      - W/"26856f01a086a305ef8e839391a4508b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -121,9 +121,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "797"
+      - "924"
       X-Request-Id:
-      - f729c3a7-5e9d-4526-a9b4-2f11ced30c9c
+      - 46ea90b5-7a37-450d-9ac8-c0e04440974d
     status: 200 OK
     code: 200
     duration: ""
@@ -134,11 +134,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_vqlsEGzCvZxt09fO
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_2SfId867ZYhs8OSr
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"185-44-253-140.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"185-44-253-145.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -155,9 +155,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:48 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"8387124f24b176dc214a109c26e10b3a"
+      - W/"26856f01a086a305ef8e839391a4508b"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -165,15 +165,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "796"
+      - "923"
       X-Request-Id:
-      - 01c21bb1-1439-4371-bcf9-f5d2c01ea1a3
+      - aa1ca296-2026-4fa8-937e-33705919da17
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_vqlsEGzCvZxt09fO</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-magnificent-alive-osprey</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_2SfId867ZYhs8OSr</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-careful-resonant-swan</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -181,11 +181,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_mcJwKAfKQxLMtGYw","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_ugKrOrD229TKzoIc","state":"pending"},"virtual_machine_build":{"id":"vmbuild_ugKrOrD229TKzoIc","state":"pending"},"hostname":"tf-magnificent-alive-osprey","annotations":[]}'
+    body: '{"task":{"id":"task_7TzkBIGEPEZo3lWD","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_rcHJmIl6HxmJCFx2","state":"pending"},"virtual_machine_build":{"id":"vmbuild_rcHJmIl6HxmJCFx2","state":"pending"},"hostname":"tf-careful-resonant-swan","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -196,13 +196,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "283"
+      - "280"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:49 GMT
+      - Thu, 06 Feb 2025 17:37:45 GMT
       Etag:
-      - W/"08eacf7b935fa2769202d1555d5efae1"
+      - W/"d7b669313243d9570cbbc66bb70f0d57"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -210,9 +210,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "795"
+      - "922"
       X-Request-Id:
-      - 52b4e911-de81-4143-a46e-d0163efd56de
+      - a1f43052-646b-4a36-8ccb-40a8dbdfa685
     status: 201 Created
     code: 201
     duration: ""
@@ -223,18 +223,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ugKrOrD229TKzoIc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rcHJmIl6HxmJCFx2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ugKrOrD229TKzoIc","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_rcHJmIl6HxmJCFx2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-alive-osprey\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.145\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-careful-resonant-swan\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -247,9 +247,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:51 GMT
+      - Thu, 06 Feb 2025 17:37:47 GMT
       Etag:
-      - W/"cb48c35696e75aa1b6261838cff73958"
+      - W/"751a2de4bf35a1694de65c9243ee29c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -257,9 +257,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "757"
+      - "915"
       X-Request-Id:
-      - b2951f10-8bfa-4cce-b974-969fd278fca6
+      - f993935a-a508-4d41-aad0-dd8d92bf99be
     status: 200 OK
     code: 200
     duration: ""
@@ -270,18 +270,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ugKrOrD229TKzoIc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rcHJmIl6HxmJCFx2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ugKrOrD229TKzoIc","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_rcHJmIl6HxmJCFx2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-alive-osprey\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.145\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-careful-resonant-swan\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -294,9 +294,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:47:56 GMT
+      - Thu, 06 Feb 2025 17:37:52 GMT
       Etag:
-      - W/"cb48c35696e75aa1b6261838cff73958"
+      - W/"751a2de4bf35a1694de65c9243ee29c3"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -304,9 +304,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "685"
+      - "909"
       X-Request-Id:
-      - 3c968e6e-5eaa-4fe2-a51f-0fb59f55fa0f
+      - 8f3c7918-ee24-4486-99c6-9b9ad0c4632d
     status: 200 OK
     code: 200
     duration: ""
@@ -317,18 +317,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ugKrOrD229TKzoIc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rcHJmIl6HxmJCFx2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ugKrOrD229TKzoIc","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_rcHJmIl6HxmJCFx2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-alive-osprey\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.145\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-careful-resonant-swan\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -341,9 +341,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:06 GMT
+      - Thu, 06 Feb 2025 17:38:02 GMT
       Etag:
-      - W/"f16fbbc3ae448c4aab1d8c082c4fc167"
+      - W/"5639a6d7ced1ea4d50bfafe160d40b60"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -351,9 +351,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "995"
+      - "999"
       X-Request-Id:
-      - 8a0f08a2-a0e3-440e-b0c7-049e6824da97
+      - fc99917f-7d99-44ca-b5f8-75dbce4857e5
     status: 200 OK
     code: 200
     duration: ""
@@ -364,18 +364,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ugKrOrD229TKzoIc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rcHJmIl6HxmJCFx2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ugKrOrD229TKzoIc","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_rcHJmIl6HxmJCFx2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-alive-osprey\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.145\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-careful-resonant-swan\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -388,9 +388,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:16 GMT
+      - Thu, 06 Feb 2025 17:38:12 GMT
       Etag:
-      - W/"f16fbbc3ae448c4aab1d8c082c4fc167"
+      - W/"5639a6d7ced1ea4d50bfafe160d40b60"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -398,9 +398,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "990"
+      - "996"
       X-Request-Id:
-      - db2f896a-f5aa-4d31-af28-2ac488b3a6ae
+      - 49911bb2-33bc-401e-a931-23b4d7d64374
     status: 200 OK
     code: 200
     duration: ""
@@ -411,18 +411,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_ugKrOrD229TKzoIc
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_rcHJmIl6HxmJCFx2
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_ugKrOrD229TKzoIc","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_rcHJmIl6HxmJCFx2","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.140\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-magnificent-alive-osprey\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.253.145\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-careful-resonant-swan\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1734018468},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","state":"started"},"created_at":1738863465},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -435,9 +435,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:26 GMT
+      - Thu, 06 Feb 2025 17:38:22 GMT
       Etag:
-      - W/"0e09e686210888f85ce0cfd8e1f10075"
+      - W/"fa558b8cb4620112cd97e80694826395"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -445,9 +445,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "951"
       X-Request-Id:
-      - cd60b1e2-8b0c-4591-a3fd-f3c807138a14
+      - df623805-a4c3-46bc-adcc-0131f50896a9
     status: 200 OK
     code: 200
     duration: ""
@@ -458,19 +458,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -483,145 +483,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
+      - Thu, 06 Feb 2025 17:38:25 GMT
       Etag:
-      - W/"89069197a65914cac489dd06dbf2b0a0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "961"
-      X-Request-Id:
-      - 09ef85c1-a528-4a6f-9364-5c39fc4770c4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"89069197a65914cac489dd06dbf2b0a0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "957"
-      X-Request-Id:
-      - bc409cc1-50b0-47b1-a3ac-acf6020a0892
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_3V58clxL17but24x
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_QKMYSf3QvHmz1I6a","name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "377"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"c8304c88d0734ac469e4b52a907dd300"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "952"
-      X-Request-Id:
-      - 20dbcb06-b083-4dda-9834-f72c8131a3d4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_QKMYSf3QvHmz1I6a
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_QKMYSf3QvHmz1I6a","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"},"name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:a3:9d:1f:bf:01","state":"attached","ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "505"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:48:28 GMT
-      Etag:
-      - W/"4aa81ae3ec8cd752f12afd12e6d28845"
+      - W/"b47c4c9efdea7a506dbd2c27237b6810"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -631,12 +495,188 @@ interactions:
       X-Ratelimit-Remaining:
       - "948"
       X-Request-Id:
-      - c7c00b34-d277-463f-89fe-75c7ce3422e3
+      - 1e282fa2-9b6f-4529-931a-eb491176f749
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vms-update-oa8iPZZyidim","resource_ids":["vm_3V58clxL17but24x"],"resource_type":"virtual_machines"}}'
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:25 GMT
+      Etag:
+      - W/"b47c4c9efdea7a506dbd2c27237b6810"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "941"
+      X-Request-Id:
+      - 00349541-9e51-41bd-b92e-768bf6fcc236
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xgLewL5DsePoEyju","name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "375"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:25 GMT
+      Etag:
+      - W/"a49709208d9c79843d031a40ba907e6d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "940"
+      X-Request-Id:
+      - b2ae0133-d1f5-495b-a8f9-e504b5e71508
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "499"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:25 GMT
+      Etag:
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "939"
+      X-Request-Id:
+      - be839246-d392-464e-ba1c-4efc13a8f6ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "499"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:25 GMT
+      Etag:
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "938"
+      X-Request-Id:
+      - 5afc1326-d620-47db-b8c2-5a2ada9d1146
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization":{"sub_domain":"terraform-acc-test"},"properties":{"data_center":{"permalink":"uk-lon-01"},"https_redirect":false,"name":"tf-acc-test-vms-update-e86wUNCgQvF4","resource_ids":["vm_4YIRpjLSwOyFQYWQ"],"resource_type":"virtual_machines"}}'
     form: {}
     headers:
       Content-Type:
@@ -646,18 +686,18 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/load_balancers
     method: POST
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -670,9 +710,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:27 GMT
       Etag:
-      - W/"d0ca2e2daf22de43e8fbf2a412920f1e"
+      - W/"a9dd763f792ccc22e7989f559a8c6d8d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -680,9 +720,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "946"
+      - "937"
       X-Request-Id:
-      - b5bb6f9c-a899-420f-ae25-b92477bfd332
+      - b11fc37e-9a12-4e72-bfca-947916fa8dab
     status: 201 Created
     code: 201
     duration: ""
@@ -692,21 +732,21 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -719,9 +759,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:27 GMT
       Etag:
-      - W/"d0ca2e2daf22de43e8fbf2a412920f1e"
+      - W/"a9dd763f792ccc22e7989f559a8c6d8d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -729,9 +769,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "904"
+      - "936"
       X-Request-Id:
-      - 751b930f-b64a-40c2-9a81-0a22bec22751
+      - 29840bcb-fb4c-41a8-a2b9-425db7b5af57
     status: 200 OK
     code: 200
     duration: ""
@@ -741,21 +781,21 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -768,9 +808,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:27 GMT
       Etag:
-      - W/"d0ca2e2daf22de43e8fbf2a412920f1e"
+      - W/"a9dd763f792ccc22e7989f559a8c6d8d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -778,9 +818,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "903"
+      - "935"
       X-Request-Id:
-      - 1bf55af0-2f85-4e8e-ad4f-b06312cf7107
+      - 924731af-5363-40cf-a9f3-e5e505e03a71
     status: 200 OK
     code: 200
     duration: ""
@@ -790,12 +830,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_vqlsEGzCvZxt09fO
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_2SfId867ZYhs8OSr
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -806,13 +846,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "733"
+      - "727"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:27 GMT
       Etag:
-      - W/"d22db1b5bf193e72ee7c661e719d7565"
+      - W/"ae2092b08a6d78408dd7bb07df7653c2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -820,9 +860,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "901"
+      - "932"
       X-Request-Id:
-      - 8c36058a-a62a-4989-a59e-607c20621286
+      - ede24bb3-54bb-42e2-8243-7d85fceab027
     status: 200 OK
     code: 200
     duration: ""
@@ -833,19 +873,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -858,9 +898,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:27 GMT
       Etag:
-      - W/"89069197a65914cac489dd06dbf2b0a0"
+      - W/"b47c4c9efdea7a506dbd2c27237b6810"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -868,9 +908,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "900"
+      - "931"
       X-Request-Id:
-      - 3071927c-4249-45a9-b406-848e6f522678
+      - 60e663a4-3804-4383-a24d-a053f1660d38
     status: 200 OK
     code: 200
     duration: ""
@@ -878,16 +918,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_QKMYSf3QvHmz1I6a","name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xgLewL5DsePoEyju","name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -898,13 +936,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "377"
+      - "375"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:27 GMT
       Etag:
-      - W/"c8304c88d0734ac469e4b52a907dd300"
+      - W/"a49709208d9c79843d031a40ba907e6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -912,9 +950,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "899"
+      - "930"
       X-Request-Id:
-      - e455b26b-1e20-4a7f-af8a-4ff344284db2
+      - 8cd3d3d7-3ccc-4155-af7a-cd0db687266e
     status: 200 OK
     code: 200
     duration: ""
@@ -922,16 +960,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_QKMYSf3QvHmz1I6a
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_QKMYSf3QvHmz1I6a","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"},"name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:a3:9d:1f:bf:01","state":"attached","ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -942,13 +978,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "505"
+      - "499"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:28 GMT
       Etag:
-      - W/"4aa81ae3ec8cd752f12afd12e6d28845"
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -956,9 +992,53 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "898"
+      - "929"
       X-Request-Id:
-      - ab2f67e4-5c59-4eac-93fa-0c4f940ed56f
+      - 72e55759-b733-444f-8f6e-7f58111a7242
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "499"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:28 GMT
+      Etag:
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "928"
+      X-Request-Id:
+      - a8ba43de-3f01-482a-a160-c456e4e2d008
     status: 200 OK
     code: 200
     duration: ""
@@ -968,21 +1048,21 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -995,9 +1075,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:28 GMT
       Etag:
-      - W/"d0ca2e2daf22de43e8fbf2a412920f1e"
+      - W/"a9dd763f792ccc22e7989f559a8c6d8d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1005,9 +1085,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "897"
+      - "927"
       X-Request-Id:
-      - 09b02c90-a03c-4c8f-bf5e-c5a50c82717d
+      - 3ee60b02-9641-42ee-8968-2946842d5f67
     status: 200 OK
     code: 200
     duration: ""
@@ -1017,12 +1097,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_vqlsEGzCvZxt09fO
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_2SfId867ZYhs8OSr
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1033,13 +1113,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "733"
+      - "727"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:28 GMT
       Etag:
-      - W/"d22db1b5bf193e72ee7c661e719d7565"
+      - W/"ae2092b08a6d78408dd7bb07df7653c2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1047,9 +1127,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "895"
+      - "926"
       X-Request-Id:
-      - 8fbafefe-3ec9-4b4c-961b-f9ad5c5debcf
+      - 34c344d2-0fcd-4de7-9cce-8a5da5e23e1b
     status: 200 OK
     code: 200
     duration: ""
@@ -1060,19 +1140,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1085,9 +1165,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:28 GMT
       Etag:
-      - W/"89069197a65914cac489dd06dbf2b0a0"
+      - W/"b47c4c9efdea7a506dbd2c27237b6810"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1095,9 +1175,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "894"
+      - "925"
       X-Request-Id:
-      - ac44e070-985f-4ed9-a4b3-3cc511dfff1c
+      - 68ec4853-8c19-489a-936b-d96aa80b2dfe
     status: 200 OK
     code: 200
     duration: ""
@@ -1105,16 +1185,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_QKMYSf3QvHmz1I6a","name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xgLewL5DsePoEyju","name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1125,13 +1203,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "377"
+      - "375"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:28 GMT
       Etag:
-      - W/"c8304c88d0734ac469e4b52a907dd300"
+      - W/"a49709208d9c79843d031a40ba907e6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1139,9 +1217,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "893"
+      - "924"
       X-Request-Id:
-      - 06736b16-cec1-4ce8-a6b5-7741cae2b8e1
+      - 70974929-9d3e-421b-a134-6782e68615e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1149,16 +1227,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_QKMYSf3QvHmz1I6a
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_QKMYSf3QvHmz1I6a","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"},"name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:a3:9d:1f:bf:01","state":"attached","ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1169,13 +1245,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "505"
+      - "499"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:30 GMT
+      - Thu, 06 Feb 2025 17:38:28 GMT
       Etag:
-      - W/"4aa81ae3ec8cd752f12afd12e6d28845"
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1183,9 +1259,53 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "892"
+      - "923"
       X-Request-Id:
-      - dc1b78c5-4976-42a9-9909-b87abcd13e04
+      - 5a2cdbae-4291-485d-9391-7c4354ad27d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "499"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:28 GMT
+      Etag:
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "922"
+      X-Request-Id:
+      - cff5d861-c9d3-4255-bf9e-84a4ea31d885
     status: 200 OK
     code: 200
     duration: ""
@@ -1195,21 +1315,21 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1222,9 +1342,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:31 GMT
+      - Thu, 06 Feb 2025 17:38:28 GMT
       Etag:
-      - W/"d0ca2e2daf22de43e8fbf2a412920f1e"
+      - W/"a9dd763f792ccc22e7989f559a8c6d8d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1232,9 +1352,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "891"
+      - "921"
       X-Request-Id:
-      - 30924602-6ebb-44de-86f0-90f48c75f349
+      - bae6cce5-5c41-4c04-a87a-a0b2191e920d
     status: 200 OK
     code: 200
     duration: ""
@@ -1262,7 +1382,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:31 GMT
+      - Thu, 06 Feb 2025 17:38:29 GMT
       Etag:
       - W/"2c9b33d800419097f42e5eccf7b390c3"
       Strict-Transport-Security:
@@ -1272,9 +1392,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "890"
+      - "920"
       X-Request-Id:
-      - 5cd294bc-6746-41f2-b4f8-9a3b279fc4f0
+      - 6873e63a-c473-4306-b6ac-69436341cf35
     status: 200 OK
     code: 200
     duration: ""
@@ -1289,7 +1409,7 @@ interactions:
     url: https://api.katapult.io/core/v1/organizations/organization/ip_addresses
     method: POST
   response:
-    body: '{"ip_address":{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"185-44-255-129.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"185-44-252-231.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null}}'
     headers:
@@ -1306,9 +1426,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:31 GMT
+      - Thu, 06 Feb 2025 17:38:29 GMT
       Etag:
-      - W/"1f364c4d9649cd83666086a9e69ef1ea"
+      - W/"be95a97f968359ea6edd68f030e35e04"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1316,9 +1436,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "889"
+      - "919"
       X-Request-Id:
-      - 46753e85-909d-4c02-8629-f7813cfcf095
+      - a1d4e572-3ce6-4707-b843-42071ab7617a
     status: 200 OK
     code: 200
     duration: ""
@@ -1328,10 +1448,10 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_EsiISUR4sV7GRkbC
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"185-44-255-129.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"185-44-252-231.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -1348,9 +1468,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:31 GMT
+      - Thu, 06 Feb 2025 17:38:29 GMT
       Etag:
-      - W/"f8167f96bf80fc4a5ed91b723b0f2ddc"
+      - W/"e7bb9a8eee5f97e1526185c41fc94db1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1358,9 +1478,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "888"
+      - "918"
       X-Request-Id:
-      - bc1f3530-9169-48b8-b6c9-8a0f1fc4dfa9
+      - 76b70702-ae73-466a-90f0-2fb42f3f18c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,11 +1491,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_EsiISUR4sV7GRkbC
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"185-44-255-129.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"185-44-252-231.rdns.katapult.io","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":null,"allocation_type":null},"allocation":null}'
     headers:
@@ -1392,9 +1512,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:31 GMT
+      - Thu, 06 Feb 2025 17:38:29 GMT
       Etag:
-      - W/"f8167f96bf80fc4a5ed91b723b0f2ddc"
+      - W/"e7bb9a8eee5f97e1526185c41fc94db1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1402,15 +1522,15 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "887"
+      - "917"
       X-Request-Id:
-      - c987c322-f86f-4c37-99a8-e86caa281058
+      - a14a02fe-6fd9-426a-993d-1f537819e9bf
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: |
-      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_EsiISUR4sV7GRkbC</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-bitter-howling-steel</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
+      {"organization":{"sub_domain":"terraform-acc-test"},"xml":"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VirtualMachineSpec><DataCenter by=\"permalink\">uk-lon-01</DataCenter><Resources><Package by=\"permalink\">rock-3</Package></Resources><DiskTemplate><DiskTemplate by=\"permalink\">templates/ubuntu-22-04</DiskTemplate><Option key=\"install_agent\">true</Option></DiskTemplate><NetworkInterfaces><NetworkInterface><Network>netw_gVRkZdSKczfNg34P</Network><IPAddressAllocation type=\"existing\"><IPAddress>ip_VY1yFEi3yDSPQG6i</IPAddress></IPAddressAllocation></NetworkInterface></NetworkInterfaces><Hostname><Hostname>tf-odd-hissing-zinc</Hostname></Hostname><AuthorizedKeys><Users all=\"yes\"></Users><SSHKeys all=\"yes\"></SSHKeys></AuthorizedKeys></VirtualMachineSpec>"}
     form: {}
     headers:
       Accept:
@@ -1418,11 +1538,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
     url: https://api.katapult.io/core/v1/organizations/_/virtual_machines/build_from_spec
     method: POST
   response:
-    body: '{"task":{"id":"task_bwiHfOlXkmWw4j4C","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_mpV0AEAEcY3QwsR3","state":"pending"},"virtual_machine_build":{"id":"vmbuild_mpV0AEAEcY3QwsR3","state":"pending"},"hostname":"tf-bitter-howling-steel","annotations":[]}'
+    body: '{"task":{"id":"task_x4d41kBTkKfdZhFj","name":"Build virtual machine","status":"pending"},"build":{"id":"vmbuild_MydGDDFC2B6tB884","state":"pending"},"virtual_machine_build":{"id":"vmbuild_MydGDDFC2B6tB884","state":"pending"},"hostname":"tf-odd-hissing-zinc","annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1433,13 +1553,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "279"
+      - "275"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:31 GMT
+      - Thu, 06 Feb 2025 17:38:29 GMT
       Etag:
-      - W/"85ddc2d4a05bbe17b7b154cfa4e8be0f"
+      - W/"31684cec745bfb0856f2c473f90f6019"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1447,9 +1567,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "886"
+      - "916"
       X-Request-Id:
-      - faebf216-26d9-4d03-900d-0d2317b4e43d
+      - 51c33684-51d1-40eb-9f3a-c7ccd9f7384e
     status: 201 Created
     code: 201
     duration: ""
@@ -1460,18 +1580,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mpV0AEAEcY3QwsR3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MydGDDFC2B6tB884
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mpV0AEAEcY3QwsR3","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_MydGDDFC2B6tB884","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.129\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-bitter-howling-steel\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.231\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-odd-hissing-zinc\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1734018511},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":null,"created_at":1738863509},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1484,9 +1604,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:33 GMT
+      - Thu, 06 Feb 2025 17:38:31 GMT
       Etag:
-      - W/"b93205453b275f86724b1187cf2b790f"
+      - W/"c4e726257d71d97ccc113fa921333106"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1494,9 +1614,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "875"
+      - "913"
       X-Request-Id:
-      - 84566aa3-716c-43d7-8e31-24a2fe09a9ae
+      - 72694b46-cb63-4595-933b-86aa6f94920f
     status: 200 OK
     code: 200
     duration: ""
@@ -1507,18 +1627,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mpV0AEAEcY3QwsR3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MydGDDFC2B6tB884
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mpV0AEAEcY3QwsR3","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_MydGDDFC2B6tB884","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.129\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-bitter-howling-steel\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.231\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-odd-hissing-zinc\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018511},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863509},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1531,9 +1651,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:38 GMT
+      - Thu, 06 Feb 2025 17:38:36 GMT
       Etag:
-      - W/"5b8b94e0d3cb0d50f3ab0d230ddc091b"
+      - W/"537851d3dd08c17ca917a79614a1e6ee"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1541,9 +1661,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "795"
+      - "878"
       X-Request-Id:
-      - 859fbb98-dd23-49ca-acb3-e5c3ece86821
+      - 063434e4-0c12-4fdb-8806-70374990fb15
     status: 200 OK
     code: 200
     duration: ""
@@ -1554,18 +1674,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mpV0AEAEcY3QwsR3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MydGDDFC2B6tB884
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mpV0AEAEcY3QwsR3","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_MydGDDFC2B6tB884","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.129\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-bitter-howling-steel\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.231\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-odd-hissing-zinc\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1734018511},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"building","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","state":"stopped"},"created_at":1738863509},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1578,9 +1698,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:48 GMT
+      - Thu, 06 Feb 2025 17:38:46 GMT
       Etag:
-      - W/"5b8b94e0d3cb0d50f3ab0d230ddc091b"
+      - W/"537851d3dd08c17ca917a79614a1e6ee"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1588,9 +1708,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "777"
+      - "865"
       X-Request-Id:
-      - 6a366257-ccf7-4454-8e57-a87105725577
+      - 51d87f9f-1656-45bc-9952-4fe822a4bda8
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,18 +1721,18 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_mpV0AEAEcY3QwsR3
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/builds/_?virtual_machine_build%5Bid%5D=vmbuild_MydGDDFC2B6tB884
     method: GET
   response:
-    body: '{"virtual_machine_build":{"id":"vmbuild_mpV0AEAEcY3QwsR3","spec_xml":"\u003c?xml
+    body: '{"virtual_machine_build":{"id":"vmbuild_MydGDDFC2B6tB884","spec_xml":"\u003c?xml
       version=\"1.0\"?\u003e\n\u003cVirtualMachineSpec\u003e\n  \u003cDataCenter\u003eloc_UUhPmoCbpic6UX0Y\u003c/DataCenter\u003e\n  \u003cResources\u003e\n    \u003cPackage
       by=\"permalink\"\u003erock-3\u003c/Package\u003e\n  \u003c/Resources\u003e\n  \u003cDiskTemplate\u003e\n    \u003cDiskTemplate
       by=\"permalink\"\u003etemplates/ubuntu-22-04\u003c/DiskTemplate\u003e\n    \u003cVersion
       by=\"number\"\u003e1\u003c/Version\u003e\n    \u003cOption key=\"install_agent\"\u003etrue\u003c/Option\u003e\n  \u003c/DiskTemplate\u003e\n  \u003cNetworkInterfaces\u003e\n    \u003cNetworkInterface\u003e\n      \u003cNetwork\u003enetw_gVRkZdSKczfNg34P\u003c/Network\u003e\n      \u003cIPAddressAllocation
-      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.255.129\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-bitter-howling-steel\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
+      type=\"existing\"\u003e\n        \u003cIPAddress by=\"address\"\u003e185.44.252.231\u003c/IPAddress\u003e\n      \u003c/IPAddressAllocation\u003e\n    \u003c/NetworkInterface\u003e\n  \u003c/NetworkInterfaces\u003e\n  \u003cHostname\u003e\n    \u003cHostname\u003etf-odd-hissing-zinc\u003c/Hostname\u003e\n  \u003c/Hostname\u003e\n  \u003cAuthorizedKeys
       continuous_management=\"no\"\u003e\n    \u003cUsers all=\"yes\"/\u003e\n    \u003cSSHKeys
-      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1734018511},"annotations":[]}'
+      all=\"yes\"/\u003e\n  \u003c/AuthorizedKeys\u003e\n\u003c/VirtualMachineSpec\u003e\n","state":"complete","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","state":"starting"},"created_at":1738863509},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1625,9 +1745,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:48:58 GMT
+      - Thu, 06 Feb 2025 17:38:56 GMT
       Etag:
-      - W/"3fbe27dfdf2e46891c384f6e3c6ecaa3"
+      - W/"ba3dd234f113b90df70592e54dff9be8"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1635,9 +1755,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "766"
+      - "859"
       X-Request-Id:
-      - 47d0a1fd-40ad-4542-a5cf-d635fc38063d
+      - 2f1f9fa0-eeb4-4c33-963f-9cae1683093a
     status: 200 OK
     code: 200
     duration: ""
@@ -1648,19 +1768,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1673,9 +1793,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:00 GMT
+      - Thu, 06 Feb 2025 17:38:58 GMT
       Etag:
-      - W/"f6f24c7ed72c5fecca028275addf07ad"
+      - W/"7647a56d819d6e18e0c3db3c48bb53cd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1683,9 +1803,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "999"
+      - "858"
       X-Request-Id:
-      - f108377e-cf27-4e4a-9a47-4305e60a223d
+      - 6321afcd-9715-4442-a112-d8676b0997d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,19 +1816,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1721,9 +1841,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:00 GMT
+      - Thu, 06 Feb 2025 17:38:58 GMT
       Etag:
-      - W/"f6f24c7ed72c5fecca028275addf07ad"
+      - W/"7647a56d819d6e18e0c3db3c48bb53cd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1731,9 +1851,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "998"
+      - "857"
       X-Request-Id:
-      - 1e1ec995-8614-4ed0-81b9-1ea2e2f9dae4
+      - 9f9d07fd-cd45-4d0a-9cb1-abcceb1a5d50
     status: 200 OK
     code: 200
     duration: ""
@@ -1741,16 +1861,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jXUtrsSHIhNWmOZQ","name":"Public
-      Network on tf-bitter-howling-steel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Z9lzxfQcLid5XztI","name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1761,13 +1879,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "373"
+      - "370"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:00 GMT
+      - Thu, 06 Feb 2025 17:38:58 GMT
       Etag:
-      - W/"abdc42d8dda0b2466c22169ff727c269"
+      - W/"fe1cd598f8e5cb20933f2ab51b46db32"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1775,9 +1893,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "997"
+      - "856"
       X-Request-Id:
-      - bee4b55c-47fe-474e-82e3-9b10f76a4da8
+      - 41243cf1-6209-4f60-9588-6a38619d6fff
     status: 200 OK
     code: 200
     duration: ""
@@ -1785,16 +1903,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jXUtrsSHIhNWmOZQ
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Z9lzxfQcLid5XztI
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_jXUtrsSHIhNWmOZQ","virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel"},"name":"Public
-      Network on tf-bitter-howling-steel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:65:e4:99:4d:8b","state":"attached","ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Z9lzxfQcLid5XztI","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"},"name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:1b:fd:b1:1a:b8","state":"detached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1805,13 +1921,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "497"
+      - "489"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:00 GMT
+      - Thu, 06 Feb 2025 17:38:58 GMT
       Etag:
-      - W/"b6253e6d17d12722ca053e2932cabc69"
+      - W/"eae8d55da522c2ea96f36a6ae3e27483"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1819,14 +1935,58 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "996"
+      - "855"
       X-Request-Id:
-      - 5ae2b5da-7c03-4712-89a4-45b32cf20817
+      - 1e3cd8a7-160e-4783-b759-71a028882185
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ"},"properties":{"resource_ids":["vm_3V58clxL17but24x","vm_cRggrlhECop1JzP7"],"resource_type":"virtual_machines"}}'
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Z9lzxfQcLid5XztI
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Z9lzxfQcLid5XztI","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"},"name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:1b:fd:b1:1a:b8","state":"detached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "489"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:58 GMT
+      Etag:
+      - W/"eae8d55da522c2ea96f36a6ae3e27483"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "854"
+      X-Request-Id:
+      - 1632395f-d10b-4ea9-afbf-444d35908360
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO"},"properties":{"resource_ids":["vm_4YIRpjLSwOyFQYWQ","vm_dwioBSDpMRbpwXlw"],"resource_type":"virtual_machines"}}'
     form: {}
     headers:
       Content-Type:
@@ -1836,26 +1996,26 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: PATCH
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x","vm_cRggrlhECop1JzP7"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128},{"virtual_machine_id":"vm_cRggrlhECop1JzP7","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ","vm_dwioBSDpMRbpwXlw"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128},{"virtual_machine_id":"vm_dwioBSDpMRbpwXlw","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1868,9 +2028,748 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:00 GMT
+      - Thu, 06 Feb 2025 17:38:59 GMT
       Etag:
-      - W/"754f33d3e476a62260921e944a016d5d"
+      - W/"fb02eb11998c3ee1c7e0a0fb049561e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "853"
+      X-Request-Id:
+      - 23214255-8d09-46a2-b4a4-9d22bb3472f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ","vm_dwioBSDpMRbpwXlw"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128},{"virtual_machine_id":"vm_dwioBSDpMRbpwXlw","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"fb02eb11998c3ee1c7e0a0fb049561e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "852"
+      X-Request-Id:
+      - d17a92a6-fa26-45b0-ad7f-3aea30be4a6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ","vm_dwioBSDpMRbpwXlw"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128},{"virtual_machine_id":"vm_dwioBSDpMRbpwXlw","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"fb02eb11998c3ee1c7e0a0fb049561e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "851"
+      X-Request-Id:
+      - 4b6e1995-54b9-479b-ac43-15f165a870da
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_2SfId867ZYhs8OSr
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "727"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"ae2092b08a6d78408dd7bb07df7653c2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "849"
+      X-Request-Id:
+      - 50270a0a-86ab-48a3-be71-b176516393b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "717"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"b7a9c9f8526d5fcdf2a95ae4e6a44f68"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "850"
+      X-Request-Id:
+      - c2db5042-cd63-43ce-8c19-9efb376852ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"b47c4c9efdea7a506dbd2c27237b6810"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "848"
+      X-Request-Id:
+      - c83c248b-cca3-4c35-b1fe-ea63d5aaa95a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"7647a56d819d6e18e0c3db3c48bb53cd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "847"
+      X-Request-Id:
+      - c97fa40d-1b21-4443-a976-86422076bb1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Z9lzxfQcLid5XztI","name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "370"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"fe1cd598f8e5cb20933f2ab51b46db32"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "845"
+      X-Request-Id:
+      - 463cec36-4b0c-4a6a-b514-8e86fb6d6cdd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xgLewL5DsePoEyju","name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "375"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"a49709208d9c79843d031a40ba907e6d"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "846"
+      X-Request-Id:
+      - f9ae5b39-7651-4d69-88f6-0ecb57c7fb92
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "499"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "844"
+      X-Request-Id:
+      - 8e995669-d96f-4b88-bb42-763533a4e060
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "499"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "842"
+      X-Request-Id:
+      - 6e273f40-22a2-43df-9f1d-032b2be7edd4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Z9lzxfQcLid5XztI
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Z9lzxfQcLid5XztI","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"},"name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:1b:fd:b1:1a:b8","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "489"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:38:59 GMT
+      Etag:
+      - W/"1218494f035bf82952e40e43c458a5b5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "844"
+      X-Request-Id:
+      - 0e74242d-9aca-4818-8d83-f00fab797c76
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Z9lzxfQcLid5XztI
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Z9lzxfQcLid5XztI","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"},"name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:1b:fd:b1:1a:b8","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "489"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:00 GMT
+      Etag:
+      - W/"1218494f035bf82952e40e43c458a5b5"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "999"
+      X-Request-Id:
+      - e6cca19d-d181-4608-9064-376bba50fbec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ","vm_dwioBSDpMRbpwXlw"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128},{"virtual_machine_id":"vm_dwioBSDpMRbpwXlw","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:00 GMT
+      Etag:
+      - W/"fb02eb11998c3ee1c7e0a0fb049561e9"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "998"
+      X-Request-Id:
+      - 3e9f4b75-d37c-4bae-bbfc-e1ec63796693
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_2SfId867ZYhs8OSr
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "727"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:00 GMT
+      Etag:
+      - W/"ae2092b08a6d78408dd7bb07df7653c2"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "997"
+      X-Request-Id:
+      - 75a58e50-62c7-4d89-ad4c-33209748dc36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
+    method: GET
+  response:
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "717"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:00 GMT
+      Etag:
+      - W/"b7a9c9f8526d5fcdf2a95ae4e6a44f68"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "996"
+      X-Request-Id:
+      - e4c9f224-e3ae-4153-87f4-662a7f1444b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:00 GMT
+      Etag:
+      - W/"b47c4c9efdea7a506dbd2c27237b6810"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1880,7 +2779,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "995"
       X-Request-Id:
-      - f4d7763b-dd22-4291-a429-a885f2bdf6bd
+      - 93081fc0-0b2b-432d-9017-1ebf17d20bdb
     status: 200 OK
     code: 200
     duration: ""
@@ -1888,31 +2787,22 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x","vm_cRggrlhECop1JzP7"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128},{"virtual_machine_id":"vm_cRggrlhECop1JzP7","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1925,9 +2815,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"754f33d3e476a62260921e944a016d5d"
+      - W/"7647a56d819d6e18e0c3db3c48bb53cd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1937,7 +2827,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "994"
       X-Request-Id:
-      - 3d7d3efa-6cf7-42c6-83d5-c581f1c26076
+      - 46a3a1c5-4f9f-43a4-9495-da8dbedf784c
     status: 200 OK
     code: 200
     duration: ""
@@ -1946,30 +2836,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x","vm_cRggrlhECop1JzP7"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128},{"virtual_machine_id":"vm_cRggrlhECop1JzP7","weight":128}],"standby_vms":[]},"annotations":[]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xgLewL5DsePoEyju","name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -1979,12 +2852,14 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Content-Length:
+      - "375"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"754f33d3e476a62260921e944a016d5d"
+      - W/"a49709208d9c79843d031a40ba907e6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1994,7 +2869,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "993"
       X-Request-Id:
-      - a6b7e095-af76-454d-a2a0-15a95255a16b
+      - 352e8297-3497-4c6f-962a-beaed4f4953b
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,13 +2878,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_EsiISUR4sV7GRkbC
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel"}}}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Z9lzxfQcLid5XztI","name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2020,13 +2895,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "725"
+      - "370"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"8589c44cf4b8106b51d7d4c8430021c9"
+      - W/"fe1cd598f8e5cb20933f2ab51b46db32"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2036,7 +2911,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "992"
       X-Request-Id:
-      - 887b577d-9980-4334-b97d-e20b8985e795
+      - 41a01304-c13e-4230-b7e8-cf89d06582f8
     status: 200 OK
     code: 200
     duration: ""
@@ -2045,13 +2920,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_vqlsEGzCvZxt09fO
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
     method: GET
   response:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2062,13 +2937,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "733"
+      - "499"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"d22db1b5bf193e72ee7c661e719d7565"
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2078,7 +2953,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "991"
       X-Request-Id:
-      - 8d823764-41ae-4332-9f5a-9c6a525eaa33
+      - a448ba76-f8f9-44fc-bed6-7235144acbad
     status: 200 OK
     code: 200
     duration: ""
@@ -2086,22 +2961,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Z9lzxfQcLid5XztI
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Z9lzxfQcLid5XztI","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"},"name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:1b:fd:b1:1a:b8","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2111,12 +2978,14 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Content-Length:
+      - "489"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"f6f24c7ed72c5fecca028275addf07ad"
+      - W/"1218494f035bf82952e40e43c458a5b5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2126,7 +2995,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "990"
       X-Request-Id:
-      - c7a5b8e0-4079-452c-aa9e-afa01a424d4e
+      - 51d03184-9760-45ca-ac67-61b710d3242d
     status: 200 OK
     code: 200
     duration: ""
@@ -2137,61 +3006,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Z9lzxfQcLid5XztI
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
-      Etag:
-      - W/"89069197a65914cac489dd06dbf2b0a0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "989"
-      X-Request-Id:
-      - f9f1a8b0-314b-4632-a8f4-17b2a8cd6959
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jXUtrsSHIhNWmOZQ","name":"Public
-      Network on tf-bitter-howling-steel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Z9lzxfQcLid5XztI","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"},"name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:1b:fd:b1:1a:b8","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2202,13 +3023,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "373"
+      - "489"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"abdc42d8dda0b2466c22169ff727c269"
+      - W/"1218494f035bf82952e40e43c458a5b5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2218,7 +3039,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "988"
       X-Request-Id:
-      - e9ba9910-fecc-42ec-8a05-4a36dd0cfc55
+      - f364caa5-f568-494e-8af5-5494040d06c5
     status: 200 OK
     code: 200
     duration: ""
@@ -2229,13 +3050,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_QKMYSf3QvHmz1I6a","name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2246,13 +3067,70 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "377"
+      - "499"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"c8304c88d0734ac469e4b52a907dd300"
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "989"
+      X-Request-Id:
+      - 0a7dae97-61bd-4471-ba75-1cf1eaec7ad7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
+    method: GET
+  response:
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ","vm_dwioBSDpMRbpwXlw"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128},{"virtual_machine_id":"vm_dwioBSDpMRbpwXlw","weight":128}],"standby_vms":[]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:00 GMT
+      Etag:
+      - W/"fb02eb11998c3ee1c7e0a0fb049561e9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2262,7 +3140,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "987"
       X-Request-Id:
-      - d2d8e9e6-c282-4ed1-b0cb-7be5e1e9d6d0
+      - e0c5cec3-d942-4718-aacc-8299f740b1dc
     status: 200 OK
     code: 200
     duration: ""
@@ -2270,16 +3148,31 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jXUtrsSHIhNWmOZQ
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_jXUtrsSHIhNWmOZQ","virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel"},"name":"Public
-      Network on tf-bitter-howling-steel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:65:e4:99:4d:8b","state":"attached","ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ","vm_dwioBSDpMRbpwXlw"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128},{"virtual_machine_id":"vm_dwioBSDpMRbpwXlw","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2289,14 +3182,12 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
-      Content-Length:
-      - "497"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"b6253e6d17d12722ca053e2932cabc69"
+      - W/"fb02eb11998c3ee1c7e0a0fb049561e9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2306,7 +3197,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "986"
       X-Request-Id:
-      - f7eea0d6-584d-4edf-bef5-ac7d8d8e8eeb
+      - 3229f488-1ada-454b-b11a-841acd3b79cc
     status: 200 OK
     code: 200
     duration: ""
@@ -2314,16 +3205,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_QKMYSf3QvHmz1I6a
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_QKMYSf3QvHmz1I6a","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"},"name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:a3:9d:1f:bf:01","state":"attached","ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2334,13 +3223,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "505"
+      - "717"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"4aa81ae3ec8cd752f12afd12e6d28845"
+      - W/"b7a9c9f8526d5fcdf2a95ae4e6a44f68"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2350,7 +3239,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "985"
       X-Request-Id:
-      - 67b6622e-07e6-4c31-ac2a-69422b722db9
+      - f667e77b-7b28-400b-a712-cf24710fd7eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2360,69 +3249,12 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_2SfId867ZYhs8OSr
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x","vm_cRggrlhECop1JzP7"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128},{"virtual_machine_id":"vm_cRggrlhECop1JzP7","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
-      Etag:
-      - W/"754f33d3e476a62260921e944a016d5d"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "984"
-      X-Request-Id:
-      - 450ac1b4-2d58-4cdb-bbd2-d50284a1079a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_EsiISUR4sV7GRkbC
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel"}}}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2433,13 +3265,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "725"
+      - "727"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"8589c44cf4b8106b51d7d4c8430021c9"
+      - W/"ae2092b08a6d78408dd7bb07df7653c2"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2447,51 +3279,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "983"
+      - "985"
       X-Request-Id:
-      - e5878308-3657-442b-b3e8-22736913f6a0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_vqlsEGzCvZxt09fO
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "733"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
-      Etag:
-      - W/"d22db1b5bf193e72ee7c661e719d7565"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "983"
-      X-Request-Id:
-      - cd5b4a02-9995-4b78-b131-9b655f396349
+      - 3c3214f0-39d6-47b7-af53-47b1e32455e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2502,19 +3292,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2527,9 +3317,99 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:00 GMT
       Etag:
-      - W/"f6f24c7ed72c5fecca028275addf07ad"
+      - W/"7647a56d819d6e18e0c3db3c48bb53cd"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "983"
+      X-Request-Id:
+      - 213adb18-b5bb-493e-906b-333760835288
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:00 GMT
+      Etag:
+      - W/"b47c4c9efdea7a506dbd2c27237b6810"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "982"
+      X-Request-Id:
+      - a93c542d-d81e-489a-b2c4-5e53d1fd009a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_xgLewL5DsePoEyju","name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "375"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:01 GMT
+      Etag:
+      - W/"a49709208d9c79843d031a40ba907e6d"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2539,7 +3419,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "981"
       X-Request-Id:
-      - 59687bf6-bcdf-43c3-b46f-b44c9b9e63e9
+      - 537648bb-0662-4798-8585-709c8e2eaaef
     status: 200 OK
     code: 200
     duration: ""
@@ -2547,16 +3427,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/virtual_machine/network_interfaces?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jXUtrsSHIhNWmOZQ","name":"Public
-      Network on tf-bitter-howling-steel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129"}]}]}'
+    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":30,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_Z9lzxfQcLid5XztI","name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}]}]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2567,13 +3445,55 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "373"
+      - "370"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"abdc42d8dda0b2466c22169ff727c269"
+      - W/"fe1cd598f8e5cb20933f2ab51b46db32"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "981"
+      X-Request-Id:
+      - 6aa00789-34e8-44b0-b89d-b4f2fea2cc99
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_Z9lzxfQcLid5XztI
+    method: GET
+  response:
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Z9lzxfQcLid5XztI","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"},"name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:1b:fd:b1:1a:b8","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "489"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:01 GMT
+      Etag:
+      - W/"1218494f035bf82952e40e43c458a5b5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2583,7 +3503,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "979"
       X-Request-Id:
-      - b63ed66c-48d1-4b9b-a4eb-6b79130b24fb
+      - c83b0dd1-6952-4e3f-acf1-3f2b31059370
     status: 200 OK
     code: 200
     duration: ""
@@ -2591,64 +3511,14 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/virtual_machine_network_interface?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
-      Etag:
-      - W/"89069197a65914cac489dd06dbf2b0a0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "980"
-      X-Request-Id:
-      - e8353ead-3b8d-4cef-9924-22863ae82659
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_3V58clxL17but24x
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_QKMYSf3QvHmz1I6a","name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}]}]}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2659,13 +3529,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "377"
+      - "499"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"c8304c88d0734ac469e4b52a907dd300"
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2673,9 +3543,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "978"
+      - "979"
       X-Request-Id:
-      - 24ce7cd4-7bb2-4458-9f4f-d1c04dfda998
+      - bf3d2c88-2ddd-4426-8662-0033be9ba8a1
     status: 200 OK
     code: 200
     duration: ""
@@ -2686,13 +3556,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jXUtrsSHIhNWmOZQ
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_Z9lzxfQcLid5XztI
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_jXUtrsSHIhNWmOZQ","virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel"},"name":"Public
-      Network on tf-bitter-howling-steel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:65:e4:99:4d:8b","state":"attached","ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_Z9lzxfQcLid5XztI","virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc"},"name":"Public
+      Network on tf-odd-hissing-zinc","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:1b:fd:b1:1a:b8","state":"attached","ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2703,13 +3573,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "497"
+      - "489"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"b6253e6d17d12722ca053e2932cabc69"
+      - W/"1218494f035bf82952e40e43c458a5b5"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2719,7 +3589,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "977"
       X-Request-Id:
-      - 441cc74a-57b3-4752-8414-1ac141437775
+      - 761cccb3-52d6-4749-82f9-fe0f0bc55cab
     status: 200 OK
     code: 200
     duration: ""
@@ -2730,13 +3600,13 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_QKMYSf3QvHmz1I6a
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_xgLewL5DsePoEyju
     method: GET
   response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_QKMYSf3QvHmz1I6a","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"},"name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:a3:9d:1f:bf:01","state":"attached","ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
+    body: '{"virtual_machine_network_interface":{"id":"vmnet_xgLewL5DsePoEyju","virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan"},"name":"Public
+      Network on tf-careful-resonant-swan","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network"},"virtual_network":null,"mac_address":"3a:ce:4c:5b:6b:ff","state":"attached","ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2747,13 +3617,13 @@ interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Length:
-      - "505"
+      - "499"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:01 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"4aa81ae3ec8cd752f12afd12e6d28845"
+      - W/"6db05fe11596b2021c580fbe3aaf84bc"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2763,7 +3633,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "976"
       X-Request-Id:
-      - cd35619b-42ce-45f2-b6fd-fb2e5566ea0d
+      - 6a59be79-3712-4246-8da3-3056d76233b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2773,29 +3643,29 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
     method: GET
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x","vm_cRggrlhECop1JzP7"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128},{"virtual_machine_id":"vm_cRggrlhECop1JzP7","weight":128}],"standby_vms":[]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_4YIRpjLSwOyFQYWQ","vm_dwioBSDpMRbpwXlw"],"ip_address":{"id":"ip_2nmTTYM8cpgT5LsK","address":"185.44.252.16"},"https_redirect":false,"backend_certificate":"-----BEGIN
+      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfdHVWV2dRQzE0Szd3Y0VrTy5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjUw\nMjA2MTczODI3WhgPMjA3NTAyMDYxNzM4MjdaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBANHGQ2m6MixSkNAjQXMbSrTaofPn6BtHwVWJ\nPFWryQTLsxAWozIXBdVVJe1kbLFSGmm/c4ABNX8ZoD7lWrju4436GySDOwoSxxzG\nFfupJnuBko597khq6j94hBdRLHQSj6wInGhZlJUE9IXjn43pZueI4KUDn5yqJvzg\nMSL8y6exRq8GdTMNsbFdJNU/1KuOiGjnUK8L5JWrubumqtBvB05UG6DDAtVkWsT1\na4H8DERlhCu+R/MZ+07NS/UKlMYpz0CHeQUS5VUeXWTn42hDRNmTL5SE5sL0FhuG\nYxq46UPnUHvNwauFvzMkR3O524s610KayAwxnF4Jd2/3vv1V+dZVa6nKXLNyHO/u\n1WDG6WVemE0+MRhoQYFTn9BGIoi3lRXjl+FL2Hb4uTIOgkiYYaBup0iHDbyqlkaJ\nWAr9RkXWJh+RS1KLTi3J/Ato+QlerwjxwI5BQUULAyO8UPpinXg+yJlcIT878qxh\nXHKHQckltrCKcJgVtd++L2lHYqqULdQgF1Bv1P7FvQI2u9QsyUuhv6g/h5VOQHLh\n6HkhNL6UhtNMZ3FjnywikcYqTEsaNPcvaTW8VlVGP3JHKvyUM76v9ujELGI8jPcO\nuVRTmQ/KH1oIICoVFtAczHhW/m1Envm7ARS0mgF53HlXHeDf8V00yQyiWZ2hMCV+\nZelmXXK7AgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTp\nld96lOHKr30CdwcWQIp34fqNFTATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFOmV33qU4cqvfQJ3BxZAinfh+o0V\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl90dVZXZ1FDMTRLN3djRWtPLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEACdBeHzi2hTis\nFKDO7IuQR8+V65ts/V84sH8z9pXnK21MPTTUk+3a5OvzcgXLRLmlAEjBbyn5YpoZ\naw732BNEC6g3Fae9K2GQZycmiiVVlkpXGYc62Yb2LOiq2LKywmHjGdYhLBCqL7Lv\nnjmygQVk40pmR97vfjmLyzeNmruAMxz6mNjnQLiq+UlMBCapRTOodfSW5m1qbUWW\n7b1w+OpDMW0ehhbsQ838SifCdHwkYwiUs7lJb4HQaOxKXzFQYZAOErWaZhLtjiDt\najC7zCBDpqlU0rMw0y8RL+75XtYcQBkBBIcXs5BQRROGOHM/m0Fqba13eXGj4jv9\n7YaaSRlqo1afqjRrH7+cl+DiWBTypRzjNwVvj8AtPCX0go+54jNRRc9Mnw9UiU7J\nC/hwXFkVRUs0ohAyr8ZqLNONs9Dw0SnmbZlsZpH9ecHsLqsMlgqCPNNZnshoQwpq\nYn0zJdR0qNNg12maDYjI/DGBUf/iBnrkxnIMWsRHGADcEprFJsmAEYkrSzIkMmdB\nCMlYBZFhA/NU0+E9EQGl0a0rhMvZp/HQz6e6vdQfwCmx3soN4f8PleHguthNhWrb\nBlZGK95qvGPRqSiJI4HgD6NjM/l/5pxINy3he7O26kle/+N5TB6dWVPoeueO+NsK\n6m9ECLg1aQkckOZUlNbhJ77wHDjfNrk=\n-----END
+      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEA0cZDaboyLFKQ0CNBcxtKtNqh8+foG0fBVYk8VavJBMuzEBaj\nMhcF1VUl7WRssVIaab9zgAE1fxmgPuVauO7jjfobJIM7ChLHHMYV+6kme4GSjn3u\nSGrqP3iEF1EsdBKPrAicaFmUlQT0heOfjelm54jgpQOfnKom/OAxIvzLp7FGrwZ1\nMw2xsV0k1T/Uq46IaOdQrwvklau5u6aq0G8HTlQboMMC1WRaxPVrgfwMRGWEK75H\n8xn7Ts1L9QqUxinPQId5BRLlVR5dZOfjaENE2ZMvlITmwvQWG4ZjGrjpQ+dQe83B\nq4W/MyRHc7nbizrXQprIDDGcXgl3b/e+/VX51lVrqcpcs3Ic7+7VYMbpZV6YTT4x\nGGhBgVOf0EYiiLeVFeOX4UvYdvi5Mg6CSJhhoG6nSIcNvKqWRolYCv1GRdYmH5FL\nUotOLcn8C2j5CV6vCPHAjkFBRQsDI7xQ+mKdeD7ImVwhPzvyrGFccodBySW2sIpw\nmBW1374vaUdiqpQt1CAXUG/U/sW9Aja71CzJS6G/qD+HlU5AcuHoeSE0vpSG00xn\ncWOfLCKRxipMSxo09y9pNbxWVUY/ckcq/JQzvq/26MQsYjyM9w65VFOZD8ofWggg\nKhUW0BzMeFb+bUSe+bsBFLSaAXnceVcd4N/xXTTJDKJZnaEwJX5l6WZdcrsCAwEA\nAQKCAgAffQjSfooYgB5Pt/MTobWhly33TEjZi3hYbBy76WjnyOHsmNFPbAhKoRjr\n3Qa5yU7Ar+XZAZVzqjeVKV1oZCeRQMlBPlem5/Gufod/OsFVibojnICfqzjVZTRC\nwcMP+1dIphRAT64PfmpsDKJ/LVluiOvbqUMUw6/NhqOpklPJrMEk9a2zB6u0KXyl\nbAry45bTVGGWnQzncJsVMWvzlK7+kX6CL7Olr4Y2iXZlUR3QSILCBDKNqclA520u\n77MsWctL7un6Gn+FOuUfB/XpSSu1EzRxsU9oVTZaVF5c/QO61yaMJvMa2Z09QoVd\nODld2WvFijFcLzg/H2Gn04L+SSESxxAr9CvcnsQdy/DTpCtS7QdHsBsmhsv6C+lb\noFveQqOnffFIUgtuPQEtgT3TH9c2Cn3VZr9a+ypgAAYUXjB9NuuFpW0FDmEHSeGk\n4jqlBa9jvCuFoRecRV34zoA1+UtC8EFRrvlYWb22WUYs6q6OLvydG3nKkjytpobb\nSQL6u89BgLulQeShR2ldUFNheCuc9KskPCrqNVKSsUd2WatZAu5H+PDCJeA7CsCw\nZG52zoBWHmz1TBS6bDpAKAwW9rZq8lXn00L+7qpiSZnGRGn+p6yxwLJqIPqCbfGp\n5mH9bEPzyvON/tDt4YnBFiLALtS9HJ1ug1G2mxTZR2inu/R78QKCAQEA92+/21j8\nkt8HVeptWo6ePdFSCPqpUx5vTajFo1vOp1rYNmpy4wLHe8N0lbezo9jvK/om78QV\nTHg1hN8AMmOwG6SDLeDKFg2A2aCd91lIYd8b3eDcLFitsIUgeSxGVneRrKOxvg55\nSiWQJ3570arpOXCXgGnjDuKgPvA50IWMCjHX8qJB/8dN5cwt7iLRQZC2DzNq8cuw\nSJM3u/sG43ohgEK5395Ov0eMzCr9/APosVK952LTjcHwOgJESrg7vOYPrAq+WXju\nNRAi+9rNVdcIQBUBzWtgwKAhkhcPrUJZ2HDkd10SyQ4DJ3KhZ+XXL+091xUDnZmP\nleZtQKZ+GkQciwKCAQEA2QjVboSzvveh1vP93x3Kb9D+lK6GqSEEx9MrBALI1MfN\nS0+yUhjh2BTJAIf0KykFvQoCdys2zh+mSYxn7zQn9BNjqOs+HQHCyZW2O62KGMNY\nmkMiXg14HRW/YeA84CZ3lTieYakV/Rfvytb/ZETDVfHpT5aFdMPsaehqwsdRmfMa\nZ0a1vNzoFMoZ8R3jt1D25AKHaKNBEmhVyVI0FQLShdx6j8O/4bUV7+rbdeoY7AkF\nTo3+9KpET+uChtTb9kYUsW8Rzs14l5Fp6e8EKAZ3wimjmCm5iW33bt/vLI30lC4v\nhhgSJhMCC0bC7ID1aeLx4cFUX8+1plVbBURNG5zYkQKCAQBhLZ9xO2q/GB7ebFqU\nZUzaxHnukturjFl0a6NrfCQWcERYYshKRg4ommQQZPyFji6o2+8s3Zrr1I5YZ+jA\n4YwJ3zux6gYUUStYzY8c1RDrd1+Pbb+rHwzgNfjB/lSFoyIwZn3pQe/64fPSvwdM\nGk7Mw16NDYkikHkVHu3l6n1Mh7TjUzyOgy0h4mXrj/sVQAtwvuXynufWKROLnZRg\nBNhhclNkDABreWNf0Ea+Ep7x/agd1x91HkUF01wU6HR1xPlEvVdy9l6/sl27An0A\niJpx6I4zqkduf7WPlcUPa+6zZeskwgYdtoYgmRGxJ4CzDv7pmRQ5clUFL2GbMYh3\nMmbvAoIBAQCqzdnyzXsMaqSyn3kHs9FSqJ8CckvGJRc3EAiFco+NbeUyRPloxO5Q\neSMrSNOvd+xtNshz8s2B8MSUk2xkg56B5xSCpwhOGcmrjihJ1SyeinZbiUQt0tnZ\nwfjJVYlzOrLX/CQhZcnJUqJD92otBjTYmbbtDN/g4iRXwTLsMaMVzo3UA4EZrpzz\nZ459BPHmnlB/Z0Ib5odarkP9WbVlZ8A42yiVpg+H2VT3aNToeqC8eej0RqoE8U8r\nuoQSCslFiyfT8D6Ki4hBeI5rLdEOkvCDHPQD16qN7r5RQulfHiUCzUpXdPAriMAO\nEdVr/Z2mhJWp/tWhRb2GtxwYDAXHGmwRAoIBAQDQAgN5LbkkpxrDMOb9OwAVshQa\nXQoq+0h5lCguJveb399HQ4SB1KEEfhZDn8QT1SFC2DBEEZiVfpy4Kxk/OxEILVd1\nWLied3A1nOkFERh/Wb965I5xPsiao3KOJsOME0ou2QJg6119yvDNUbiWFpNkK8A+\noS7tVU8imxkKYnUJii3S9Sj1B9ks2wTb19mq9iedgnmQLqNd3wiOzw2qGPm4QxtL\n9zBi5RkdQBvQ3AVpxJqeVHvAWhSPXGPjaqso3YLvbdfoHBbcfom9tqHiGnTy7OoM\nsifHIhenqX+fER6ENC7F5zrCQJsKtUU8OaPu0jJMIlUsmAxx+ly/4faIZUph\n-----END
+      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_4YIRpjLSwOyFQYWQ","weight":128},{"virtual_machine_id":"vm_dwioBSDpMRbpwXlw","weight":128}],"standby_vms":[]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -2808,9 +3678,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"754f33d3e476a62260921e944a016d5d"
+      - W/"fb02eb11998c3ee1c7e0a0fb049561e9"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2820,482 +3690,12 @@ interactions:
       X-Ratelimit-Remaining:
       - "975"
       X-Request-Id:
-      - 4342301d-2cf7-49d5-98e9-0c4259b13ea9
+      - f80483b6-1549-4459-ae31-f4e362074e9c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x","vm_cRggrlhECop1JzP7"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128},{"virtual_machine_id":"vm_cRggrlhECop1JzP7","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"754f33d3e476a62260921e944a016d5d"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "974"
-      X-Request-Id:
-      - fcc9797e-98db-41c6-bfe1-9460c3b647ad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_EsiISUR4sV7GRkbC
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "725"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"8589c44cf4b8106b51d7d4c8430021c9"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "973"
-      X-Request-Id:
-      - 51cb4213-7277-4616-9ffd-8877ea5b1a63
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address?ip_address%5Bid%5D=ip_vqlsEGzCvZxt09fO
-    method: GET
-  response:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"},"allocation":{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "733"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"d22db1b5bf193e72ee7c661e719d7565"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "972"
-      X-Request-Id:
-      - f2088943-0044-4148-81b6-ad0dc0d232d4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"89069197a65914cac489dd06dbf2b0a0"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "970"
-      X-Request-Id:
-      - 909e5afc-a44d-41cc-9bac-ef8427e8b63e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"f6f24c7ed72c5fecca028275addf07ad"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "971"
-      X-Request-Id:
-      - e16acbc3-b876-479d-9455-23cd3e901411
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_3V58clxL17but24x
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_QKMYSf3QvHmz1I6a","name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "377"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"c8304c88d0734ac469e4b52a907dd300"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - 3a4b243e-c817-4052-881d-56a62242e904
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/network_interfaces?page=1&per_page=1&virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
-    method: GET
-  response:
-    body: '{"pagination":{"current_page":1,"total_pages":1,"total":1,"per_page":1,"large_set":false},"virtual_machine_network_interfaces":[{"id":"vmnet_jXUtrsSHIhNWmOZQ","name":"Public
-      Network on tf-bitter-howling-steel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129"}]}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "373"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"abdc42d8dda0b2466c22169ff727c269"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "969"
-      X-Request-Id:
-      - 66db4faa-8eb7-4975-b7a1-beef7c684098
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_QKMYSf3QvHmz1I6a
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_QKMYSf3QvHmz1I6a","virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey"},"name":"Public
-      Network on tf-magnificent-alive-osprey","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:a3:9d:1f:bf:01","state":"attached","ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "505"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"4aa81ae3ec8cd752f12afd12e6d28845"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "967"
-      X-Request-Id:
-      - a66e4477-aa00-4cdb-8e25-3664771eb1a6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machine_network_interfaces/_?virtual_machine_network_interface%5Bid%5D=vmnet_jXUtrsSHIhNWmOZQ
-    method: GET
-  response:
-    body: '{"virtual_machine_network_interface":{"id":"vmnet_jXUtrsSHIhNWmOZQ","virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel"},"name":"Public
-      Network on tf-bitter-howling-steel","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network"},"virtual_network":null,"mac_address":"3a:65:e4:99:4d:8b","state":"attached","ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129"}],"speed_profile":{"id":"nsp_FKZSFo5xhn9Pfr79","name":"10Gbps","permalink":"10gbps"}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "497"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"b6253e6d17d12722ca053e2932cabc69"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "966"
-      X-Request-Id:
-      - b617db55-4e73-4346-a392-ea3c0febdad2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
-    method: GET
-  response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null,"resource_type":"virtual_machines","resources":[{"type":"VirtualMachine","value":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}},{"type":"VirtualMachine","value":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]}}],"resource_ids":["vm_3V58clxL17but24x","vm_cRggrlhECop1JzP7"],"ip_address":{"id":"ip_nDnX563gTEODBoQl","address":"185.44.253.30"},"https_redirect":false,"backend_certificate":"-----BEGIN
-      CERTIFICATE-----\nMIIHAzCCBOugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBlzELMAkGA1UEBhMCR0Ix\nDzANBgNVBAgMBkxvbmRvbjE3MDUGA1UEAwwubGJfNE9CeG40dUhOcXhiMGpnWi5s\nYi1iYWNrZW5kcy5rYXRhcHVsdC5jbG91ZDERMA8GA1UECgwIS2F0YXB1bHQxKzAp\nBgNVBAsMIkxvYWQgQmFsYW5jZXIgQmFja2VuZCBDZXJ0aWZpY2F0ZXMwIBcNMjQx\nMjEyMTU0ODI5WhgPMjA3NDEyMTIxNTQ4MjlaMIGXMQswCQYDVQQGEwJHQjEPMA0G\nA1UECAwGTG9uZG9uMTcwNQYDVQQDDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJh\nY2tlbmRzLmthdGFwdWx0LmNsb3VkMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UE\nCwwiTG9hZCBCYWxhbmNlciBCYWNrZW5kIENlcnRpZmljYXRlczCCAiIwDQYJKoZI\nhvcNAQEBBQADggIPADCCAgoCggIBAPd22uzGcil1UDUdaeTHvNKKGDUS+2wxC3K2\nA/8YVudzyo53kMJ9Yq8DWI11pMKxTE5uHclpR2T8GYyOJnz3MZg0P0FxLje6SnCV\nMiv9afhtMaBmllGXUdezkuhN9d1EYF4W9FZ0W+gZjmI7cjvzUI+8x3wdXgKIBfkn\nliuuKVft7uZ2bP5CQ1FxB4eBqKh1kAUGQa1zDKRYR0YD4XvaIASkzQSQMhnemRfG\n//QhwfYA1CYdzd0Chtvuppvk80zBJEKfxqpRlJP3hBpIn+jEHNLY8xIrMlPedvWs\nIYdgdNUD+f412xKewND0BnjIC9k6SwyWl/8T34AhtVCej+N/qOl1fzfHwVy55yRu\n3TOIw+kChs80AYBPoOqkFLDRcIR+3HvAqMwYh9EITQLZTa6nmziYRjyWC5G3n9RH\n2EKzwdji5rQNm1gESo47jAZdXN1VTX/Her9fzoSe6sPFmbz3Ny/UYYaTUadiu1Nb\nZ/xMzIMGvjuiu6s4xpor0AooYu73R/LdvQwUqBs6DFJ1sz130h4kQlhkP36dX6lF\ncdi7rG3Jw4/NSrG8NK7kSqUcwy/A9vX8yFEH1trUuVrW+U87klXiFlGTKVbB3zdF\nzndcwv5ofW9sTKWTI8F+fMjZsCGqLsqAzhOpF1xEDXzUt9gJJvZ0m8Ny42r41wQU\nMr8NaKFpAgMBAAGjggFUMIIBUDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTE\nAzOqpXEPvZT91ZhLdbvJGr2RazATBgNVHSUEDDAKBggrBgEFBQcDATBCBgNVHREE\nOzA5gi5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNs\nb3VkggdiYWNrZW5kMIHEBgNVHSMEgbwwgbmAFMQDM6qlcQ+9lP3VmEt1u8kavZFr\noYGdpIGaMIGXMQswCQYDVQQGEwJHQjEPMA0GA1UECAwGTG9uZG9uMTcwNQYDVQQD\nDC5sYl80T0J4bjR1SE5xeGIwamdaLmxiLWJhY2tlbmRzLmthdGFwdWx0LmNsb3Vk\nMREwDwYDVQQKDAhLYXRhcHVsdDErMCkGA1UECwwiTG9hZCBCYWxhbmNlciBCYWNr\nZW5kIENlcnRpZmljYXRlc4IBATANBgkqhkiG9w0BAQsFAAOCAgEAR8j59IBD/8Fz\nsJyWnAVs6axm0OoYKc6v33xyeZAK0fcqunZBlkWJ0oR89nhfe8lGFdEg7INbmuN/\nproJrSkTTG81V4eK60KKZIy/sBbNfgXoQbuOTa0YiipJBoq0GHzk5Fw7fGGDFf0i\nuheRtHdfnb7vnzVnjH1+mCN0u26mB/lws7PLe2w4cnVitFdQjXWSs+r4E/R6FKpp\n3GZ2QVO4S05UFRb8qc01kktMTkwjRmXI9d3hk2sEltRzOxmThOXERhK5cDPKCaXl\njz2e99uohacRGE7sy9xeIQJmo4JcFqaJV1YMvgnuxJOl2Aa7egvdb4KR7bHRxPA+\nXniGPqt7E1DiK6QtVN2aoAqXL551OeCLXFC3k99psxyMwdG0dnokb3vwQ8KDwTX8\nrli0PH/CSvpgeOzuw4dMovnHoDDaeJjAUZCypG7aG7l3ymvf4buPTVBgznUxmudV\nALL5ZIPtG2gKkB/9kCpMdCNzdOgiuVJvhWXwG+yETq7sllUk30peiOP5lqNh7SQ3\nFwQa9So01kl/iXyMDyZO5Om7se/CKxETiXVBXGfL3a9K5q/sj705hws7ALGKkRrp\n0j4rwBgXR6YSHUanz4ECVlrYWr72wQEnJvOtZ+D2ZOWHoQtqhw7OV52VdgplOrgj\nb05JeHHcn3gJA8uQULrUky7JaP1R6DY=\n-----END
-      CERTIFICATE-----\n","backend_certificate_key":"-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEA93ba7MZyKXVQNR1p5Me80ooYNRL7bDELcrYD/xhW53PKjneQ\nwn1irwNYjXWkwrFMTm4dyWlHZPwZjI4mfPcxmDQ/QXEuN7pKcJUyK/1p+G0xoGaW\nUZdR17OS6E313URgXhb0VnRb6BmOYjtyO/NQj7zHfB1eAogF+SeWK64pV+3u5nZs\n/kJDUXEHh4GoqHWQBQZBrXMMpFhHRgPhe9ogBKTNBJAyGd6ZF8b/9CHB9gDUJh3N\n3QKG2+6mm+TzTMEkQp/GqlGUk/eEGkif6MQc0tjzEisyU9529awhh2B01QP5/jXb\nEp7A0PQGeMgL2TpLDJaX/xPfgCG1UJ6P43+o6XV/N8fBXLnnJG7dM4jD6QKGzzQB\ngE+g6qQUsNFwhH7ce8CozBiH0QhNAtlNrqebOJhGPJYLkbef1EfYQrPB2OLmtA2b\nWARKjjuMBl1c3VVNf8d6v1/OhJ7qw8WZvPc3L9RhhpNRp2K7U1tn/EzMgwa+O6K7\nqzjGmivQCihi7vdH8t29DBSoGzoMUnWzPXfSHiRCWGQ/fp1fqUVx2LusbcnDj81K\nsbw0ruRKpRzDL8D29fzIUQfW2tS5Wtb5TzuSVeIWUZMpVsHfN0XOd1zC/mh9b2xM\npZMjwX58yNmwIaouyoDOE6kXXEQNfNS32Akm9nSbw3LjavjXBBQyvw1ooWkCAwEA\nAQKCAgAyB0oOpLbnOUOQHWRvX08F7Guk7TO9pXOoSvJnY8ML8z2PzE3Md/9XnPBN\n1usKfkAMOhhVA+7uVEYRA5r12B6jY+qm3wwGMagDdzInsQl3sxGdmSfKEnK2DiSE\nyOAMDdsCopbelJMRCvudUeHQC2ptyK82oRREpD26530lUwYiM+TAnFAAHiLQZ+6q\n/zQ67FuDnIZyG6iCYCN2nOm8uXYQIkYdZk5uqvEd3LoZn6qAAp5hH1TjWbOsamSt\n7x0d1w0u1/DYtXn5aQiArM6BRwaBvOD1OxznVjoMBDLaFM7B0tY7RaWGr+gQxki5\nqc21aqLKBnbvl1OvqoDmrcuupTwfIr4GwQo7X7THFxso/tHB4FpKI6zZvvmzJIcw\nE6OQwvrPTmdXb5bSR97IMk5rCEx+/5r7kyg9AtPiFrWzxlMywo032la4kd+X3USn\nnVPfd5qy7fWln70x2RVDAMLpFJ4O5Gns0lKICIjNk90okN1GiHf2DaRuHXs8h1rx\nVs1H10elk/hIDc7kXQG8qQdw5tc8jpJ0v5Yyk0MWshyNKu16Y8uxVVF9t/37JsKK\nXwH+D6kdkGpzjGLL8lgEfYQtAzW1qhZE2PtlhkgkLkRKIEIDZXnOhC/TSZi19uLw\nPv/Y6pD26mbB/29lH+4Eg0q37R8yVWaRtcoHRriUe+OAzPC6ZQKCAQEA/vEg7iPf\nnZhZpK1wkQ0uYIcMHytXQ2NxK54FxjFuIIGkfaHAgk1+TbW7PeSwPd2vqq+plOJa\nsdUkDC9/QEqDzHa1dF3KuyFIKNysDE0iyYKCQWvX1NDD9gAguRtMh+egwYFFm9sy\neiBdZgorDqlHB9D8pViCWbjlFoY8KnnD1NlOLYbjRn1UUNU2Rz82nrWjm6+U/E1/\nRkxgeGSejPuKxWBO5ekgjwH2WFyqgkRR6y6+qRhaoA5snjgKJdAWMZloTIuxnCq1\n72M5CFT5qdUyd1vl0kHFD6WseFB9W6jj/3Uex9VCwLNLLOpkNNyGLr8tPM9+ZsJe\nevpjnqRgkDbYRQKCAQEA+H3IHLwXYxcna8U1lJU+zUHqVZvBukNu2Usel4jojjum\nXlw5UXJdJjjaQNxkTrVjyh5TeLprkmsPtc0vep2hp8HtA720sNz/AolPcs1uAz4B\n/5nP/KpHz5AeAf1EGukG/ZFJIVOLfWCGRmNZfsDB+T8I9sKg9o+6jKn/4sLk3BnV\nMsqUaC/7HaItywLpxKHawVJBhhQqPESW9+6GOBaWBiFB3CxKjPo9h4Z9EsbWzwLe\nOnoUVBPgO7aLltYtTF4b/owg3tojhrcg3KEUJwWC4GYxaX/Y3lgICbczsZ2mC5GV\nSGZFfLyH2wJz+hwDxZVwh188AK5eFnupNTDCwE7w1QKCAQBf2cjHwDUSy3TotUzd\nPFdzc1LbZTAp5flmrML/ARamohd2JJp8YyZZkToUyyZ4HCEvy1u23mO6+KfU7Qaq\n5VkoRnlyhtDyClFXC6Cj/1xU5vySHDnJibQjiWjEL79WWX/XQQMq1f7ka8ax1qDZ\noktSZQCYKe7YTOvUzCNS1PUL0afS9iP9HKHWwlLl9p5SjXg10I3zTi/L/mtG2I3D\n88745nzDdCMJoXM9RZnV4FnsUmbcrItmIgY0dl1aWiH+A+9y2BKu5GAC4QtQVqKH\nd+DBf4uowZGVkHSHx7tZ+uW95grslwHB8acR/A4w0bihWr9nXZvohqt/ESTjQGoN\nzpEBAoIBAErhdH0cPRvyLUHvoq7Mrqkh1ODJV/6uNWgrl+NoMVQzK3ZB6k/d264Z\n8cMb5upFBPYyX0sBOktcEdbiJw2XFNC9wpOfBiVJ41q7UAKzXxSBCg8hJajpE0y8\nDB7jWDOXxzCAKH5vc5hrjusFI0HsCkf2s9fQXLsQItIipGaL/nVJH5L3svMWimCq\nr4v+q71CXO5mwDIMP5H7xVafPTkHrVvZh8Q2YJzNB9+gKm6PFso4/gi3IwsXFjpI\nTxY8Ilhh/6OcTId7Srtc0f1KWQ1NPtwqT3eQPCT8eCedWmmKrS/NRiQUFZp6IaJg\nwdw7tvNCji9tBmLaKKYzy5CoyfczkqUCggEBALtyF/hSu2rdldMecX5yRQbTXIOK\nWanlwI0RRfOjOeab4ExfzUvwdPz8RgHf9iXC75S4xUo5IgKau0r/1j/dsIUY4qUb\npuHBcbEopmj//5SAScWhAv/AkWzo4oPr20/yj2mt/wbZrwZv1ppMcA2vlkpKtafB\ndxYtve7LUbsccKguaek/aJlo2rIOydVTF4Y3qXnHKXPICGa2BJBsqNQaSXpc3fs3\nkngrIHoVk3grgMkZHgMKz5wI3nwt/w3gs7SfyxHK9WMG8bTVFyEk0wzKnSjZH12f\n1pxbIfZakPvn7l8rX9ZURKxu59LHMpWyeIZ93YznNlTtfNIR5+sSvEQQEqE=\n-----END
-      RSA PRIVATE KEY-----\n","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01"},"enable_weighting":false,"weights":[{"virtual_machine_id":"vm_3V58clxL17but24x","weight":128},{"virtual_machine_id":"vm_cRggrlhECop1JzP7","weight":128}],"standby_vms":[]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:02 GMT
-      Etag:
-      - W/"754f33d3e476a62260921e944a016d5d"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "965"
-      X-Request-Id:
-      - cb4b0acd-2a00-4080-9ac6-0f941029238e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ"}}'
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO"}}'
     form: {}
     headers:
       Content-Type:
@@ -3305,7 +3705,7 @@ interactions:
     url: https://api.katapult.io/core/v1/load_balancers/load_balancer
     method: DELETE
   response:
-    body: '{"load_balancer":{"id":"lb_4OBxn4uHNqxb0jgZ","name":"tf-acc-test-vms-update-oa8iPZZyidim","api_reference":null}}'
+    body: '{"load_balancer":{"id":"lb_tuVWgQC14K7wcEkO","name":"tf-acc-test-vms-update-e86wUNCgQvF4","api_reference":null}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3320,9 +3720,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"1106dc5912f1d33e7a3a3df055ac9dc5"
+      - W/"b5d832316765058ae5519c36b1cd9631"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3330,9 +3730,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "964"
+      - "973"
       X-Request-Id:
-      - 6e9b1888-317d-4810-8f5c-c2b8efd57e7a
+      - 228ee67f-b40b-48c3-a7bb-7ab66b467666
     status: 200 OK
     code: 200
     duration: ""
@@ -3343,19 +3743,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3368,9 +3768,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"f6f24c7ed72c5fecca028275addf07ad"
+      - W/"7647a56d819d6e18e0c3db3c48bb53cd"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3378,9 +3778,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "962"
+      - "972"
       X-Request-Id:
-      - 0e1bcbea-fd4f-4c78-9096-f7518a1b1854
+      - cf5bbc74-2256-4afa-9bae-d81c2c5bc456
     status: 200 OK
     code: 200
     duration: ""
@@ -3391,19 +3791,19 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"started","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"started","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3416,9 +3816,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"89069197a65914cac489dd06dbf2b0a0"
+      - W/"b47c4c9efdea7a506dbd2c27237b6810"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3426,9 +3826,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "963"
+      - "971"
       X-Request-Id:
-      - b4392511-dd2d-4bc1-ba67-5f6dacbd6e4a
+      - f341eae0-98f1-4548-8f0b-ed046fa10b6b
     status: 200 OK
     code: 200
     duration: ""
@@ -3439,11 +3839,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
     method: POST
   response:
-    body: '{"task":{"id":"task_9g7bVmRzO3mEDEaO","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_OyeJu0cEslimQiIr","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3458,9 +3858,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"3f6cb9ad6290492cd4c8b70e3176469d"
+      - W/"e77e3b6e6501323f17bdf19356b2485f"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3468,9 +3868,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "961"
+      - "970"
       X-Request-Id:
-      - f8bb8293-e417-4a3a-a654-e55e49f4df5c
+      - 8520a038-3494-42f7-804c-3cf98394d1b8
     status: 200 OK
     code: 200
     duration: ""
@@ -3481,11 +3881,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_/stop?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
     method: POST
   response:
-    body: '{"task":{"id":"task_k7tBCWlXPiJL337A","name":"Stop virtual machine","status":"pending"}}'
+    body: '{"task":{"id":"task_qUxGsrgEhDNFY5vS","name":"Stop virtual machine","status":"pending"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3500,9 +3900,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:03 GMT
+      - Thu, 06 Feb 2025 17:39:01 GMT
       Etag:
-      - W/"6f7a2ad84b58e047dcc22245a5c85647"
+      - W/"ba1af0f620707bc12a04c96b3debd064"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3510,9 +3910,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "960"
+      - "969"
       X-Request-Id:
-      - 2f8d2662-4b7c-4e45-a227-c4c1d3036519
+      - 9e412fc1-e415-473d-93f4-fecf96ae2138
     status: 200 OK
     code: 200
     duration: ""
@@ -3523,11 +3923,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_9g7bVmRzO3mEDEaO
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_OyeJu0cEslimQiIr
     method: GET
   response:
-    body: '{"task":{"id":"task_9g7bVmRzO3mEDEaO","name":"Stop virtual machine","status":"pending","created_at":1734018543,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_OyeJu0cEslimQiIr","name":"Stop virtual machine","status":"pending","created_at":1738863541,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3542,9 +3942,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:04 GMT
+      - Thu, 06 Feb 2025 17:39:02 GMT
       Etag:
-      - W/"ab645fac5f4bb24dc2ab931b02648f0f"
+      - W/"9b08afa3d739b6b38d0df5cc7ecce3df"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3552,9 +3952,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "954"
+      - "968"
       X-Request-Id:
-      - 99082b78-e94c-4f18-8932-c75add55651e
+      - 0274a315-a3cb-4ed5-8fc2-4057f09d4041
     status: 200 OK
     code: 200
     duration: ""
@@ -3565,11 +3965,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_k7tBCWlXPiJL337A
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_qUxGsrgEhDNFY5vS
     method: GET
   response:
-    body: '{"task":{"id":"task_k7tBCWlXPiJL337A","name":"Stop virtual machine","status":"running","created_at":1734018543,"started_at":1734018543,"finished_at":null,"progress":5}}'
+    body: '{"task":{"id":"task_qUxGsrgEhDNFY5vS","name":"Stop virtual machine","status":"running","created_at":1738863541,"started_at":1738863542,"finished_at":null,"progress":5}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3584,9 +3984,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:04 GMT
+      - Thu, 06 Feb 2025 17:39:02 GMT
       Etag:
-      - W/"5cfd43b9df007129e25f4ceba0ac7622"
+      - W/"b4d8a931f7369332521b4da25fcc5126"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3594,9 +3994,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "953"
+      - "967"
       X-Request-Id:
-      - aa37d2a7-8fa3-4b48-8863-aab7e58920a2
+      - 1189d650-d8f3-43b1-9ede-0b9ba2490a78
     status: 200 OK
     code: 200
     duration: ""
@@ -3607,53 +4007,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_k7tBCWlXPiJL337A
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_OyeJu0cEslimQiIr
     method: GET
   response:
-    body: '{"task":{"id":"task_k7tBCWlXPiJL337A","name":"Stop virtual machine","status":"completed","created_at":1734018543,"started_at":1734018543,"finished_at":1734018545,"progress":100}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "178"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:09 GMT
-      Etag:
-      - W/"b054db633835d220c6301823e92e7c9f"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "946"
-      X-Request-Id:
-      - 792b70ee-5ee5-4b08-b800-724cc0fb7799
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_9g7bVmRzO3mEDEaO
-    method: GET
-  response:
-    body: '{"task":{"id":"task_9g7bVmRzO3mEDEaO","name":"Stop virtual machine","status":"pending","created_at":1734018543,"started_at":null,"finished_at":null,"progress":0}}'
+    body: '{"task":{"id":"task_OyeJu0cEslimQiIr","name":"Stop virtual machine","status":"pending","created_at":1738863541,"started_at":null,"finished_at":null,"progress":0}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3668,9 +4026,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:09 GMT
+      - Thu, 06 Feb 2025 17:39:07 GMT
       Etag:
-      - W/"ab645fac5f4bb24dc2ab931b02648f0f"
+      - W/"9b08afa3d739b6b38d0df5cc7ecce3df"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3678,9 +4036,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "946"
+      - "966"
       X-Request-Id:
-      - 97bf4572-950d-4464-a7d7-b78df74851a8
+      - 588f8f73-19f5-4fde-82b7-32d3a980e799
     status: 200 OK
     code: 200
     duration: ""
@@ -3691,19 +4049,61 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_qUxGsrgEhDNFY5vS
     method: GET
   response:
-    body: '{"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+    body: '{"task":{"id":"task_qUxGsrgEhDNFY5vS","name":"Stop virtual machine","status":"completed","created_at":1738863541,"started_at":1738863542,"finished_at":1738863543,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:07 GMT
+      Etag:
+      - W/"22f7161ae043add1817eb98e07dddd21"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "965"
+      X-Request-Id:
+      - 5ead576e-abc8-4d56-9344-6b8c552a8449
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
       Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
       Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
       Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
       Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
       Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]},"annotations":[]}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3716,9 +4116,615 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:10 GMT
+      - Thu, 06 Feb 2025 17:39:08 GMT
       Etag:
-      - W/"bfedbbbcbbfe4e6e363884c9707377c7"
+      - W/"be01bdff200ba0efeed4ad4254d3b791"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "964"
+      X-Request-Id:
+      - 9980de5c-a118-435a-93e0-5f15facd31f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_4YIRpjLSwOyFQYWQ
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_BXakxyiY66oxF6f2","keep_until":1739036348,"object_id":"vm_4YIRpjLSwOyFQYWQ","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_4YIRpjLSwOyFQYWQ","name":"tf-careful-resonant-swan","hostname":"tf-careful-resonant-swan","fqdn":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863474,"initial_root_password":"zWx4lB3i9vgnBFpI","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_2SfId867ZYhs8OSr","address":"185.44.253.145","reverse_dns":"tf-careful-resonant-swan.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.145/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_4YIRpjLSwOyFQYWQ","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:08 GMT
+      Etag:
+      - W/"cf4943c796d88ddf7345d54904b576e1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "963"
+      X-Request-Id:
+      - f3dbc3cc-defc-4dfc-97e5-2e735ea816b2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_2SfId867ZYhs8OSr
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:09 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "962"
+      X-Request-Id:
+      - 03edebcf-ccee-476c-931b-49cb6ea2a352
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4YIRpjLSwOyFQYWQ
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_z5X47U8Br5Ci6tsU","name":"Purge items from trash","status":"pending","created_at":1738863549,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:09 GMT
+      Etag:
+      - W/"b4f4830b888103bd6cc07c2b199650c1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "961"
+      X-Request-Id:
+      - f36580c0-0e29-484a-ac59-c5855c12437f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_BXakxyiY66oxF6f2","keep_until":1739036348,"object_id":"vm_4YIRpjLSwOyFQYWQ","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:10 GMT
+      Etag:
+      - W/"6533bba68c54f63de9094b64623a920c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "960"
+      X-Request-Id:
+      - 893d6b66-de48-47ce-90b4-d6193c5d49c9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_BXakxyiY66oxF6f2","keep_until":1739036348,"object_id":"vm_4YIRpjLSwOyFQYWQ","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:15 GMT
+      Etag:
+      - W/"6533bba68c54f63de9094b64623a920c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "958"
+      X-Request-Id:
+      - 4c97d5f4-f92b-4891-b3de-dbaf345cfee3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_OyeJu0cEslimQiIr
+    method: GET
+  response:
+    body: '{"task":{"id":"task_OyeJu0cEslimQiIr","name":"Stop virtual machine","status":"running","created_at":1738863541,"started_at":1738863557,"finished_at":null,"progress":5}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "168"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:17 GMT
+      Etag:
+      - W/"fb2a1243f3a99aa1fef49c1fa091fc11"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "957"
+      X-Request-Id:
+      - 089ed508-eef1-4399-a723-1c355974cecc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_BXakxyiY66oxF6f2","keep_until":1739036348,"object_id":"vm_4YIRpjLSwOyFQYWQ","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:25 GMT
+      Etag:
+      - W/"6533bba68c54f63de9094b64623a920c"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "951"
+      X-Request-Id:
+      - 9c5edc97-cf81-4a10-9573-b15721eff2d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/tasks/task_OyeJu0cEslimQiIr
+    method: GET
+  response:
+    body: '{"task":{"id":"task_OyeJu0cEslimQiIr","name":"Stop virtual machine","status":"completed","created_at":1738863541,"started_at":1738863557,"finished_at":1738863559,"progress":100}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "178"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:27 GMT
+      Etag:
+      - W/"54ea373cb900cfc67b472a0f0882106f"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "950"
+      X-Request-Id:
+      - be9a3c49-fb27-4ea5-86dc-3b1e4b53d6a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
+    method: GET
+  response:
+    body: '{"virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]},"annotations":[]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:28 GMT
+      Etag:
+      - W/"13d152e472f37bf89f54c084393e3850"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "949"
+      X-Request-Id:
+      - 9bece87e-27ed-46be-87bc-e22de57b5196
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_dwioBSDpMRbpwXlw
+    method: DELETE
+  response:
+    body: '{"trash_object":{"id":"trsh_SfOBEFjE96whSelX","keep_until":1739036368,"object_id":"vm_dwioBSDpMRbpwXlw","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_dwioBSDpMRbpwXlw","name":"tf-odd-hissing-zinc","hostname":"tf-odd-hissing-zinc","fqdn":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","description":null,"created_at":1738863515,"initial_root_password":"20KuXwlefMxkWLUP","state":"stopped","zone":{"id":"zone_SIfjBnlL8Qox99oX","name":"LON-4","permalink":"lon-zone-4","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
+      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
+      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
+      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
+      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_VY1yFEi3yDSPQG6i","address":"185.44.252.231","reverse_dns":"tf-odd-hissing-zinc.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.252.231/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
+      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
+      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_dwioBSDpMRbpwXlw","allocation_type":"VirtualMachine"}]}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:29 GMT
+      Etag:
+      - W/"4fbe66ea08a5cf691e33943f82a915c4"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "948"
+      X-Request-Id:
+      - a0248244-2307-4cf0-b7d5-99c6d999110b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_VY1yFEi3yDSPQG6i
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:29 GMT
+      Etag:
+      - W/"44136fa355b3678a1146ad16f7e8649e"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "947"
+      X-Request-Id:
+      - adf9d80c-a47c-4b98-82cf-458de3cfa462
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_dwioBSDpMRbpwXlw
+    method: DELETE
+  response:
+    body: '{"task":{"id":"task_d5KfBo2qFqvy1ZOy","name":"Purge items from trash","status":"pending","created_at":1738863569,"started_at":null,"finished_at":null,"progress":0}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "164"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:29 GMT
+      Etag:
+      - W/"78772f68c89f6eac64ee305718fdf97b"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "946"
+      X-Request-Id:
+      - a7eb638a-c790-4b2c-84a9-1181c915bb2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_dwioBSDpMRbpwXlw
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_SfOBEFjE96whSelX","keep_until":1739036368,"object_id":"vm_dwioBSDpMRbpwXlw","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:30 GMT
+      Etag:
+      - W/"6e8611f9e146b4de1a44a4c5c4484543"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "945"
+      X-Request-Id:
+      - 2de9039c-79e5-4766-ad63-0018c53e5b41
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"trash_object":{"id":"trsh_BXakxyiY66oxF6f2","keep_until":1739036348,"object_id":"vm_4YIRpjLSwOyFQYWQ","object_type":"VirtualMachine"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:35 GMT
+      Etag:
+      - W/"6533bba68c54f63de9094b64623a920c"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3728,7 +4734,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "944"
       X-Request-Id:
-      - 0a62df80-7418-49a2-9ce2-188e87df6a6f
+      - 87660110-eaea-4e7f-9759-deedd761c8d3
     status: 200 OK
     code: 200
     duration: ""
@@ -3739,19 +4745,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_3V58clxL17but24x
-    method: DELETE
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_dwioBSDpMRbpwXlw
+    method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_W8HbjMHBMqywN2Vc","keep_until":1734191350,"object_id":"vm_3V58clxL17but24x","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_3V58clxL17but24x","name":"tf-magnificent-alive-osprey","hostname":"tf-magnificent-alive-osprey","fqdn":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018476,"initial_root_password":"Ft5BxQ8dG2BmsDGe","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_vqlsEGzCvZxt09fO","address":"185.44.253.140","reverse_dns":"tf-magnificent-alive-osprey.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.253.140/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_3V58clxL17but24x","allocation_type":"VirtualMachine"}]}}'
+    body: '{"trash_object":{"id":"trsh_SfOBEFjE96whSelX","keep_until":1739036368,"object_id":"vm_dwioBSDpMRbpwXlw","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3761,12 +4759,14 @@ interactions:
       - '*'
       Cache-Control:
       - max-age=0, private, must-revalidate
+      Content-Length:
+      - "136"
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:10 GMT
+      - Thu, 06 Feb 2025 17:39:36 GMT
       Etag:
-      - W/"977681c5fe76c5864c0d172896c3b074"
+      - W/"6e8611f9e146b4de1a44a4c5c4484543"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3776,7 +4776,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "943"
       X-Request-Id:
-      - e7705a53-262e-4b4f-b2f5-135de3a52c76
+      - f1577bea-7764-4aec-8580-83a54777df72
     status: 200 OK
     code: 200
     duration: ""
@@ -3787,9 +4787,52 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_vqlsEGzCvZxt09fO
-    method: POST
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_4YIRpjLSwOyFQYWQ
+    method: GET
+  response:
+    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
+      was found matching any of the criteria provided in the arguments","detail":{}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "152"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 06 Feb 2025 17:39:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Api-Schema:
+      - json-error
+      X-Ratelimit-Permitted:
+      - "1000"
+      X-Ratelimit-Remaining:
+      - "942"
+      X-Request-Id:
+      - 0474fd72-c182-4888-b563-caa3a72169f6
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"ip_address":{"id":"ip_2SfId867ZYhs8OSr"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
+    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
+    method: DELETE
   response:
     body: '{}'
     headers:
@@ -3806,51 +4849,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:11 GMT
+      - Thu, 06 Feb 2025 17:39:45 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "942"
-      X-Request-Id:
-      - 950b1392-61fd-486b-97ae-0f4e93fbfadb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_3V58clxL17but24x
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_NdZPIQt63j7efLYh","name":"Purge items from trash","status":"pending","created_at":1734018551,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:11 GMT
-      Etag:
-      - W/"808c2d64e0083ab9f10a0820dfecff17"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3860,7 +4861,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "941"
       X-Request-Id:
-      - 9ccd40bd-7c28-4acb-bc57-f42d8015f54c
+      - 8f747aaf-f052-4856-9fe3-de4727517565
     status: 200 OK
     code: 200
     duration: ""
@@ -3871,11 +4872,11 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
-    body: '{"trash_object":{"id":"trsh_W8HbjMHBMqywN2Vc","keep_until":1734191350,"object_id":"vm_3V58clxL17but24x","object_type":"VirtualMachine"}}'
+    body: '{"trash_object":{"id":"trsh_SfOBEFjE96whSelX","keep_until":1739036368,"object_id":"vm_dwioBSDpMRbpwXlw","object_type":"VirtualMachine"}}'
     headers:
       Access-Control-Allow-Headers:
       - Authorization, Content-Type
@@ -3890,9 +4891,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:12 GMT
+      - Thu, 06 Feb 2025 17:39:46 GMT
       Etag:
-      - W/"35926228fa331604d8bbbc2526b8ef62"
+      - W/"6e8611f9e146b4de1a44a4c5c4484543"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3902,7 +4903,7 @@ interactions:
       X-Ratelimit-Remaining:
       - "940"
       X-Request-Id:
-      - f9c5827f-dc36-40e8-af4c-1ba0d1b04b5c
+      - 865cc027-e199-4c58-b581-bcd2714420cd
     status: 200 OK
     code: 200
     duration: ""
@@ -3913,8 +4914,8 @@ interactions:
       Accept:
       - application/json
       User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_3V58clxL17but24x
+      - Terraform/1.10.5 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
+    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_dwioBSDpMRbpwXlw
     method: GET
   response:
     body: '{"error":{"code":"trash_object_not_found","description":"No trash object
@@ -3933,7 +4934,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:17 GMT
+      - Thu, 06 Feb 2025 17:39:56 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -3943,14 +4944,14 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "935"
+      - "939"
       X-Request-Id:
-      - 94a93e16-6cae-467d-902e-5605e6f93a3a
+      - 366946a4-02ea-4851-84e6-c54a38e80102
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"ip_address":{"id":"ip_vqlsEGzCvZxt09fO"}}'
+    body: '{"ip_address":{"id":"ip_VY1yFEi3yDSPQG6i"}}'
     form: {}
     headers:
       Content-Type:
@@ -3975,7 +4976,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:17 GMT
+      - Thu, 06 Feb 2025 17:39:56 GMT
       Etag:
       - W/"44136fa355b3678a1146ad16f7e8649e"
       Strict-Transport-Security:
@@ -3985,400 +4986,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "934"
+      - "938"
       X-Request-Id:
-      - e2b3c53b-a165-41e6-b4cd-7e624eaaf42d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_9g7bVmRzO3mEDEaO
-    method: GET
-  response:
-    body: '{"task":{"id":"task_9g7bVmRzO3mEDEaO","name":"Stop virtual machine","status":"pending","created_at":1734018543,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "162"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:19 GMT
-      Etag:
-      - W/"ab645fac5f4bb24dc2ab931b02648f0f"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "933"
-      X-Request-Id:
-      - e9620da3-4907-44e0-8884-d968116f910f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/tasks/task_9g7bVmRzO3mEDEaO
-    method: GET
-  response:
-    body: '{"task":{"id":"task_9g7bVmRzO3mEDEaO","name":"Stop virtual machine","status":"completed","created_at":1734018543,"started_at":1734018560,"finished_at":1734018561,"progress":100}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "178"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:29 GMT
-      Etag:
-      - W/"a485c49db2af92c7829713856b556666"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "932"
-      X-Request-Id:
-      - 84b8353d-5320-4c13-96a0-08bba166cbd7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
-    method: GET
-  response:
-    body: '{"virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]},"annotations":[]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:30 GMT
-      Etag:
-      - W/"35e7686970021ad4b6bf2c0a0c72b54c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "931"
-      X-Request-Id:
-      - 46c8b412-0a32-4de0-bc9b-40fb6cd94546
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/virtual_machines/_?virtual_machine%5Bid%5D=vm_cRggrlhECop1JzP7
-    method: DELETE
-  response:
-    body: '{"trash_object":{"id":"trsh_bDZLurvu5GsGzr1O","keep_until":1734191370,"object_id":"vm_cRggrlhECop1JzP7","object_type":"VirtualMachine"},"virtual_machine":{"id":"vm_cRggrlhECop1JzP7","name":"tf-bitter-howling-steel","hostname":"tf-bitter-howling-steel","fqdn":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","description":null,"created_at":1734018515,"initial_root_password":"Dred5fLFzzjd3uWJ","state":"stopped","zone":{"id":"zone_7Uuz6wzE17ZShh8f","name":"LON-1","permalink":"lon-zone-1","data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"organization":{"id":"org_eodfyqFF3YWb2OFC","name":"terraform-acc-test","sub_domain":"terraform-acc-test","infrastructure_domain":"terraform-acc-test.katapult.cloud","created_at":1605785692,"activated_at":1605785692,"suspended":false,"managed":false,"billing_name":"terraform-acc-test","address1":"42
-      Barren Fields","address2":"Oxygen Farm","address3":"Seed Colony 1","address4":"Landing
-      Site","postcode":"ZZ9 1LS","vat_number":null,"phone_number":null,"currency":{"id":"cur_zShCGgjgBz4EbnX1","name":"British
-      Pound","iso_code":"GBP","symbol":"£"},"country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false},"country_state":null},"group":null,"package":{"id":"vmpkg_Eh5LYVKScVHpj7sM","name":"ROCK-3","permalink":"rock-3","cpu_cores":1,"ipv4_addresses":1,"memory_in_gb":3,"storage_in_gb":25,"monthly_bandwidth_allowance_in_gb":2048,"privacy":"public","icon":null,"use_dedicated_cpus":false,"group":{"id":"vmpkgrp_P5kCZvAtvXRC3sVl","name":"Standard
-      vCPU"}},"attached_iso":null,"memory_in_gb":3,"cpu_cores":1,"use_dedicated_cpus":false,"gpu_type":null,"gpus":[],"tags":[],"tag_names":[],"ip_addresses":[{"id":"ip_EsiISUR4sV7GRkbC","address":"185.44.255.129","reverse_dns":"tf-bitter-howling-steel.terraform-acc-test.katapult.cloud","vip":false,"label":null,"address_with_mask":"185.44.255.129/22","network":{"id":"netw_gVRkZdSKczfNg34P","name":"Public
-      Network","permalink":"uk-lon-01-public","default":true,"data_center":{"id":"loc_UUhPmoCbpic6UX0Y","name":"London","permalink":"uk-lon-01","country":{"id":"ctry_6AO9tYYugvTGnd5b","name":"United
-      Kingdom","iso_code2":"GB","iso_code3":"GBR","time_zone":"Europe/London","eu":false}}},"allocation_id":"vm_cRggrlhECop1JzP7","allocation_type":"VirtualMachine"}]}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:30 GMT
-      Etag:
-      - W/"a42fcf974cb0462247355c398235455c"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "930"
-      X-Request-Id:
-      - 059103df-c9c6-4046-9e61-293511b0a977
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/ip_addresses/_/unallocate?ip_address%5Bid%5D=ip_EsiISUR4sV7GRkbC
-    method: POST
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:31 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "929"
-      X-Request-Id:
-      - ad6e6aa5-e46b-4114-b4aa-228eaa1c86bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_cRggrlhECop1JzP7
-    method: DELETE
-  response:
-    body: '{"task":{"id":"task_mQVqqDBX0GwMIxB2","name":"Purge items from trash","status":"pending","created_at":1734018571,"started_at":null,"finished_at":null,"progress":0}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "164"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:31 GMT
-      Etag:
-      - W/"8ed6a8f54694541e84bda686b2f23658"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "928"
-      X-Request-Id:
-      - 9b57a6b7-14df-462d-adb9-bf0905663d13
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_cRggrlhECop1JzP7
-    method: GET
-  response:
-    body: '{"trash_object":{"id":"trsh_bDZLurvu5GsGzr1O","keep_until":1734191370,"object_id":"vm_cRggrlhECop1JzP7","object_type":"VirtualMachine"}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "136"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:32 GMT
-      Etag:
-      - W/"ae797f0c4462e3fb4ef63cd9665bd581"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "927"
-      X-Request-Id:
-      - 2c11b3de-26c8-40d9-b40a-6423f07d5313
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Terraform/1.10.2 (+https://www.terraform.io) Terraform-Plugin-SDK/2.31.0 terraform-provider-katapult/0.0.999
-    url: https://api.katapult.io/core/v1/trash_objects/_?trash_object%5Bobject_id%5D=vm_cRggrlhECop1JzP7
-    method: GET
-  response:
-    body: '{"error":{"code":"trash_object_not_found","description":"No trash object
-      was found matching any of the criteria provided in the arguments","detail":{}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "152"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:37 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Api-Schema:
-      - json-error
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "926"
-      X-Request-Id:
-      - aeb14239-6876-4927-a691-56c82242c2cd
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: '{"ip_address":{"id":"ip_EsiISUR4sV7GRkbC"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/ip_addresses/ip_address
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Content-Type
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Length:
-      - "2"
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 12 Dec 2024 15:49:37 GMT
-      Etag:
-      - W/"44136fa355b3678a1146ad16f7e8649e"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Ratelimit-Permitted:
-      - "1000"
-      X-Ratelimit-Remaining:
-      - "925"
-      X-Request-Id:
-      - c50da878-9abc-49da-89c4-35bcde79ca0e
+      - 04ef83e2-6c9b-4681-8d4c-7ff1bfb64fd8
     status: 200 OK
     code: 200
     duration: ""
@@ -4388,7 +4998,7 @@ interactions:
     headers:
       User-Agent:
       - Terraform/ (+https://www.terraform.io) Terraform-Plugin-Framework terraform-provider-katapult
-    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_4OBxn4uHNqxb0jgZ
+    url: https://api.katapult.io/core/v1/load_balancers/load_balancer?load_balancer%5Bid%5D=lb_tuVWgQC14K7wcEkO
     method: GET
   response:
     body: '{"error":{"code":"load_balancer_not_found","description":"No load balancer
@@ -4407,7 +5017,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 15:49:37 GMT
+      - Thu, 06 Feb 2025 17:39:56 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -4417,9 +5027,9 @@ interactions:
       X-Ratelimit-Permitted:
       - "1000"
       X-Ratelimit-Remaining:
-      - "924"
+      - "937"
       X-Request-Id:
-      - cf14dd01-045b-4e84-b796-d40e42ca8d88
+      - 14f6e109-39af-4341-8804-9868ec219313
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
Adds a `virtual_network_ids` attribute similar to `ip_address_ids`. When
populated with virtual network IDs, the virtual machine will be connected to the
specified virtual networks via new network interfaces for each.

Also adds a read-only `network_interfaces` attribute to the virtual machine
resource and data source. It contains full details of each network interface,
including the network ID or virtual network ID, MAC address, and any assigned IP
addresses for non-virtual network interfaces.