### PR TITLE
test: speed up object storage account replay waiter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,11 @@ without explicit authorization for live acceptance testing. After tests, check
 `WaitForStateContext`; do not capture refresh results for unsynchronized reads
 outside the callback because cancellation can return before a refresh finishes.
 
+Route every `StateChangeConf` delay, minimum timeout, and poll interval through
+the provider `Meta` timing helpers, including test sweepers. Compress any
+additional wall-clock settling window in replay mode so recorded state
+transitions remain fast without changing production timing.
+
 VCR cassette YAML is massive and can exhaust agent context very quickly. Do not
 print whole cassette files or review complete cassette diffs by default. Start
 with `git diff --stat`, `git diff --numstat`, and `git diff --name-only`, then use

--- a/internal/v6provider/resource_object_storage_account.go
+++ b/internal/v6provider/resource_object_storage_account.go
@@ -534,17 +534,22 @@ func createObjectStorageAccount(
 }
 
 // waitForObjectStorageAccountProvisioned polls the account until it reaches
-// the `provisioned` state. A transient `failed` state during the first
-// settling window is tolerated; a sustained `failed` state results in an
-// error that includes the API response body for diagnostics.
+// the `provisioned` state. A transient `failed` state is tolerated for a
+// settling window; a sustained `failed` state results in an error that includes
+// the API response body for diagnostics.
 func waitForObjectStorageAccountProvisioned(
 	ctx context.Context,
 	m *Meta,
 	region string,
 ) (*core.ObjectStorageAccount, error) {
-	const settleWindow = 15 * time.Second
+	settleWindow := 15 * time.Second
+	if replayPollInterval := m.stateChangePollInterval(); replayPollInterval > 0 {
+		// Replay advances recorded states per poll rather than over wall-clock
+		// seconds. Preserve a bounded settling window without waiting 15 seconds.
+		settleWindow = 15 * replayPollInterval
+	}
 
-	firstSeen := time.Now()
+	var failedSince time.Time
 
 	waiter := &retry.StateChangeConf{
 		Pending: []string{
@@ -564,20 +569,27 @@ func waitForObjectStorageAccountProvisioned(
 			}
 			state := deref(acct.ProvisioningState)
 
-			if state == core.ObjectStorageAccountProvisioningStateEnumFailed &&
-				time.Since(firstSeen) > settleWindow {
-				return acct, string(state), fmt.Errorf(
-					"object storage account provisioning failed "+
-						"for region %q after %s — contact Katapult support",
-					region, settleWindow,
-				)
+			if state == core.ObjectStorageAccountProvisioningStateEnumFailed {
+				if failedSince.IsZero() {
+					failedSince = time.Now()
+				}
+				if time.Since(failedSince) > settleWindow {
+					return acct, string(state), fmt.Errorf(
+						"object storage account provisioning failed "+
+							"for region %q after %s — contact Katapult support",
+						region, settleWindow,
+					)
+				}
+			} else {
+				failedSince = time.Time{}
 			}
 
 			return acct, string(state), nil
 		},
 		Timeout:                   5 * time.Minute,
-		Delay:                     2 * time.Second,
-		MinTimeout:                5 * time.Second,
+		Delay:                     m.stateChangeDelay(2 * time.Second),
+		MinTimeout:                m.stateChangeDelay(5 * time.Second),
+		PollInterval:              m.stateChangePollInterval(),
 		ContinuousTargetOccurence: 1,
 	}
 

--- a/internal/v6provider/resource_object_storage_create_recovery_test.go
+++ b/internal/v6provider/resource_object_storage_create_recovery_test.go
@@ -504,6 +504,66 @@ func TestObjectStorageAccountCreateRetainsStateWhenWaiterFails(
 	requireKnownNullString(t, state.ProvisioningState)
 }
 
+func TestObjectStorageAccountProvisioningWaiterReplayTiming(t *testing.T) {
+	tests := []struct {
+		name       string
+		states     []string
+		wantState  string
+		wantErr    string
+		wantMinGet int32
+	}{
+		{
+			name:      "transient failure recovers",
+			states:    []string{"failed", "provisioned"},
+			wantState: "provisioned",
+		},
+		{
+			name:       "sustained failure terminates",
+			states:     []string{"failed"},
+			wantErr:    "object storage account provisioning failed",
+			wantMinGet: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var getCalls atomic.Int32
+			meta := newObjectStorageFailureTestMeta(t, http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					call := getCalls.Add(1)
+					stateIndex := min(int(call)-1, len(tt.states)-1)
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{
+						"object_storage_account": {
+							"region": "uk-lon-1",
+							"provisioning_state": "` + tt.states[stateIndex] + `"
+						}
+					}`))
+				},
+			))
+			meta.testMode = true
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			account, err := waitForObjectStorageAccountProvisioned(
+				ctx, meta, "uk-lon-1",
+			)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.GreaterOrEqual(t, getCalls.Load(), tt.wantMinGet)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, account)
+			require.Equal(t, tt.wantState, string(*account.ProvisioningState))
+			require.Equal(t, len(tt.states), int(getCalls.Load()))
+		})
+	}
+}
+
 func TestObjectStorageAccountDeleteResumesTrashPurgeFromPrivateState(
 	t *testing.T,
 ) {


### PR DESCRIPTION
PR #181 made the existing `StateChangeConf` waiters replay-aware, but the object storage account provisioning waiter landed later and still used production delays during VCR replay. This brings the remaining waiter under the same replay timing policy.

- Route its delay, minimum timeout, and poll interval through the provider `Meta` timing helpers.
- Compress the 15-second failed-state settling window into replay poll intervals while preserving the production duration.
- Start the settling window when a failed state is first observed, so a genuinely transient failure still has a full recovery window.
- Cover transient recovery and sustained failure with a focused behavioral regression test.
- Audit all 17 provider and test-sweeper `StateChangeConf` instances; the other 16 were already replay-aware.
- Document the waiter timing rule for future additions.

## Testing

- `mise run check`
- `go test ./internal/v6provider -run ^TestObjectStorageAccountProvisioningWaiterReplayTiming$ -count=1 -v`
- `TEST=./internal/v6provider TESTARGS="-run ^TestAccKatapultObjectStorageAccount_" mise run test:acceptance` (3.18s)
- `TEST=./internal/v6provider TESTARGS="-run ^TestAccKatapultObjectStorage_scenarios$$" mise run test:acceptance` (37.20s)

---
_Description written on behalf of jimeh by `gpt-5.6-sol` using `Codex`._