### PR TITLE
fix: improve API error handling and prevent nil dereferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 *.tfstate
 *.tfstate.*
+.codegraph/
 .envrc*
 .mise.*local.toml
 .terraform

--- a/internal/v6provider/data_source_address_list.go
+++ b/internal/v6provider/data_source_address_list.go
@@ -83,8 +83,11 @@ func (ds *AddressListDataSource) Read(
 			AddressListId: data.ID.ValueStringPointer(),
 		})
 	if err != nil {
-		resp.Diagnostics.AddError("Address List get by ID error", err.Error())
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
 
+		resp.Diagnostics.AddError("Address List Error", err.Error())
 		return
 	}
 

--- a/internal/v6provider/data_source_address_list_entries.go
+++ b/internal/v6provider/data_source_address_list_entries.go
@@ -102,10 +102,11 @@ func (ds *AddressListEntriesDataSource) Read(
 				AddressListId: data.AddressListID.ValueStringPointer(),
 			})
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"Address List Entries get by ID error",
-				err.Error())
+			if res != nil {
+				err = genericAPIError(err, res.Body)
+			}
 
+			resp.Diagnostics.AddError("Address List Entries Error", err.Error())
 			return
 		}
 

--- a/internal/v6provider/data_source_address_list_entry.go
+++ b/internal/v6provider/data_source_address_list_entry.go
@@ -87,10 +87,11 @@ func (ds *AddressListEntryDataSource) Read(
 			AddressListEntryId: data.ID.ValueStringPointer(),
 		})
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Address List Entry get by ID error",
-			err.Error())
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
 
+		resp.Diagnostics.AddError("Address List Entry Error", err.Error())
 		return
 	}
 

--- a/internal/v6provider/data_source_address_lists.go
+++ b/internal/v6provider/data_source_address_lists.go
@@ -96,8 +96,11 @@ func (ds *AddressListsDataSource) Read(
 				Page:                  &i,
 			})
 		if err != nil {
-			resp.Diagnostics.AddError("Address Lists get error", err.Error())
+			if res != nil {
+				err = genericAPIError(err, res.Body)
+			}
 
+			resp.Diagnostics.AddError("Address Lists Error", err.Error())
 			return
 		}
 

--- a/internal/v6provider/data_source_file_storage_volume.go
+++ b/internal/v6provider/data_source_file_storage_volume.go
@@ -109,10 +109,11 @@ func (r *FileStorageVolumeDataSource) Read(
 			FileStorageVolumeId: data.ID.ValueStringPointer(),
 		})
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"File Storage Volume Error",
-			err.Error(),
-		)
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
+
+		resp.Diagnostics.AddError("File Storage Volume Error", err.Error())
 		return
 	}
 

--- a/internal/v6provider/data_source_file_storage_volume_test.go
+++ b/internal/v6provider/data_source_file_storage_volume_test.go
@@ -204,7 +204,8 @@ func TestAccKatapultDataSourceFileStorageVolume_not_found(t *testing.T) {
 				),
 				ExpectError: regexp.MustCompile(
 					regexp.QuoteMeta(
-						"resource not found",
+						"file_storage_volume_not_found: " +
+							"No file storage volume",
 					),
 				),
 			},

--- a/internal/v6provider/data_source_file_storage_volumes.go
+++ b/internal/v6provider/data_source_file_storage_volumes.go
@@ -114,11 +114,11 @@ func (r *FileStorageVolumesDataSource) Read(
 				Page:                  &pageNum,
 			})
 		if err != nil {
-			resp.Diagnostics.AddError(
-				"FileStorageVolumes Error",
-				err.Error(),
-			)
+			if res != nil {
+				err = genericAPIError(err, res.Body)
+			}
 
+			resp.Diagnostics.AddError("File Storage Volumes Error", err.Error())
 			return
 		}
 

--- a/internal/v6provider/data_source_global_address_lists.go
+++ b/internal/v6provider/data_source_global_address_lists.go
@@ -95,8 +95,11 @@ func (ds *GlobalAddressListsDataSource) Read(
 				Page: &i,
 			})
 		if err != nil {
-			resp.Diagnostics.AddError("Address Lists get error", err.Error())
+			if res != nil {
+				err = genericAPIError(err, res.Body)
+			}
 
+			resp.Diagnostics.AddError("Address Lists Error", err.Error())
 			return
 		}
 

--- a/internal/v6provider/data_source_ip.go
+++ b/internal/v6provider/data_source_ip.go
@@ -145,10 +145,11 @@ func (r *IPDataSource) Read(
 	}
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"IP Error",
-			err.Error(),
-		)
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
+
+		resp.Diagnostics.AddError("IP Error", err.Error())
 		return
 	}
 

--- a/internal/v6provider/data_source_load_balancer.go
+++ b/internal/v6provider/data_source_load_balancer.go
@@ -111,7 +111,11 @@ func (ds *LoadBalancerDataSource) Read(
 			LoadBalancerId: data.ID.ValueStringPointer(),
 		})
 	if err != nil {
-		resp.Diagnostics.AddError("Load Balancer GetByID Error", err.Error())
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
+
+		resp.Diagnostics.AddError("Load Balancer Error", err.Error())
 		return
 	}
 	lb := res.JSON200.LoadBalancer

--- a/internal/v6provider/data_source_load_balancer_rule.go
+++ b/internal/v6provider/data_source_load_balancer_rule.go
@@ -152,11 +152,11 @@ func (ds LoadBalancerRuleDataSource) Read(
 			LoadBalancerRuleId: data.ID.ValueStringPointer(),
 		})
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Load Balancer Rule GetByID Error",
-			err.Error(),
-		)
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
 
+		resp.Diagnostics.AddError("Load Balancer Rule Error", err.Error())
 		return
 	}
 

--- a/internal/v6provider/data_source_load_balancer_rules.go
+++ b/internal/v6provider/data_source_load_balancer_rules.go
@@ -87,7 +87,6 @@ func (ds *LoadBalancerRulesDataSource) Read(
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("Load Balancer Rules Error", err.Error())
-
 		return
 	}
 
@@ -118,6 +117,10 @@ func getLBRules(
 			},
 		)
 		if err != nil {
+			if res != nil {
+				err = genericAPIError(err, res.Body)
+			}
+
 			return nil, err
 		}
 
@@ -137,6 +140,10 @@ func getLBRules(
 					LoadBalancerRuleId: rl.Id,
 				})
 		if err != nil {
+			if res != nil {
+				err = genericAPIError(err, res.Body)
+			}
+
 			return nil, err
 		}
 

--- a/internal/v6provider/data_source_load_balancers.go
+++ b/internal/v6provider/data_source_load_balancers.go
@@ -93,7 +93,11 @@ func (ds *LoadBalancersDataSource) Read(
 				Page:                  &pageNum,
 			})
 		if err != nil {
-			resp.Diagnostics.AddError("Load Balancer List Error", err.Error())
+			if res != nil {
+				err = genericAPIError(err, res.Body)
+			}
+
+			resp.Diagnostics.AddError("Load Balancers Error", err.Error())
 			return
 		}
 
@@ -105,9 +109,11 @@ func (ds *LoadBalancersDataSource) Read(
 			res, err := ds.M.Core.GetLoadBalancerWithResponse(ctx,
 				&core.GetLoadBalancerParams{LoadBalancerId: lb.Id})
 			if err != nil {
-				resp.Diagnostics.AddError(
-					"Load Balancer Get Error",
-					err.Error())
+				if res != nil {
+					err = genericAPIError(err, res.Body)
+				}
+
+				resp.Diagnostics.AddError("Load Balancer Error", err.Error())
 				return
 			}
 

--- a/internal/v6provider/data_source_network.go
+++ b/internal/v6provider/data_source_network.go
@@ -158,6 +158,10 @@ func (nds *NetworkDataSource) Read(
 
 	res, err := nds.M.Core.GetNetworkWithResponse(ctx, params)
 	if err != nil {
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
+
 		resp.Diagnostics.AddError(
 			"Network get by "+getField+" error", err.Error(),
 		)

--- a/internal/v6provider/data_source_networks.go
+++ b/internal/v6provider/data_source_networks.go
@@ -104,7 +104,12 @@ func (nds *NetworksDataSource) Read(
 		},
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("Networks get error", err.Error())
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
+
+		resp.Diagnostics.AddError("Networks Error", err.Error())
+		return
 	}
 
 	networks := res.JSON200.Networks

--- a/internal/v6provider/data_source_virtual_network.go
+++ b/internal/v6provider/data_source_virtual_network.go
@@ -97,7 +97,11 @@ func (ds *VirtualNetworkDataSource) Read(
 		ctx, &core.GetVirtualNetworkParams{VirtualNetworkId: &id},
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading virtual network", err.Error())
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
+
+		resp.Diagnostics.AddError("Virtual Networks Error", err.Error())
 		return
 	}
 

--- a/internal/v6provider/data_source_virtual_network_test.go
+++ b/internal/v6provider/data_source_virtual_network_test.go
@@ -65,7 +65,10 @@ func TestAccKatapultDataSourceVirtualNetwork_not_found(t *testing.T) {
 					}
 				`),
 				ExpectError: regexp.MustCompile(
-					regexp.QuoteMeta("resource not found"),
+					regexp.QuoteMeta(
+						"virtual_network_not_found: " +
+							"No virtual network",
+					),
 				),
 			},
 		},

--- a/internal/v6provider/data_source_virtual_networks.go
+++ b/internal/v6provider/data_source_virtual_networks.go
@@ -95,7 +95,12 @@ func (nds *VirtualNetworksDataSource) Read(
 		},
 	)
 	if err != nil {
-		resp.Diagnostics.AddError("VirtualNetworks get error", err.Error())
+		if res != nil {
+			err = genericAPIError(err, res.Body)
+		}
+
+		resp.Diagnostics.AddError("Virtual Networks Error", err.Error())
+		return
 	}
 
 	virtualNetworks := res.JSON200.VirtualNetworks

--- a/internal/v6provider/helpers.go
+++ b/internal/v6provider/helpers.go
@@ -57,13 +57,20 @@ func waitForTrashObjectNotFound(
 		Pending: []string{"exists"},
 		Target:  []string{"not_found"},
 		Refresh: func() (interface{}, string, error) {
-			_, e := m.Core.GetTrashObjectWithResponse(ctx,
+			res, err := m.Core.GetTrashObjectWithResponse(ctx,
 				&core.GetTrashObjectParams{
 					TrashObjectId:       trashObject.Id,
 					TrashObjectObjectId: trashObject.ObjectId,
 				})
-			if e != nil && errors.Is(e, core.ErrNotFound) {
-				return 1, "not_found", nil
+			if err != nil {
+				if errors.Is(err, core.ErrNotFound) {
+					return 1, "not_found", nil
+				}
+				if res != nil {
+					err = genericAPIError(err, res.Body)
+				}
+
+				return nil, "", err
 			}
 
 			return nil, "exists", nil

--- a/internal/v6provider/polling_helpers_test.go
+++ b/internal/v6provider/polling_helpers_test.go
@@ -1,0 +1,198 @@
+package v6provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krystal/go-katapult/next/core"
+	"github.com/stretchr/testify/require"
+)
+
+type testFSV = core.GetFileStorageVolume200ResponseFileStorageVolume
+
+type pollingCoreClient struct {
+	core.ClientWithResponsesInterface
+
+	getFileStorageVolume func(
+		context.Context,
+		*core.GetFileStorageVolumeParams,
+		...core.RequestEditorFn,
+	) (*core.GetFileStorageVolumeResponse, error)
+	getTrashObject func(
+		context.Context,
+		*core.GetTrashObjectParams,
+		...core.RequestEditorFn,
+	) (*core.GetTrashObjectResponse, error)
+}
+
+func (c *pollingCoreClient) GetFileStorageVolumeWithResponse(
+	ctx context.Context,
+	params *core.GetFileStorageVolumeParams,
+	reqEditors ...core.RequestEditorFn,
+) (*core.GetFileStorageVolumeResponse, error) {
+	return c.getFileStorageVolume(ctx, params, reqEditors...)
+}
+
+func (c *pollingCoreClient) GetTrashObjectWithResponse(
+	ctx context.Context,
+	params *core.GetTrashObjectParams,
+	reqEditors ...core.RequestEditorFn,
+) (*core.GetTrashObjectResponse, error) {
+	return c.getTrashObject(ctx, params, reqEditors...)
+}
+
+func TestWaitForTrashObjectNotFoundReturnsAPIError(t *testing.T) {
+	calls := 0
+	client := &pollingCoreClient{
+		getTrashObject: func(
+			context.Context,
+			*core.GetTrashObjectParams,
+			...core.RequestEditorFn,
+		) (*core.GetTrashObjectResponse, error) {
+			calls++
+
+			return &core.GetTrashObjectResponse{
+				Body: []byte(`{
+					"error": {
+						"code": "permission_denied",
+						"description": "Not permitted"
+					}
+				}`),
+			}, core.ErrRequestFailed
+		},
+	}
+	meta := &Meta{Core: client, testMode: true}
+
+	err := waitForTrashObjectNotFound(
+		context.Background(), meta, time.Second, core.TrashObject{},
+	)
+
+	require.EqualError(t, err, "permission_denied: Not permitted")
+	require.Equal(t, 1, calls)
+}
+
+func TestWaitForTrashObjectNotFoundHandlesNotFound(t *testing.T) {
+	client := &pollingCoreClient{
+		getTrashObject: func(
+			context.Context,
+			*core.GetTrashObjectParams,
+			...core.RequestEditorFn,
+		) (*core.GetTrashObjectResponse, error) {
+			return &core.GetTrashObjectResponse{}, core.ErrNotFound
+		},
+	}
+	meta := &Meta{Core: client, testMode: true}
+
+	err := waitForTrashObjectNotFound(
+		context.Background(), meta, time.Second, core.TrashObject{},
+	)
+
+	require.NoError(t, err)
+}
+
+func TestWaitForFileStorageVolumeToBeReadyReturnsAPIError(t *testing.T) {
+	client := &pollingCoreClient{
+		getFileStorageVolume: func(
+			context.Context,
+			*core.GetFileStorageVolumeParams,
+			...core.RequestEditorFn,
+		) (*core.GetFileStorageVolumeResponse, error) {
+			return &core.GetFileStorageVolumeResponse{
+				Body: []byte(`{
+					"error": {
+						"code": "permission_denied",
+						"description": "Not permitted"
+					}
+				}`),
+			}, core.ErrRequestFailed
+		},
+	}
+	meta := &Meta{Core: client, testMode: true}
+
+	volume, err := waitForFileStorageVolumeToBeReady(
+		context.Background(), meta, time.Second, 0, nil,
+	)
+
+	require.Nil(t, volume)
+	require.EqualError(t, err, "permission_denied: Not permitted")
+}
+
+func TestWaitForFileStorageVolumeToBeReadyRejectsEmptyResponse(t *testing.T) {
+	client := &pollingCoreClient{
+		getFileStorageVolume: func(
+			context.Context,
+			*core.GetFileStorageVolumeParams,
+			...core.RequestEditorFn,
+		) (*core.GetFileStorageVolumeResponse, error) {
+			return &core.GetFileStorageVolumeResponse{}, nil
+		},
+	}
+	meta := &Meta{Core: client, testMode: true}
+
+	volume, err := waitForFileStorageVolumeToBeReady(
+		context.Background(), meta, time.Second, 0, nil,
+	)
+
+	require.Nil(t, volume)
+	require.EqualError(t, err, "unexpected empty file storage volume response")
+}
+
+func TestWaitForFileStorageVolumeToBeReadyRejectsMissingState(t *testing.T) {
+	client := &pollingCoreClient{
+		getFileStorageVolume: func(
+			context.Context,
+			*core.GetFileStorageVolumeParams,
+			...core.RequestEditorFn,
+		) (*core.GetFileStorageVolumeResponse, error) {
+			return fileStorageVolumeResponse(nil), nil
+		},
+	}
+	meta := &Meta{Core: client, testMode: true}
+
+	volume, err := waitForFileStorageVolumeToBeReady(
+		context.Background(), meta, time.Second, 0, nil,
+	)
+
+	require.Nil(t, volume)
+	require.EqualError(
+		t, err, "unexpected file storage volume response: missing state",
+	)
+}
+
+func TestWaitForFileStorageVolumeToBeReadyReturnsReadyVolume(t *testing.T) {
+	state := core.FileStorageVolumeStateEnumReady
+	client := &pollingCoreClient{
+		getFileStorageVolume: func(
+			context.Context,
+			*core.GetFileStorageVolumeParams,
+			...core.RequestEditorFn,
+		) (*core.GetFileStorageVolumeResponse, error) {
+			return fileStorageVolumeResponse(&state), nil
+		},
+	}
+	meta := &Meta{Core: client, testMode: true}
+
+	volume, err := waitForFileStorageVolumeToBeReady(
+		context.Background(), meta, time.Second, 0, nil,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, volume)
+	require.Equal(t, state, *volume.State)
+}
+
+func fileStorageVolumeResponse(
+	state *core.FileStorageVolumeStateEnum,
+) *core.GetFileStorageVolumeResponse {
+	return &core.GetFileStorageVolumeResponse{
+		JSON200: &struct {
+			Annotations       []core.KeyValue `json:"annotations"`
+			FileStorageVolume testFSV         `json:"file_storage_volume"`
+		}{
+			FileStorageVolume: testFSV{
+				State: state,
+			},
+		},
+	}
+}

--- a/internal/v6provider/resource_file_storage_volume.go
+++ b/internal/v6provider/resource_file_storage_volume.go
@@ -509,10 +509,24 @@ func waitForFileStorageVolumeToBeReady(
 					FileStorageVolumeId: fsvID,
 				})
 			if err != nil {
+				if res != nil {
+					err = genericAPIError(err, res.Body)
+				}
+
 				return nil, "", err
+			}
+			if res == nil || res.JSON200 == nil {
+				return nil, "", errors.New(
+					"unexpected empty file storage volume response",
+				)
 			}
 
 			f := &res.JSON200.FileStorageVolume
+			if f.State == nil {
+				return nil, "", errors.New(
+					"unexpected file storage volume response: missing state",
+				)
+			}
 
 			return f, string(*f.State), nil
 		},


### PR DESCRIPTION
The generated API client currently collapses structured API failures into generic request errors. That hides useful diagnostics from Terraform users, while a few error and polling paths can continue into incomplete responses and panic or report misleading timeouts.

This change:

- parses structured API response bodies across v6 data-source reads;
- returns immediately from collection reads after an API failure;
- propagates unexpected trash polling errors instead of masking them as timeouts;
- validates file-storage polling responses before dereferencing them;
- adds focused coverage for API failures, not-found completion, incomplete responses, and successful readiness; and
- ignores local Codegraph indexes.

## Testing

- `mise run check`
